### PR TITLE
move bet validation to Bet data type

### DIFF
--- a/backend/handlers/bets/betutils/validatebet.go
+++ b/backend/handlers/bets/betutils/validatebet.go
@@ -7,33 +7,6 @@ import (
 	"gorm.io/gorm"
 )
 
-func ValidateBuy(db *gorm.DB, bet *models.Bet) error {
-	var user models.User
-	var market models.Market
-
-	// Check if username exists
-	if err := db.First(&user, "username = ?", bet.Username).Error; err != nil {
-		return errors.New("invalid username")
-	}
-
-	// Check if market exists and is open
-	if err := db.First(&market, "id = ? AND is_resolved = false", bet.MarketID).Error; err != nil {
-		return errors.New("invalid or closed market")
-	}
-
-	// Check for valid amount: it should be greater than or equal to 1
-	if bet.Amount < 1 {
-		return errors.New("Buy amount must be greater than or equal to 1")
-	}
-
-	// Validate bet outcome: it should be either 'YES' or 'NO'
-	if bet.Outcome != "YES" && bet.Outcome != "NO" {
-		return errors.New("bet outcome must be 'YES' or 'NO'")
-	}
-
-	return nil
-}
-
 func ValidateSale(db *gorm.DB, bet *models.Bet) error {
 	var user models.User
 	var market models.Market

--- a/backend/handlers/bets/placebethandler.go
+++ b/backend/handlers/bets/placebethandler.go
@@ -76,7 +76,7 @@ func PlaceBetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate the final bet before putting into database
-	if err := betutils.ValidateBuy(db, &bet); err != nil {
+	if err := bet.ValidateBuy(db); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/backend/models/bets_test.go
+++ b/backend/models/bets_test.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"errors"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 func TestGetNumMarketUsers(t *testing.T) {
@@ -36,6 +39,29 @@ func TestGetNumMarketUsers(t *testing.T) {
 			got := GetNumMarketUsers(test.bets)
 			if got != test.want {
 				t.Errorf("%d market users, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateBuy_invalid(t *testing.T) {
+	tests := []struct {
+		name string
+		bet  Bet
+		db   gorm.DB
+		want error
+	}{
+		{
+			name: "invalid user",
+			bet:  buildBet(t, 1, "u1"),
+			db:   gorm.DB{},
+			want: errors.New("invalid username"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.bet.ValidateBuy(&test.db); err == nil {
+				t.Errorf("No error received, want %v", test.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR is not ready. 
It: 
- adds a `Bets` type to enable operating on multiple Bets at once
- moves `ValidateBuy` to models/bets
- updates function signature for `ValdiateBuy` to be a method on the `Bet` type, and to remove the `Bet` parameter from the signature

TODO:
- add test case for valid Bets
- add remaining test cases for invalid Bets
- add ability to use a test double in place of gorm db