### PR TITLE
Upgrade to Go 1.23

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM golang:1.22.5-bookworm
+FROM golang:1.23-bookworm
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/scripts/dev/compose_dev.sh
+++ b/scripts/dev/compose_dev.sh
@@ -6,6 +6,8 @@
 if [ "$1" = "up" ]; then
 	docker compose --env-file $ENV_PATH --file "$SCRIPT_DIR/scripts/docker-compose-dev.yaml" up -d && \
 	echo "SocialPredict may be found at http://localhost . This may take a few seconds to load initially."
+  	echo "Here are the initial settings. These can be changed in setup.yaml"
+	cat $SCRIPT_DIR/backend/setup/setup.yaml
 elif [ "$1" = "down" ]; then
 	docker compose --env-file $ENV_PATH --file "$SCRIPT_DIR/scripts/docker-compose-dev.yaml" down
 else


### PR DESCRIPTION
Upgraded to go 1.23. Printed `setup.yaml` in `compose-dev.sh` for usability reasons. Tested on dev, works fine for getting dev version up - need to run some go tests