### PR TITLE
Lowercase alphanumeric usernames only

### DIFF
--- a/backend/handlers/admin/adduser.go
+++ b/backend/handlers/admin/adduser.go
@@ -32,8 +32,8 @@ func AddUserHandler(loadEconConfig setup.EconConfigLoader) func(http.ResponseWri
 			return
 		}
 
-		if match, _ := regexp.MatchString("^[a-zA-Z0-9]+$", req.Username); !match {
-			err := fmt.Errorf("username %s must only contain letters and numbers", req.Username)
+		if match, _ := regexp.MatchString("^[a-z0-9]+$", req.Username); !match {
+			err := fmt.Errorf("username %s must only contain lowercase letters and numbers", req.Username)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			log.Printf("AddUserHandler: %v", err)
 			return


### PR DESCRIPTION
The frontend directs the admin to only create users with lowercase alphanumeric values, but performs no validation of this before passing to the backend. Username validation currently rests solely with the backend, so it should validate these requirements on behalf of the frontend.