### PR TITLE
Update vite.config.mjs

### DIFF
--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -3,6 +3,17 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(() => {
   return {
+    server: {
+      allowedHosts: [
+        'frontend', // we need this to be able to access the app on localhost
+        'localhost',
+        'brierfoxforecast.com', // staging instance
+        'openprediction.xyz' // prod instance
+
+        // add your own domain here!
+
+      ]
+    },
     build: {
       outDir: 'build',
       commonjsOptions: { transformMixedEsModules: true },


### PR DESCRIPTION
Added `frontend`, prod and staging instances to vite.config.mjs to fix a breaking change. Added comments for future users who need to add their own domains to the list of allowed hosts