### PR TITLE
Upgrade node.js, adding to list of allowed hosts

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM node:22.4.0
+FROM node:22.12.0
 
 WORKDIR /app
 

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -3,6 +3,17 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(() => {
   return {
+    server: {
+      allowedHosts: [
+        'frontend', // we need this to be able to access the app on localhost
+        'localhost',
+        'brierfoxforecast.com', // staging instance
+        'openprediction.xyz' // prod instance
+
+        // add your own domain here!
+
+      ]
+    },
     build: {
       outDir: 'build',
       commonjsOptions: { transformMixedEsModules: true },


### PR DESCRIPTION
- Upgraded node.js to 22.12.0.
- Added `frontend`, localhost, staging and prod URLs to `vite.config.mjs`.