### PR TITLE
Move GetNumMarketUsers from listusers to models/bets

### DIFF
--- a/backend/handlers/markets/listmarkets.go
+++ b/backend/handlers/markets/listmarkets.go
@@ -48,7 +48,7 @@ func ListMarketsHandler(w http.ResponseWriter, r *http.Request) {
 	for _, market := range markets {
 		bets := tradingdata.GetBetsForMarket(db, uint(market.ID))
 		probabilityChanges := wpam.CalculateMarketProbabilitiesWPAM(market.CreatedAt, bets)
-		numUsers := usersHandlers.GetNumMarketUsers(bets)
+		numUsers := models.GetNumMarketUsers(bets)
 		marketVolume := marketmath.GetMarketVolume(bets)
 		lastProbability := probabilityChanges[len(probabilityChanges)-1].Probability
 

--- a/backend/handlers/markets/marketdetailshandler.go
+++ b/backend/handlers/markets/marketdetailshandler.go
@@ -8,6 +8,7 @@ import (
 	"socialpredict/handlers/math/probabilities/wpam"
 	"socialpredict/handlers/tradingdata"
 	usersHandlers "socialpredict/handlers/users"
+	"socialpredict/models"
 	"socialpredict/util"
 	"strconv"
 
@@ -53,7 +54,7 @@ func MarketDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	probabilityChanges := wpam.CalculateMarketProbabilitiesWPAM(publicResponseMarket.CreatedAt, bets)
 
 	// find the number of users on the market
-	numUsers := usersHandlers.GetNumMarketUsers(bets)
+	numUsers := models.GetNumMarketUsers(bets)
 	if err != nil {
 		http.Error(w, "Error retrieving number of users.", http.StatusInternalServerError)
 		return

--- a/backend/handlers/users/listusers.go
+++ b/backend/handlers/users/listusers.go
@@ -7,16 +7,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// getMarketUsers returns the number of unique users for a given market
-func GetNumMarketUsers(bets []models.Bet) int {
-	userMap := make(map[string]bool)
-	for _, bet := range bets {
-		userMap[bet.Username] = true
-	}
-
-	return len(userMap)
-}
-
 // ListUserMarkets lists all markets that a specific user is betting in, ordered by the date of the last bet.
 func ListUserMarkets(db *gorm.DB, userID int64) ([]models.Market, error) {
 	var markets []models.Market

--- a/backend/models/bets.go
+++ b/backend/models/bets.go
@@ -18,3 +18,14 @@ type Bet struct {
 	PlacedAt time.Time `json:"placedAt"`
 	Outcome  string    `json:"outcome,omitempty"`
 }
+type Bets []Bet
+
+// getMarketUsers returns the number of unique users for a given market
+func GetNumMarketUsers(bets []Bet) int {
+	userMap := make(map[string]bool)
+	for _, bet := range bets {
+		userMap[bet.Username] = true
+	}
+
+	return len(userMap)
+}

--- a/backend/models/bets_test.go
+++ b/backend/models/bets_test.go
@@ -1,0 +1,57 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestGetNumMarketUsers(t *testing.T) {
+	tests := []struct {
+		name string
+		bets Bets
+		want int
+	}{
+		{
+			name: "0 users",
+			bets: Bets{},
+			want: 0,
+		},
+		{
+			name: "1 user",
+			bets: Bets{buildBet(t, 1, "u1")},
+			want: 1,
+		},
+		{
+			name: "1 user",
+			bets: Bets{buildBet(t, 1, "u1"), buildBet(t, 2, "u1")},
+			want: 1,
+		},
+		{
+			name: "2 users",
+			bets: Bets{buildBet(t, 1, "u1"), buildBet(t, 3, "u2"), buildBet(t, 2, "u1")},
+			want: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := GetNumMarketUsers(test.bets)
+			if got != test.want {
+				t.Errorf("%d market users, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func buildBet(t *testing.T, id uint, username string) Bet {
+	t.Helper()
+	return Bet{
+		//Action   string    `json:"action"`
+		ID:       id,       //       uint      `json:"id" gorm:"primary_key"`
+		Username: username, // string    `json:"username"`
+		//User     User      `gorm:"foreignKey:Username;references:Username"`
+		//MarketID uint      `json:"marketId"`
+		//Market   Market    `gorm:"foreignKey:ID;references:MarketID"`
+		//Amount   int64     `json:"amount"`
+		//PlacedAt time.Time `json:"placedAt"`
+		//Outcome  string    `json:"outcome,omitempty"`
+	}
+}


### PR DESCRIPTION
This move:
- adds unit tests to the `GetNumMarketUsers` function
-  introduces a `Bets` type which can be used in the future to convert `GetNumMarketUsers` from a parameterized function to a method of `Bets` allowing calls like: `bets.GetNumMarketUsers()`
- updates calls to use the function in its new package.