### PR TITLE
Fix/surface better error messages from api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ go.work
 
 # Keys
 .playground_key_pointer
+
+# Local temporary files
+tmp/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,8 +5,8 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Install Dependencies
 RUN apt-get update && apt-get install -y --allow-downgrades \
-    inotify-tools=3.22.6.0-4             \
-    openssl=3.0.14-1~deb12u2
+  inotify-tools=3.22.6.0-4             \
+  openssl
 
 # Set the Working Directory inside the container
 WORKDIR /backend

--- a/backend/handlers/users/changepassword.go
+++ b/backend/handlers/users/changepassword.go
@@ -3,9 +3,12 @@ package usershandlers
 import (
 	"encoding/json"
 	"net/http"
+	"socialpredict/logger"
 	"socialpredict/middleware"
 	"socialpredict/security"
 	"socialpredict/util"
+
+	"fmt"
 )
 
 type ChangePasswordRequest struct {
@@ -19,6 +22,8 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	logger.LogInfo("ChangePassword", "ChangePassword", "ChangePassword handler called")
+
 	// Initialize security service
 	securityService := security.NewSecurityService()
 
@@ -26,41 +31,49 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 	user, httperr := middleware.ValidateTokenAndGetUser(r, db)
 	if httperr != nil {
 		http.Error(w, "Invalid token: "+httperr.Error(), http.StatusUnauthorized)
+		logger.LogError("ChangePassword", "ValidateTokenAndGetUser", httperr)
 		return
 	}
 
 	var req ChangePasswordRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Error decoding request body", http.StatusBadRequest)
+		logger.LogError("ChangePassword", "DecodeRequestBody", err)
 		return
 	}
 
 	// Validate input fields
 	if req.CurrentPassword == "" {
 		http.Error(w, "Current password is required", http.StatusBadRequest)
+		logger.LogError("ChangePassword", "ValidateInputFields", fmt.Errorf("Current password is required"))
 		return
 	}
 
 	if req.NewPassword == "" {
 		http.Error(w, "New password is required", http.StatusBadRequest)
+		logger.LogError("ChangePassword", "ValidateInputFields", fmt.Errorf("New password is required"))
 		return
 	}
 
 	// Check if the current password is correct
 	if !user.CheckPasswordHash(req.CurrentPassword) {
 		http.Error(w, "Current password is incorrect", http.StatusUnauthorized)
+		logger.LogError("ChangePassword", "CheckPasswordHash", fmt.Errorf("Current password is incorrect"))
 		return
 	}
 
 	// Validate new password strength
-	if err := securityService.Sanitizer.SanitizePassword(req.NewPassword); err != nil {
-		http.Error(w, "New password does not meet security requirements: "+err.Error(), http.StatusBadRequest)
+	if _, err := securityService.Sanitizer.SanitizePassword(req.NewPassword); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		// http.Error(w, "New password does not meet security requirements: "+err.Error(), http.StatusBadRequest)
+		logger.LogError("ChangePassword", "ValidateNewPasswordStrength", err)
 		return
 	}
 
 	// Hash the new password
 	if err := user.HashPassword(req.NewPassword); err != nil {
 		http.Error(w, "Failed to hash new password", http.StatusInternalServerError)
+		logger.LogError("ChangePassword", "HashNewPassword", err)
 		return
 	}
 
@@ -70,10 +83,12 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 	// Update the password and MustChangePassword in the database
 	if result := db.Save(&user); result.Error != nil {
 		http.Error(w, "Failed to update password", http.StatusInternalServerError)
+		logger.LogError("ChangePassword", "UpdatePasswordInDB", result.Error)
 		return
 	}
 
 	// Send a success response
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("Password changed successfully"))
+	logger.LogInfo("ChangePassword", "ChangePassword", "Password changed successfully for user "+user.Username)
 }

--- a/backend/handlers/users/changepassword_test.go
+++ b/backend/handlers/users/changepassword_test.go
@@ -77,7 +77,7 @@ func TestPasswordValidation(t *testing.T) {
 
 			// Test password strength validation
 			securityService := security.NewSecurityService()
-			err := securityService.Sanitizer.SanitizePassword(tt.newPass)
+			_, err := securityService.Sanitizer.SanitizePassword(tt.newPass)
 
 			if tt.expectedValid {
 				if err != nil {
@@ -151,7 +151,7 @@ func TestPasswordStrengthRequirements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := securityService.Sanitizer.SanitizePassword(tt.password)
+			_, err := securityService.Sanitizer.SanitizePassword(tt.password)
 
 			if tt.shouldPass {
 				if err != nil {
@@ -186,7 +186,7 @@ func TestPasswordSecurityFeatures(t *testing.T) {
 			testName = testName[:10]
 		}
 		t.Run("Security_Test_"+testName, func(t *testing.T) {
-			err := securityService.Sanitizer.SanitizePassword(maliciousPass)
+			_, err := securityService.Sanitizer.SanitizePassword(maliciousPass)
 
 			// These should either be rejected for weakness or pass sanitization
 			// The key is that they shouldn't cause any security issues
@@ -235,7 +235,7 @@ func TestPasswordLengthValidation(t *testing.T) {
 				password = "A" + "a" + "1" + strings.Repeat("x", remainingLength)
 			}
 
-			err := securityService.Sanitizer.SanitizePassword(password)
+			_, err := securityService.Sanitizer.SanitizePassword(password)
 
 			if tt.shouldPass {
 				if err != nil && strings.Contains(err.Error(), "length") {
@@ -287,7 +287,7 @@ func TestPasswordComplexityPatterns(t *testing.T) {
 
 	for _, pattern := range patterns {
 		t.Run(pattern.name, func(t *testing.T) {
-			err := securityService.Sanitizer.SanitizePassword(pattern.password)
+			_, err := securityService.Sanitizer.SanitizePassword(pattern.password)
 
 			if pattern.shouldPass {
 				if err != nil {

--- a/backend/logger/simplelogging.go
+++ b/backend/logger/simplelogging.go
@@ -1,0 +1,74 @@
+package logger
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"runtime"
+)
+
+// CustomLogger provides logging with enhanced details.
+type CustomLogger struct {
+	logger *log.Logger
+}
+
+// NewCustomLogger creates a new CustomLogger instance.
+func NewCustomLogger(output *os.File, prefix string, flags int) *CustomLogger {
+	return &CustomLogger{
+		logger: log.New(output, prefix, flags),
+	}
+}
+
+// Info logs an informational message with caller details.
+func (l *CustomLogger) Info(message string) {
+	l.logWithCaller("INFO", message)
+}
+
+// Warn logs a warning message with caller details.
+func (l *CustomLogger) Warn(message string) {
+	l.logWithCaller("WARN", message)
+}
+
+// Error logs an error message with caller details.
+func (l *CustomLogger) Error(message string) {
+	l.logWithCaller("ERROR", message)
+}
+
+// logWithCaller retrieves caller information and logs the message.
+func (l *CustomLogger) logWithCaller(level, message string) {
+	_, file, line, ok := runtime.Caller(3) // Caller(3) gets the caller of the Info/Error method
+	if !ok {
+		file = "???"
+		line = 0
+	}
+	funcName := "???"
+	pc, _, _, ok := runtime.Caller(1) // Caller(1) gets the immediate caller of logWithCaller
+	if ok {
+		fn := runtime.FuncForPC(pc)
+		if fn != nil {
+			funcName = fn.Name()
+		}
+	}
+
+	formattedMessage := fmt.Sprintf("%s %s:%d %s() - %s", level, path.Base(file), line, path.Base(funcName), message)
+	l.logger.Println(formattedMessage)
+}
+
+// LogInfo is a convenience function to log informational messages with context.
+func LogInfo(context, function, message string) {
+	logger := NewCustomLogger(os.Stdout, "", log.LstdFlags)
+	logger.Info(fmt.Sprintf("%s - %s: %s", context, function, message))
+}
+
+// LogWarn is a convenience function to log warning messages with context.
+func LogWarn(context, function, message string) {
+	logger := NewCustomLogger(os.Stdout, "", log.LstdFlags)
+	logger.Warn(fmt.Sprintf("%s - %s: %s", context, function, message))
+}
+
+// LogError is a convenience function to log errors with context.
+func LogError(context, function string, err error) {
+	logger := NewCustomLogger(os.Stdout, "", log.LstdFlags)
+	logger.Error(fmt.Sprintf("%s - %s: %v", context, function, err))
+}

--- a/backend/security/sanitizer_test.go
+++ b/backend/security/sanitizer_test.go
@@ -382,7 +382,7 @@ func TestSanitizer_SanitizePassword(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := s.SanitizePassword(tt.input)
+			_, err := s.SanitizePassword(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SanitizePassword() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/backend/security/security.go
+++ b/backend/security/security.go
@@ -93,7 +93,7 @@ func (s *SecurityService) ValidateAndSanitizeUserInput(input UserInput) (*Saniti
 
 	// Validate password if provided
 	if input.Password != "" {
-		if err := s.Sanitizer.SanitizePassword(input.Password); err != nil {
+		if _, err := s.Sanitizer.SanitizePassword(input.Password); err != nil {
 			return nil, err
 		}
 	}

--- a/frontend/src/components/layouts/changepassword/ChangePasswordLayout.jsx
+++ b/frontend/src/components/layouts/changepassword/ChangePasswordLayout.jsx
@@ -46,11 +46,16 @@ function ChangePasswordLayout() {
                 body: JSON.stringify({ currentPassword, newPassword })
             });
             if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.message || 'Failed to change password');
+                // NOTE: The backend returns error messages in plain text
+                // so we read it as text and capitalize the first character
+                // before displaying it to the user. /RR
+                const errMsg = capitalizeFirstChar(await response.text());
+                throw new Error(errMsg || 'Failed to change password');
             }
+
             // Set success message
             setSuccess("Password changed successfully! Logging out. Please log in with your new password.");
+
             // Logout user and redirect to login page after a short delay
             setTimeout(() => {
                 logout();
@@ -96,6 +101,15 @@ function ChangePasswordLayout() {
             {error && <p className="error">{error}</p>}
         </div>
     );
+}
+
+// Utility function to capitalize the first character of a string
+// TODO: Move to utils file if needed elsewhere /RR
+function capitalizeFirstChar(str) {
+  if (typeof str !== 'string' || str.length === 0) {
+    return str; // Handle empty or non-string input
+  }
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 export default ChangePasswordLayout;


### PR DESCRIPTION
- Improved error message handling for `backend/handlers/users/changepassword.go`
  - abstracted `/security/sanitizer.go!sanitizePassword` into two helpers - `CheckPasswordLength`, `CheckPasswordChars` with  better error messages. 
  - broke out tests `hasUppercase`, `hasLowercase`, `hasDigit` into their own functions for convenience. (Should prolly be moved to a util mod.)
  - added a new logger in `backend/logger/simplelogging.go` so I could see errors in backend container logs. NOTE: This isn't really needed, but it was very useful to see where shit hit the fan. Would be happy to remove but I'm a very big believer in copious logging, especially for backend services. "You won't need it until you do; and when you do, it'll save you HOURS."
  
- Refactored error handing in `frontend/src/components/layouts/changepassword/ChangePasswordLayout.jsx` -- the issue here was that the backend api returns error messages in the body of the response as text. the existing code tried to convert to json.
  - added helper `capitalizeFirstChar()` -- this was required because the go convention is error messages start with lowercase. (Should prolly be moved to a utils mod.)

- updated backend tests.