### PR TITLE
Fix issue with building backend container

### DIFF
--- a/backend/backend.Dockerfile
+++ b/backend/backend.Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.21-bookworm
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Install Dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --allow-downgrades \
     inotify-tools=3.22.6.0-4             \
     openssl=3.0.11-1~deb12u2
 


### PR DESCRIPTION
Running the dockerfile in backend/ directory to build the container throws an error. The specified version of openssl=3.0.11-1~deb12u2 is a downgrade for the image used and adding "--allow-downgrades" to the dockerfile command fixes the issue and allows for the successful creation of the container.