### PR TITLE
Fix/upgradego

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM golang:1.23-bookworm
+FROM golang:1.25-bookworm
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM node:22.4.0
+FROM node:22.12.0
 
 WORKDIR /app
 

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -3,6 +3,17 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(() => {
   return {
+    server: {
+      allowedHosts: [
+        'frontend', // we need this to be able to access the app on localhost
+        'localhost',
+        'brierfoxforecast.com', // staging instance
+        'openprediction.xyz' // prod instance
+
+        // add your own domain here!
+
+      ]
+    },
     build: {
       outDir: 'build',
       commonjsOptions: { transformMixedEsModules: true },


### PR DESCRIPTION
- vite upgraded as in last PR
- node.js also upgraded to 22.12.0
- go upgraded to 1.25, which I _think_ is best practice and/or saves us time/effort down the line?

builds fine on local machine