### PR TITLE
Refactor user model to include private fields explicitly

### DIFF
--- a/backend/handlers/admin/adduser.go
+++ b/backend/handlers/admin/adduser.go
@@ -48,13 +48,15 @@ func AddUserHandler(loadEconConfig setup.EconConfigLoader) func(http.ResponseWri
 		user := models.User{
 			Username:              req.Username,
 			DisplayName:           util.UniqueDisplayName(db),
-			Email:                 util.UniqueEmail(db),
 			UserType:              "REGULAR",
 			InitialAccountBalance: appConfig.Economics.User.InitialAccountBalance,
 			AccountBalance:        appConfig.Economics.User.InitialAccountBalance,
 			PersonalEmoji:         randomEmoji(),
-			ApiKey:                util.GenerateUniqueApiKey(db),
-			MustChangePassword:    true,
+			PrivateUser: models.PrivateUser{
+				Email:  util.UniqueEmail(db),
+				APIKey: util.GenerateUniqueApiKey(db),
+			},
+			MustChangePassword: true,
 		}
 
 		// Check uniqueness of username, displayname, and email
@@ -92,7 +94,7 @@ func checkUniqueFields(db *gorm.DB, user *models.User) error {
 	var count int64
 	db.Model(&models.User{}).Where(
 		"username = ? OR display_name = ? OR email = ? OR api_key = ?",
-		user.Username, user.DisplayName, user.Email, user.ApiKey,
+		user.Username, user.DisplayName, user.Email, user.APIKey,
 	).Count(&count)
 
 	if count > 0 {

--- a/backend/handlers/bets/betutils/feeutils_test.go
+++ b/backend/handlers/bets/betutils/feeutils_test.go
@@ -15,7 +15,7 @@ func TestGetUserInitialBetFee(t *testing.T) {
 	}
 
 	appConfig = setuptesting.MockEconomicConfig()
-	user := &models.User{Username: "testuser", AccountBalance: 1000, ApiKey: "unique_api_key_1"}
+	user := &models.User{Username: "testuser", AccountBalance: 1000}
 	if err := db.Create(user).Error; err != nil {
 		t.Fatalf("Failed to save user to database: %v", err)
 	}

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -33,6 +33,7 @@ func ValidateUserAndEnforcePasswordChangeGetUser(r *http.Request, db *gorm.DB) (
 	return user, nil
 }
 
+// ValidateTokenAndGetUser checks that the user is who they claim to be, and returns their information for use
 func ValidateTokenAndGetUser(r *http.Request, db *gorm.DB) (*models.User, *HTTPError) {
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -10,19 +10,23 @@ type User struct {
 	ID                    int64  `json:"id" gorm:"primary_key"`
 	Username              string `json:"username" gorm:"unique;not null"`
 	DisplayName           string `json:"displayname" gorm:"unique;not null"`
-	Email                 string `json:"email" gorm:"unique;not null"`
 	Password              string `json:"password,omitempty" gorm:"not null"`
 	UserType              string `json:"usertype" gorm:"not null"`
 	InitialAccountBalance int64  `json:"initialAccountBalance"`
 	AccountBalance        int64  `json:"accountBalance"`
-	ApiKey                string `json:"apiKey,omitempty" gorm:"unique"`
 	PersonalEmoji         string `json:"personalEmoji,omitempty"`
 	Description           string `json:"description,omitempty"`
 	PersonalLink1         string `json:"personalink1,omitempty"`
 	PersonalLink2         string `json:"personalink2,omitempty"`
 	PersonalLink3         string `json:"personalink3,omitempty"`
 	PersonalLink4         string `json:"personalink4,omitempty"`
-	MustChangePassword    bool   `json:"mustChangePassword" gorm:"default:true"`
+	PrivateUser
+	MustChangePassword bool `json:"mustChangePassword" gorm:"default:true"`
+}
+
+type PrivateUser struct {
+	Email  string `json:"email" gorm:"unique;not null"`
+	APIKey string `json:"apiKey,omitempty" gorm:"unique"`
 }
 
 // HashPassword hashes given password

--- a/backend/seed/seed.go
+++ b/backend/seed/seed.go
@@ -41,14 +41,16 @@ func SeedUsers(db *gorm.DB) {
 			adminUser := models.User{
 				Username:              "admin",
 				DisplayName:           "Administrator",
-				Email:                 "admin@example.com",
 				UserType:              "ADMIN",
 				InitialAccountBalance: config.Economics.User.InitialAccountBalance,
 				AccountBalance:        config.Economics.User.InitialAccountBalance,
-				ApiKey:                "NONE",
 				PersonalEmoji:         "NONE",
 				Description:           "Administrator",
-				MustChangePassword:    false,
+				PrivateUser: models.PrivateUser{
+					Email:  "admin@example.com",
+					APIKey: "NONE",
+				},
+				MustChangePassword: false,
 			}
 
 			adminUser.HashPassword(adminPassword)


### PR DESCRIPTION
This update to the user model declares the fields which are private and should not be displayed to other users. These fields are embedded into the `User` type as `PrivateUser` and can be directly accessed as they were previously called via `User.Email` or `User.APIKey`. This change allows the Private fields to be accessed/retrieved as a whole instead of individually knowing what is or is not private. This also helps us prevent these fields from being accidentally leaked.

`ApiKey` was renamed to `APIKey` to be consistent with language standards for initialisms https://go.dev/wiki/CodeReviewComments#initialisms