### PR TITLE
Update package-lock.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "postcss": "^8.4.35",
         "rollup": ">=4.22.4",
         "tailwindcss": "^3.4.1",
-        "vite": "^5.4.10"
+        "vite": ">=5.4.17"
       },
       "engines": {
         "node": ">=21.0.0"


### PR DESCRIPTION
updating package-lock.json to have vite 5.4.17

looks like this avoids some of the nasty breaking changes that we got a couple of months ago

on the other hand, "failed to fetch user credit" error has come back

![image](https://github.com/user-attachments/assets/dd354bd9-6b7a-4990-8e0d-b218f3c1ea32)
