### PR TITLE
Update GetBetsForMarkets so it only ever sorts ASC.

### DIFF
--- a/README/DEVELOPMENT/DEVELOPMENT.md
+++ b/README/DEVELOPMENT/DEVELOPMENT.md
@@ -6,3 +6,7 @@
 * Plugins:
 
 * [Go for VS Code](https://code.visualstudio.com/docs/languages/go)
+
+### Checkint Local Development Documentation
+
+* [LOCAL_SETUP](README/LOCAL_SETUP.md)

--- a/backend/handlers/tradingdata/getbets.go
+++ b/backend/handlers/tradingdata/getbets.go
@@ -19,8 +19,10 @@ type PublicBet struct {
 func GetBetsForMarket(db *gorm.DB, marketID uint) []models.Bet {
 	var bets []models.Bet
 
-	// Retrieve all bets for the market
-	if err := db.Where("market_id = ?", marketID).Find(&bets).Error; err != nil {
+	if err := db.
+		Where("market_id = ?", marketID).
+		Order("placed_at ASC").
+		Find(&bets).Error; err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
Forcing GetBetsForMarkets to only ever sort ascending by timestamp so that the API endpoint and positions calculation only ever calculates in a time direction regardless of whatever random output postgres choses to do as the number of bets increase.