### PR TITLE
Add Createmarket unit tests

### DIFF
--- a/backend/handlers/markets/createmarket.go
+++ b/backend/handlers/markets/createmarket.go
@@ -3,7 +3,7 @@ package marketshandlers
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"socialpredict/logging"
@@ -59,7 +59,7 @@ func CreateMarketHandler(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&newMarket)
 	if err != nil {
-		bodyBytes, _ := ioutil.ReadAll(r.Body)
+		bodyBytes, _ := io.ReadAll(r.Body)
 		log.Printf("Error reading request body: %v, Body: %s", err, string(bodyBytes))
 		http.Error(w, "Error reading request body", http.StatusBadRequest)
 		return

--- a/backend/handlers/markets/createmarket.go
+++ b/backend/handlers/markets/createmarket.go
@@ -3,6 +3,7 @@ package marketshandlers
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -12,6 +13,8 @@ import (
 	"socialpredict/setup"
 	"socialpredict/util"
 )
+
+const maxQuestionTitleLength = 160
 
 // appConfig holds the loaded application configuration accessible within the package
 var appConfig *setup.EconomicConfig
@@ -26,8 +29,8 @@ func init() {
 }
 
 func checkQuestionTitleLength(title string) error {
-	if len(title) > 160 || len(title) < 1 {
-		return errors.New("Question Title exceeds 160 characters or is blank")
+	if len(title) > maxQuestionTitleLength || len(title) < 1 {
+		return fmt.Errorf("question title exceeds %d characters or is blank", maxQuestionTitleLength)
 	}
 	return nil
 }

--- a/backend/handlers/markets/createmarket_test.go
+++ b/backend/handlers/markets/createmarket_test.go
@@ -39,7 +39,7 @@ func TestCheckQuestionTitleLength_valid(t *testing.T) {
 		},
 		{
 			testname:      "Max length title",
-			questionTitle: strings.Repeat("a", 160),
+			questionTitle: strings.Repeat("a", maxQuestionTitleLength),
 		},
 	}
 	for _, test := range tests {

--- a/backend/handlers/markets/createmarket_test.go
+++ b/backend/handlers/markets/createmarket_test.go
@@ -1,0 +1,51 @@
+package marketshandlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCheckQuestionTitleLength_invalid tests the question titles that should generate an error
+func TestCheckQuestionTitleLength_invalid(t *testing.T) {
+	tests := []struct {
+		testname      string
+		questionTitle string
+	}{
+		{
+			testname:      "TitleExceedsLength",
+			questionTitle: strings.Repeat("a", 161),
+		},
+		{
+			testname:      "EmptyTitle",
+			questionTitle: "",
+		},
+	}
+	for _, test := range tests {
+		err := checkQuestionTitleLength(test.questionTitle)
+		if err == nil {
+			t.Errorf("Expected error in test %s", test.testname)
+		}
+	}
+}
+
+func TestCheckQuestionTitleLength_valid(t *testing.T) {
+	tests := []struct {
+		testname      string
+		questionTitle string
+	}{
+		{
+			testname:      "Single character title",
+			questionTitle: "a",
+		},
+		{
+			testname:      "Max length title",
+			questionTitle: strings.Repeat("a", 160),
+		},
+	}
+	for _, test := range tests {
+		err := checkQuestionTitleLength(test.questionTitle)
+		if err != nil {
+			t.Errorf("Unexpected error in test %s", test.testname)
+		}
+	}
+}

--- a/backend/handlers/markets/createmarket_test.go
+++ b/backend/handlers/markets/createmarket_test.go
@@ -13,7 +13,7 @@ func TestCheckQuestionTitleLength_invalid(t *testing.T) {
 	}{
 		{
 			testname:      "TitleExceedsLength",
-			questionTitle: strings.Repeat("a", 161),
+			questionTitle: strings.Repeat("a", maxQuestionTitleLength+1),
 		},
 		{
 			testname:      "EmptyTitle",


### PR DESCRIPTION
This PR adds unit tests for checking the length of the question title (both valid and invalid inputs), declares a constant for the maximum length of the question title, and updates the formatting of the error returned to use the constant.