### PR TITLE
Changing env_writer_dev.sh and docker-compose-dev.yaml to allow running on new versions os MacOS

### DIFF
--- a/README/LOCAL_SETUP.md
+++ b/README/LOCAL_SETUP.md
@@ -20,7 +20,7 @@ mkdir -p data/postgres data/certbot
 chown -R $(whoami):staff data
 ```
 
-* Next, for newer versions of MacOS, you may need to allow Docker within system settings, as well as terminal, because otherwise Apple adds some `xattrs` which maintain provenance over files, not allowing Docker to work with them properly. [This issue here explains a fix](https://github.com/docker/for-mac/issues/7636#issuecomment-2755395642). NOTE! This issue is still pending. We may need to re-write how docker-compose-dev.yaml runs things as it seems to be incompatible with new versions of MacOS due to the `xattrs`. See [here](https://developer.apple.com/forums/thread/723397).
+* For newer versions of MacOS, Apple adds some `xattrs` which maintain provenance over the files, not allowing Docker to work with them directly on the disk. Hence, we have to mount our database from local on development mode. See [here](https://developer.apple.com/forums/thread/723397).
 
 #### Instructions
 

--- a/README/LOCAL_SETUP.md
+++ b/README/LOCAL_SETUP.md
@@ -20,6 +20,8 @@ mkdir -p data/postgres data/certbot
 chown -R $(whoami):staff data
 ```
 
+Next, for newer versions of MacOS, you may need to allow Docker within system settings, as well as terminal, because otherwise Apple adds some xattrs which maintain provenance over files, not allowing Docker to work with them properly. [This issue here explains a fix](https://github.com/docker/for-mac/issues/7636#issuecomment-2755395642).
+
 #### Instructions
 
 - **Clone the Repository**: Download the repository to your local machine.

--- a/README/LOCAL_SETUP.md
+++ b/README/LOCAL_SETUP.md
@@ -20,7 +20,7 @@ mkdir -p data/postgres data/certbot
 chown -R $(whoami):staff data
 ```
 
-Next, for newer versions of MacOS, you may need to allow Docker within system settings, as well as terminal, because otherwise Apple adds some xattrs which maintain provenance over files, not allowing Docker to work with them properly. [This issue here explains a fix](https://github.com/docker/for-mac/issues/7636#issuecomment-2755395642).
+* Next, for newer versions of MacOS, you may need to allow Docker within system settings, as well as terminal, because otherwise Apple adds some `xattrs` which maintain provenance over files, not allowing Docker to work with them properly. [This issue here explains a fix](https://github.com/docker/for-mac/issues/7636#issuecomment-2755395642). NOTE! This issue is still pending. We may need to re-write how docker-compose-dev.yaml runs things as it seems to be incompatible with new versions of MacOS due to the `xattrs`. See [here](https://developer.apple.com/forums/thread/723397).
 
 #### Instructions
 

--- a/SocialPredict
+++ b/SocialPredict
@@ -7,6 +7,21 @@ set -x # Verbose
 # Determine script's directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Ensure .env file exists before resolving path
+if [ ! -f "$SCRIPT_DIR/.env" ]; then
+  echo ".env file not found."
+
+  if [ -f "$SCRIPT_DIR/scripts/dev/env_writer_dev.sh" ]; then
+    echo "Initializing .env file using env_writer_dev.sh (first-run only)..."
+    export CALLED_FROM_SOCIALPREDICT=yes
+    SCRIPT_INTERACTIVE=true source "$SCRIPT_DIR/scripts/dev/env_writer_dev.sh"
+    unset CALLED_FROM_SOCIALPREDICT
+  else
+    echo "Cannot continue. .env file is missing and env_writer_dev.sh was not found."
+    exit 1
+  fi
+fi
+
 # Calculate the absolute path to the .env file
 ENV_PATH="$( readlink -f "$SCRIPT_DIR/.env" )"
 ENV_FILE="--env-file $ENV_PATH"

--- a/scripts/dev/env_writer_dev.sh
+++ b/scripts/dev/env_writer_dev.sh
@@ -4,15 +4,23 @@
 [ -z "$CALLED_FROM_SOCIALPREDICT" ] && { echo "Not called from SocialPredict"; exit 42; }
 
 # Function to create and update .env file
+# Updated to be compatible with MacOS Sonoma.
+# Uses POSTGRES_VOLUME to deal with MacOS xattrs provenence.
 init_env() {
 	# Create .env file
 	cp "$SCRIPT_DIR/.env.example" "$SCRIPT_DIR/.env"
 
-	# Update .env file
-
 	# Update APP_ENV
 	sed -i -e "s/APP_ENV=.*/APP_ENV='development'/g" "$SCRIPT_DIR/.env"
 	echo "ENV_PATH=$SCRIPT_DIR/.env" >> "$SCRIPT_DIR/.env"
+
+	# Add OS-specific POSTGRES_VOLUME
+	OS=$(uname -s)
+	if [[ "$OS" == "Darwin" ]]; then
+		echo "POSTGRES_VOLUME=pgdata:/var/lib/postgresql/data" >> "$SCRIPT_DIR/.env"
+	else
+		echo "POSTGRES_VOLUME=../data/postgres:/var/lib/postgresql/data" >> "$SCRIPT_DIR/.env"
+	fi
 }
 
 if [[ ! -f "$SCRIPT_DIR/.env" ]]; then

--- a/scripts/docker-compose-dev.yaml
+++ b/scripts/docker-compose-dev.yaml
@@ -81,3 +81,6 @@ networks:
     driver: bridge
   frontend_network:
     driver: bridge
+
+volumes:
+  pgdata:

--- a/scripts/docker-compose-dev.yaml
+++ b/scripts/docker-compose-dev.yaml
@@ -1,15 +1,14 @@
 services:
-
   db:
-    container_name: ${POSTGRES_CONTAINER_NAME}
     image: postgres:16.6-alpine3.20
+    container_name: ${POSTGRES_CONTAINER_NAME}
     environment:
       ENVIRONMENT: ${APP_ENV}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DATABASE}
     volumes:
-      - ../data/postgres:/var/lib/postgresql/data
+      - ${POSTGRES_VOLUME}
     ports:
       - "${DB_PORT}:${POSTGRES_PORT}"
     networks:


### PR DESCRIPTION
* This is a fix to allow SocialPredict to work with newer versions of MacOS locally.
* (High Level Overview) There are known issues with Docker which deal with how Mac sets certain xattrs in files not allowing Docker to manipulate them directly on the disk, which means we need to mount our postgres volume.
* I have not tested this out on linux.
* The disadvantage of this pattern may be that we might not be able to maintain our postgres volume within the SocialPredict directory for dev unfortunately. This still might work for linux but have not tested it.