### PR TITLE
Placing openapi.yaml on alternate branch.

### DIFF
--- a/backend/docs/API-ISSUES.md
+++ b/backend/docs/API-ISSUES.md
@@ -1,0 +1,319 @@
+# Issues/Concerns with the Backend API
+
+In my experimentation with the backend, I've discovered a number of issues that
+I feel should be addressed before we can consider the API "fully baked".
+
+## Routes That Fail To Handle Errors Correctly
+
+Once I reconstructed the openapi.yaml file from the source code rather than
+the documentation, I found a number of routes that bubble unhandled errors
+up to the top-level service.
+
+The first I found was `POST /v0/markets` which failed to handle validation correctly
+resulting in `500 Server failed` responses. After digging into the code, I found
+that a new market created with a `resolutionDateTime` that was, according to the
+business rules, too short in duration, would fail to trap the condition and bubbled
+up this 500.
+
+I fixed this code in commit `(af21cd85) - fix 500 resp when market resolution time is too short`.
+
+However, further investigation has found several other handlers that have the same problem:
+
+- Stats
+  - backend/handlers/stats/statshandler.go
+    - On failures computing or encoding stats, uses:
+      - `http.Error(w, "Failed to calculate financial stats: "+err.Error(), http.StatusInternalServerError))`
+      - `http.Error(w, "Failed to load setup configuration: "+err.Error(), http.StatusInternalServerError))`
+      - `http.Error(w, "Failed to encode stats response: "+err.Error(), http.StatusInternalServerError))`
+- CMS Homepage
+  - backend/handlers/cms/homepage/http/handler.go
+    - Several branches write raw errors:
+      - `http.Error(w, err.Error(), http.StatusBadRequest)` in the parse/validation path.
+- Bets – Buying/Selling
+  - backend/handlers/bets/selling/sellpositionhandler.go
+    - Uses `httpErr.Error()` and various `err.Error()` / `dustErr.Error()` for 4xx/5xx:
+      - e.g. `http.Error(w, err.Error(), http.StatusBadRequest/Conflict/UnprocessableEntity/InternalServerError)`
+  - backend/handlers/bets/buying/buypositionhandler.go
+    - Similar pattern:
+      - `http.Error(w, httpErr.Error(), httpErr.StatusCode)`
+      - `http.Error(w, err.Error(), http.StatusBadRequest/Conflict/UnprocessableEntity/InternalServerError)`
+- Positions
+  - `backend/handlers/positions/positionshandler.go`
+    - On certain service errors, uses:
+      - `http.Error(w, "Internal server error", http.StatusInternalServerError)` (generic, not leaking message)
+    - But other errors are mapped to literal strings (“Market not found”, etc.), not raw `err.Error()`.
+- Users – Profile / Position
+  - `backend/handlers/users/changedisplayname.go`
+    - Final catch-all path uses:
+      - `http.Error(w, err.Error(), http.StatusInternalServerError)`
+  - backend/handlers/users/userpositiononmarkethandler.go
+    - On some paths:
+      - `http.Error(w, "Failed to fetch user position", 500)`
+      - `http.Error(w, err.Error(), http.StatusInternalServerError)`
+- Users – Profile helpers
+  - `backend/handlers/users/profile_helpers.go`
+    - writeProfileError inspects `err.Error()` and, for validation errors, passes the message straight through in JSON:
+      - `writeProfileJSONError(w, http.StatusBadRequest, message)`
+    - For some error types it maps to sanitized messages (“User not found”, etc.), but in the generic case it uses the raw error string.
+
+### Thoughts
+
+Generally I really don't favor relying on HTTP Response Codes to indicate error conditions.
+
+Originally when we formalized the HTTP Protocol, its Response Codes were designed specifically to alert clients of problematic conditions with the server-layer rather than the operational-layer. In other words, these codes were to inform clients of a failure of the server itself, *not the operations it undertook.*
+
+Most developers do not have the luxury of this hindsight and continue to try to force their error conditions into the procrustean bed of HTTP Response Codes.
+
+A perfect example of this is these responses returned by `POST /v0/markets`:
+
+- '400': Bad Request - Validation failed while creating the market.
+  - From a server standpoint, this operation is not a bad request, the payload was received and handled properly by the server. Rather, it's an issue with payload validation.
+- '403': Forbidden - Password change required before creating markets.
+  - This is an abuse of the HTTP standard since the issue is one of business rules, not that the user cannot complete the activity. (I have thoughts on the login process which I'll discuss below.)
+
+So, rather than trying to shoehorn everything into Response Codes, what is a better pattern?
+
+All requests that have been *processed correctly by the backend* return 2XX (200, 201, or 204 as appropriate) along with a payload like:
+
+```json
+{
+  "ok": true,
+  "result": any
+}
+```
+
+for successful operations, and
+
+```json
+{
+  "ok": false,
+  "reason": string
+}
+```
+
+for failed operations.
+
+A quick check on the value of `ok` informs the client whether to look for `result` or `reason`.
+
+## The Current Login Process
+
+As you know, the current login flow follows:
+
+- Initial login for new user with initial (temporary) credentials, returns (temporary) JWT
+- Client then must change password using JWT, returns string
+- Client must then re-login with new (correct) credentials, returns JWT.
+
+This flow is problematic for a number of reasons:
+
+**1. You’re fully authenticating a user you don’t fully trust.**
+
+On first login you return:
+
+```json
+{
+  "mustChangePassword": true,
+  "token": "...",
+  "username": "...",
+  "usertype": "..."
+}
+```
+
+Even if the client UI says “you must change your password first,” a malicious client can just ignore mustChangePassword and start using the JWT.
+
+Unless every single protected endpoint:
+
+- parses the JWT,
+- looks up the user,
+- checks mustChangePassword == false,
+- and denies access if not…
+
+…then this user effectively has full access with a default/compromised password.
+
+This is:
+
+- error-prone (easy to forget the check on a new endpoint),
+  - The following routes do not return 401:
+    - GET /health
+    - GET /v0/home
+    - GET /v0/setup
+    - GET /v0/setup/frontend
+    - GET /v0/markets
+    - GET /v0/markets/search
+    - GET /v0/markets/status
+    - GET /v0/markets/status/{status}
+    - GET /v0/markets/{id}
+    - GET /v0/markets/{id}/leaderboard
+    - GET /v0/markets/{id}/projection
+    - GET /v0/marketprojection/{marketId}/{amount}/{outcome}
+    - GET /v0/markets/bets/{marketId}
+    - GET /v0/markets/positions/{marketId}
+    - GET /v0/markets/positions/{marketId}/{username}
+    - GET /v0/userinfo/{username}
+    - GET /v0/usercredit/{username}
+    - GET /v0/portfolio/{username}
+    - GET /v0/users/{username}/financial
+    - GET /v0/stats
+    - GET /v0/system/metrics
+    - GET /v0/global/leaderboard
+    - GET /v0/content/home
+  - If it is your intent to make all of these routes freely accessible, I'd suggest you reconsider since many of these leak information that could be used nefariously by person or persons unknown.
+- a violation of least privilege, and
+- gives attackers a very nice “foot in the door” with default credentials.
+
+Safer pattern:
+
+If mustChangePassword is true, don’t issue a normal access token. Instead:
+
+- Return a distinct error / status like `{ ok: false, reason: "PASSWORD_CHANGE_REQUIRED" }`, or
+- Return a limited-scope, short-lived token this is only allowed to call `/changepassword`.
+
+**2. You’re encoding workflow in a flag the server may not actually enforce**
+
+Right now your security story is “the client will do the right thing.”
+
+Security should **always** assume a hostile client.
+
+If the server is relying on `mustChangePassword` being respected by the front-end, but not enforcing it everywhere server-side, you’ve got:
+
+- Inconsistent authorization rules
+- Lots of subtle bugs waiting to happen
+- Potential privilege escalation if any endpoint forgets the mustChangePassword check
+
+**3. Unnecessary double-login and token churn**
+
+Your flow:
+
+Login → get token A (mustChangePassword: true)
+
+Change password (probably using username+password body, not token)
+
+Login again → get token B (mustChangePassword: false)
+
+Issues:
+
+- Two logins where one would do.
+- Now token A is still valid unless you implement revocation / invalidation on password change.
+- If token A remains usable, you’ve just given a long-lived token to someone with a weak/default password.
+
+Cleaner flow:
+
+- First login attempt with default password → respond with `{ ok: false, reason: "PASSWORD_CHANGE_REQUIRED" }` + password-reset token (or reuse the same endpoint but no normal JWT yet).
+- Call `/changepassword` using that special token.
+- If successful, issue a new normal JWT in the same response or require a regular login from then on.
+
+**4. Inconsistent API semantics & UX**
+
+A few design smells (less severe, but still worth fixing):
+
+- You return 200 OK with a JWT even though the user cannot (or should not) use the system yet. That’s semantically weird; 4xx (“extra action required before full login”) is more natural than “OK, here’s a token, but also no.”
+
+- `/changepassword` returns text/plain instead of JSON, which is inconsistent with the rest of the API shape and makes clients do special-casing.
+
+- You mix authentication concerns (issuing tokens) with account-state workflow in an ad hoc way (mustChangePassword + “but here’s a full token”).
+
+**5. Default / temporary credentials become more dangerous**
+
+If new users are created with known/guessable passwords (common in enterprise setups):
+
+Anyone who learns those default creds can log in and immediately get a full JWT.
+
+Even if you intend to require a password change, in practice they may already have enough access to cause harm unless you’ve perfectly locked down all other endpoints to mustChangePassword == false.
+
+If instead you:
+
+Treat “must change password” as a hard gate to issuing a real access token,
+you dramatically reduce the damage possible from leaked default credentials.
+
+### Bottom Line
+
+This login flow is brittle and requires special handling on the server **and on the client**.
+
+If, on initial login, you reply with:
+
+```json
+{
+  "ok": false,
+  "reason": "MUST CHANGE PASSWORD"
+}
+```
+
+The client can then call `/changepassword` with:
+
+```json
+{
+  "username": string,
+  "password": string,
+  "newPassword": string
+}
+```
+
+which
+
+1. authenticates username and password
+2. updates password with newPassword
+3. return a JWT that allows the user access to the rest of the routes.
+
+## Route Organization
+
+REST is about **Resources** and all of its commands are meant to retrieve and otherwise manipulate resources.
+
+In the backend, I identify the following resources:
+
+- Users
+- Content
+- Markets
+- Bets (Buys/Sells) - N.B. rename this Trades to disconnect semantically from gambling
+- Configuration
+
+As it is, there are a number of routes that seem miss-identified related to their resource, e.g. `/v0/markets/positions/{marketId}` is identified as a 'Users' route.
+
+And the Users routes are very oddly organized. `POST /v0/profilechange/description` and its ilk really seem like they could be better designed, i.e. more RESTully.
+
+Here's how I'd redesign the User routes using Create/Retrieve/Update/Delete (CRUD) semantics:
+
+- Create:
+  - POST /user - creates a new user
+
+- Retrieve:
+  - GET /user[?filter=fields] - paged list of users, optionally filtered
+  - GET /user[?name=username] - info for a specific user
+    - replaces:
+      - GET /userinfo/{username}
+  - GET /user/my - info for the currently logged in user
+    - replaces:
+      - GET /privateprofile
+  - GET /user/{id} - info for a specific user
+
+- Update:
+  - PUT /user/{id} - replaces a user record
+  - PATCH /user/{id} - updates a part of a user record
+    - replaces:
+      - POST /profilechange/description
+      - POST /profilechange/displayname
+      - POST /profilechange/emoji
+      - POST /profilechange/link
+
+- Delete:
+  - DELETE /user/{id} - deletes a user
+
+And the Markets routes: (TO BE COMPLETED... I ran out of steam)
+
+- Create
+  - POST /market - creates a new market
+- Retrieve
+  - GET /market[?filter=fields] - paged list of markets, optionally filtered
+  - GET /market[?username=name] - paged list of markets owned by name
+  - GET /market[?status=value] - paged list of markets by status
+  - GET /market[?search=query] - paged list of markets found using query
+    - Note: These query params can be combined, e.g. [?filter=id,questionTitle,description&search=foobar]
+  - GET /market/my - list of markets owned by current user
+  - GET /market/{id} - get a market by id
+
+- Update
+  - PUT /market/{id}
+  - PATCH /market/{id} -
+    - replaces:
+      - POST /markets/{id}/resolve
+        - payload: {isResolved:true}
+- Delete
+  - DELETE /market/{id} - deletes a market (and its associated records in the DB)

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -99,8 +99,6 @@ paths:
       tags: [Config]
       summary: Get economics configuration
       description: Returns the current economic configuration used by the backend.
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: Economics configuration returned.
@@ -120,8 +118,6 @@ paths:
       tags: [Config]
       summary: Get frontend configuration
       description: Returns minimal configuration values needed by the frontend, such as chart precision.
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: Frontend configuration returned.
@@ -143,8 +139,6 @@ paths:
       description: >
         Returns markets with optional filtering by status and creator. When status is
         provided, results are backed by a status-specific query.
-      security:
-        - bearerAuth: []
       parameters:
         - in: query
           name: status
@@ -246,8 +240,6 @@ paths:
       description: >
         Searches markets by question title with optional status filtering. Supports both
         "query" and legacy "q" parameters.
-      security:
-        - bearerAuth: []
       parameters:
         - in: query
           name: query
@@ -307,8 +299,6 @@ paths:
       tags: [Markets]
       summary: List markets across all statuses
       description: Convenience endpoint equivalent to `/v0/markets?status=all`.
-      security:
-        - bearerAuth: []
       parameters:
         - in: query
           name: limit
@@ -350,8 +340,6 @@ paths:
       tags: [Markets]
       summary: List markets by status
       description: Returns markets filtered by a specific lifecycle status.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: status
@@ -403,8 +391,6 @@ paths:
       description: >
         Fetches a single market by its identifier, including probability history and
         aggregate statistics.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: id
@@ -505,8 +491,6 @@ paths:
       tags: [Markets]
       summary: Get market leaderboard
       description: Ranks participants in a single market by profit and traded volume.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: id
@@ -562,8 +546,6 @@ paths:
       description: >
         Computes the projected probability for a market after a hypothetical bet,
         using the market identifier and bet parameters.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: id
@@ -605,8 +587,6 @@ paths:
       description: >
         Legacy route for computing a probability projection using path parameters
         instead of query parameters.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: marketId
@@ -656,8 +636,6 @@ paths:
       tags: [Bets, Markets]
       summary: List bets for a market
       description: Returns the bet history for a specific market.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: marketId
@@ -699,8 +677,6 @@ paths:
       tags: [Markets, Users]
       summary: List user positions for a market
       description: Returns all user positions (YES/NO shares) in a specific market.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: marketId
@@ -742,8 +718,6 @@ paths:
       tags: [Markets, Users]
       summary: Get a user's position in a market
       description: Returns the holdings for a specific user in the given market.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: marketId
@@ -1156,8 +1130,6 @@ paths:
     get:
       tags: [Users]
       summary: Get public user info
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: username
@@ -1242,8 +1214,6 @@ paths:
       tags: [Users]
       summary: Get user credit
       description: Returns the user's available credit limit, treating missing users as max debt.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: username
@@ -1322,8 +1292,6 @@ paths:
       tags: [Users]
       summary: Get user portfolio
       description: Returns the markets and share counts for a user's portfolio.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: username
@@ -1362,8 +1330,6 @@ paths:
       tags: [Users]
       summary: Get user financial snapshot
       description: Returns a map of financial metrics (e.g., balances and exposures) by key.
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
           name: username
@@ -1402,8 +1368,6 @@ paths:
       tags: [Metrics]
       summary: Get platform stats
       description: Returns aggregate stats and the current economics configuration.
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: Stats returned successfully.
@@ -1423,8 +1387,6 @@ paths:
       tags: [Metrics]
       summary: Get system metrics
       description: Computes money creation/utilization metrics for auditing the economy.
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: Metrics returned successfully.
@@ -1444,8 +1406,6 @@ paths:
       tags: [Metrics]
       summary: Get global leaderboard
       description: Returns a leaderboard ranking users by profitability across all markets.
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: Global leaderboard returned successfully.

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -697,21 +697,21 @@ paths:
         '400':
           description: Invalid market ID.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '404':
           description: Market not found.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '500':
           description: Unexpected server error while fetching positions.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/markets/positions/{marketId}/{username}:
     get:
@@ -742,21 +742,21 @@ paths:
         '400':
           description: Invalid market ID or username.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '404':
           description: Market or user not found.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '500':
           description: Unexpected server error while fetching position.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/bet:
     post:
@@ -781,39 +781,39 @@ paths:
         '400':
           description: Invalid outcome, amount, or request body.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '401':
           description: Authentication failed or password change required.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '404':
           description: Target market not found.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '409':
           description: Market is closed and does not accept new bets.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '422':
           description: Insufficient balance to place the bet.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '500':
           description: Unexpected server error while placing bet.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/sell:
     post:
@@ -838,39 +838,39 @@ paths:
         '400':
           description: Invalid sale request or amount/outcome.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '401':
           description: Authentication failed or password change required.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '404':
           description: Market not found.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '409':
           description: Market closed; sale not allowed.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '422':
           description: No position, insufficient shares, or dust cap exceeded.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '500':
           description: Unexpected server error while processing sale.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/privateprofile:
     get:
@@ -989,9 +989,9 @@ paths:
         '500':
           description: Unexpected server error while updating display name.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/profilechange/emoji:
     post:
@@ -1199,15 +1199,15 @@ paths:
         '404':
           description: Market or user not found.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '500':
           description: Unexpected server error while fetching user position.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/usercredit/{username}:
     get:
@@ -1378,9 +1378,9 @@ paths:
         '500':
           description: Failed to compute stats.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/system/metrics:
     get:
@@ -1397,9 +1397,9 @@ paths:
         '500':
           description: Failed to compute metrics.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
   /v0/global/leaderboard:
     get:
@@ -1463,9 +1463,9 @@ paths:
         '400':
           description: Invalid request body or update failure.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
         '401':
           description: Authentication failed or token invalid.
           content:
@@ -1481,9 +1481,9 @@ paths:
         '500':
           description: Unexpected server error while updating content.
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                type: string
 
 components:
   securitySchemes:

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1,0 +1,2244 @@
+openapi: 3.0.3
+info:
+  title: SocialPredict API
+  version: 0.1.0
+  description: >
+    HTTP contract for the SocialPredict backend service. This spec is generated
+    from the Go handlers and DTOs under backend/server and backend/handlers.
+servers:
+  - url: http://localhost:8080
+    description: Local dev server
+tags:
+  - name: Auth
+    description: Authentication and session management.
+  - name: Config
+    description: Health and configuration endpoints.
+  - name: Markets
+    description: Market creation, listing, search, and resolution.
+  - name: Bets
+    description: Placing and selling bets.
+  - name: Users
+    description: Public and private user profile and financial data.
+  - name: Metrics
+    description: Platform-wide metrics and leaderboards.
+  - name: Content
+    description: CMS-powered homepage content.
+
+paths:
+  /health:
+    get:
+      tags: [Config]
+      summary: Backend health check
+      description: Simple liveness probe that returns "ok" when the backend is running.
+      responses:
+        '200':
+          description: Backend is healthy.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok
+
+  /v0/login:
+    post:
+      tags: [Auth]
+      summary: Authenticate user
+      description: >
+        Validates username and password and returns a JWT bearer token for subsequent
+        authenticated requests.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '400':
+          description: Invalid JSON payload or validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Invalid username or password.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Database access or token creation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/home:
+    get:
+      tags: [Config]
+      summary: Backend home
+      description: Returns a simple JSON message to verify backend availability.
+      responses:
+        '200':
+          description: Backend responded successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+
+  /v0/setup:
+    get:
+      tags: [Config]
+      summary: Get economics configuration
+      description: Returns the current economic configuration used by the backend.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Economics configuration returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Economics'
+        '500':
+          description: Failed to load or encode configuration.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/setup/frontend:
+    get:
+      tags: [Config]
+      summary: Get frontend configuration
+      description: Returns minimal configuration values needed by the frontend, such as chart precision.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Frontend configuration returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrontendConfig'
+        '500':
+          description: Failed to load or encode configuration.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets:
+    get:
+      tags: [Markets]
+      summary: List markets
+      description: >
+        Returns markets with optional filtering by status and creator. When status is
+        provided, results are backed by a status-specific query.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: status
+          required: false
+          description: >
+            Filter by market status. Accepted values are active, closed, resolved, and all
+            (or omitted for all markets).
+          schema:
+            type: string
+            enum: [active, closed, resolved, all]
+        - in: query
+          name: created_by
+          required: false
+          description: Only include markets created by the given username.
+          schema:
+            type: string
+        - in: query
+          name: limit
+          required: false
+          description: Maximum number of markets to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - in: query
+          name: offset
+          required: false
+          description: Number of markets to skip before collecting results.
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Markets returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListMarketsResponse'
+        '400':
+          description: Invalid status or pagination parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while listing markets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags: [Markets]
+      summary: Create a market
+      description: Creates a new prediction market for the authenticated user.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMarketRequest'
+      responses:
+        '201':
+          description: Market created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketResponse'
+        '400':
+          description: Validation failed while creating the market.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed or user not authorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Password change required before creating markets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error during market creation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/search:
+    get:
+      tags: [Markets]
+      summary: Search markets
+      description: >
+        Searches markets by question title with optional status filtering. Supports both
+        "query" and legacy "q" parameters.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: query
+          required: false
+          description: Search query (preferred parameter name).
+          schema:
+            type: string
+        - in: query
+          name: q
+          required: false
+          description: Legacy search query parameter (used if "query" is not provided).
+          schema:
+            type: string
+        - in: query
+          name: status
+          required: false
+          description: Filter by market status; same accepted values as /v0/markets.
+          schema:
+            type: string
+            enum: [active, closed, resolved, all]
+        - in: query
+          name: limit
+          required: false
+          description: Maximum number of primary results to return.
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: offset
+          required: false
+          description: Number of primary results to skip before collecting.
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Search completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '400':
+          description: Missing query parameter or invalid status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error during search.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/status:
+    get:
+      tags: [Markets]
+      summary: List markets across all statuses
+      description: Convenience endpoint equivalent to `/v0/markets?status=all`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          description: Maximum number of markets to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - in: query
+          name: offset
+          required: false
+          description: Number of markets to skip before collecting results.
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Markets returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListMarketsResponse'
+        '400':
+          description: Invalid pagination parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while listing markets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/status/{status}:
+    get:
+      tags: [Markets]
+      summary: List markets by status
+      description: Returns markets filtered by a specific lifecycle status.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: status
+          required: true
+          description: >
+            Market status to filter by. Accepted values are active, closed, resolved, and all.
+          schema:
+            type: string
+            enum: [active, closed, resolved, all]
+        - in: query
+          name: limit
+          required: false
+          description: Maximum number of markets to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - in: query
+          name: offset
+          required: false
+          description: Number of markets to skip before collecting results.
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Markets returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListMarketsResponse'
+        '400':
+          description: Invalid or unsupported status value.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while listing markets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/{id}:
+    get:
+      tags: [Markets]
+      summary: Get market details
+      description: >
+        Fetches a single market by its identifier, including probability history and
+        aggregate statistics.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Numeric identifier of the market.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Market returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDetailsResponse'
+        '400':
+          description: Invalid market ID.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching market details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/{id}/resolve:
+    post:
+      tags: [Markets]
+      summary: Resolve a market
+      description: Sets the final outcome for a market once it has concluded.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Numeric identifier of the market to resolve.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResolveMarketRequest'
+      responses:
+        '204':
+          description: Market resolved successfully; no content is returned.
+        '400':
+          description: Invalid market ID, resolution value, or market state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed or user not authorized to resolve the market.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Password change required before resolving markets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market or user not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Market already resolved or cannot be resolved in its current state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error during resolution.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/{id}/leaderboard:
+    get:
+      tags: [Markets]
+      summary: Get market leaderboard
+      description: Ranks participants in a single market by profit and traded volume.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Numeric identifier of the market.
+          schema:
+            type: integer
+            format: int64
+        - in: query
+          name: limit
+          required: false
+          description: Maximum number of rows to return.
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: offset
+          required: false
+          description: Number of rows to skip before collecting results.
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Leaderboard returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketLeaderboardResponse'
+        '400':
+          description: Invalid market ID or pagination parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while computing leaderboard.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/{id}/projection:
+    get:
+      tags: [Markets]
+      summary: Project market probability
+      description: >
+        Computes the projected probability for a market after a hypothetical bet,
+        using the market identifier and bet parameters.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Numeric identifier of the market.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Projection computed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbabilityProjectionResponse'
+        '400':
+          description: Invalid market ID or bet parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while computing projection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/marketprojection/{marketId}/{amount}/{outcome}:
+    get:
+      tags: [Markets]
+      summary: Legacy market projection endpoint
+      description: >
+        Legacy route for computing a probability projection using path parameters
+        instead of query parameters.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: marketId
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - in: path
+          name: amount
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: outcome
+          required: true
+          schema:
+            type: string
+            enum: [YES, NO]
+      responses:
+        '200':
+          description: Projection computed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbabilityProjectionResponse'
+        '400':
+          description: Invalid market ID, amount, or outcome.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while computing projection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/bets/{marketId}:
+    get:
+      tags: [Bets, Markets]
+      summary: List bets for a market
+      description: Returns the bet history for a specific market.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: marketId
+          required: true
+          description: Numeric identifier of the market.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Bets returned successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketBet'
+        '400':
+          description: Invalid market ID.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching bets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/positions/{marketId}:
+    get:
+      tags: [Markets, Users]
+      summary: List user positions for a market
+      description: Returns all user positions (YES/NO shares) in a specific market.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: marketId
+          required: true
+          description: Numeric identifier of the market.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Positions returned successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketPosition'
+        '400':
+          description: Invalid market ID.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching positions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/markets/positions/{marketId}/{username}:
+    get:
+      tags: [Markets, Users]
+      summary: Get a user's position in a market
+      description: Returns the holdings for a specific user in the given market.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: marketId
+          required: true
+          description: Numeric identifier of the market.
+          schema:
+            type: integer
+            format: int64
+        - in: path
+          name: username
+          required: true
+          description: Username to query.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Position returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketPosition'
+        '400':
+          description: Invalid market ID or username.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market or user not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching position.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/bet:
+    post:
+      tags: [Bets]
+      summary: Place a bet
+      description: Places a YES/NO bet on a market for the authenticated user.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlaceBetRequest'
+      responses:
+        '201':
+          description: Bet placed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceBetResponse'
+        '400':
+          description: Invalid outcome, amount, or request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed or password change required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Target market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Market is closed and does not accept new bets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Insufficient balance to place the bet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while placing bet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/sell:
+    post:
+      tags: [Bets]
+      summary: Sell shares
+      description: Sells an amount of YES/NO shares for the authenticated user and deposits the proceeds.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SellBetRequest'
+      responses:
+        '201':
+          description: Sale processed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SellBetResponse'
+        '400':
+          description: Invalid sale request or amount/outcome.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed or password change required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Market closed; sale not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: No position, insufficient shares, or dust cap exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while processing sale.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/privateprofile:
+    get:
+      tags: [Users]
+      summary: Get private profile
+      description: Returns the authenticated user’s private profile data.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Private profile returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateUserResponse'
+        '401':
+          description: Invalid or missing token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching profile.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/profilechange/description:
+    post:
+      tags: [Users]
+      summary: Update profile description
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeDescriptionRequest'
+      responses:
+        '200':
+          description: Description updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateUserResponse'
+        '400':
+          description: Invalid request body or validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while updating description.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/profilechange/displayname:
+    post:
+      tags: [Users]
+      summary: Update display name
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeDisplayNameRequest'
+      responses:
+        '200':
+          description: Display name updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateUserResponse'
+        '400':
+          description: Invalid request body or validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while updating display name.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/profilechange/emoji:
+    post:
+      tags: [Users]
+      summary: Update personal emoji
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeEmojiRequest'
+      responses:
+        '200':
+          description: Personal emoji updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateUserResponse'
+        '400':
+          description: Invalid request body or validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while updating emoji.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/profilechange/links:
+    post:
+      tags: [Users]
+      summary: Update personal links
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePersonalLinksRequest'
+      responses:
+        '200':
+          description: Personal links updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateUserResponse'
+        '400':
+          description: Invalid request body or validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while updating personal links.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/changepassword:
+    post:
+      tags: [Users]
+      summary: Change account password
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+      responses:
+        '200':
+          description: Password changed successfully.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Password changed successfully
+        '400':
+          description: Invalid request body or password requirements not met.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Invalid or missing token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while changing password.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/userinfo/{username}:
+    get:
+      tags: [Users]
+      summary: Get public user info
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: username
+          required: true
+          description: Username of the profile to fetch.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Public profile returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicUserResponse'
+        '400':
+          description: Username missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching public user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/userposition/{marketId}:
+    get:
+      tags: [Users, Markets]
+      summary: Get authenticated user's position in a market
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: marketId
+          required: true
+          description: Market identifier.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Position returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPosition'
+        '400':
+          description: Invalid market ID.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Market or user not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching user position.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/usercredit/{username}:
+    get:
+      tags: [Users]
+      summary: Get user credit
+      description: Returns the user's available credit limit, treating missing users as max debt.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: username
+          required: true
+          description: Username to evaluate for credit availability.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Credit calculated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCreditResponse'
+        '400':
+          description: Username missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to calculate user credit.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/admin/createuser:
+    post:
+      tags: [Users]
+      summary: Create a new user (admin)
+      description: >
+        Admin-only endpoint that creates a new REGULAR user with a generated password.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCreateUserRequest'
+      responses:
+        '200':
+          description: User created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCreateUserResponse'
+        '400':
+          description: Invalid username or username/display name/email/API key already in use.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to create user or hash password.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/portfolio/{username}:
+    get:
+      tags: [Users]
+      summary: Get user portfolio
+      description: Returns the markets and share counts for a user's portfolio.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: username
+          required: true
+          description: Username whose portfolio should be returned.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Portfolio returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortfolioResponse'
+        '400':
+          description: Username missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while fetching portfolio.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/users/{username}/financial:
+    get:
+      tags: [Users]
+      summary: Get user financial snapshot
+      description: Returns a map of financial metrics (e.g., balances and exposures) by key.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: username
+          required: true
+          description: Username whose financial snapshot is requested.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Financial snapshot returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserFinancialResponse'
+        '400':
+          description: Username missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to generate financial snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/stats:
+    get:
+      tags: [Metrics]
+      summary: Get platform stats
+      description: Returns aggregate stats and the current economics configuration.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Stats returned successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Failed to compute stats.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/system/metrics:
+    get:
+      tags: [Metrics]
+      summary: Get system metrics
+      description: Computes money creation/utilization metrics for auditing the economy.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Metrics returned successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Failed to compute metrics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/global/leaderboard:
+    get:
+      tags: [Metrics]
+      summary: Get global leaderboard
+      description: Returns a leaderboard ranking users by profitability across all markets.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Global leaderboard returned successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GlobalLeaderboardEntry'
+        '500':
+          description: Failed to compute global leaderboard.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v0/content/home:
+    get:
+      tags: [Content]
+      summary: Get public homepage content
+      description: Retrieves CMS-configured homepage content.
+      responses:
+        '200':
+          description: Homepage content returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HomeContent'
+        '404':
+          description: Homepage content not found.
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /v0/admin/content/home:
+    put:
+      tags: [Content]
+      summary: Update homepage content
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HomeContentUpdateRequest'
+      responses:
+        '200':
+          description: Homepage content updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HomeContent'
+        '400':
+          description: Invalid request body or update failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected server error while updating content.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+      required: [error]
+
+    LoginRequest:
+      type: object
+      required: [username, password]
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+
+    LoginResponse:
+      type: object
+      required: [token, username, usertype, mustChangePassword]
+      properties:
+        token:
+          type: string
+        username:
+          type: string
+        usertype:
+          type: string
+        mustChangePassword:
+          type: boolean
+
+    CreateMarketRequest:
+      type: object
+      required: [questionTitle, outcomeType, resolutionDateTime]
+      properties:
+        questionTitle:
+          type: string
+          maxLength: 160
+        description:
+          type: string
+          maxLength: 2000
+        outcomeType:
+          type: string
+        resolutionDateTime:
+          type: string
+          format: date-time
+        yesLabel:
+          type: string
+          maxLength: 20
+        noLabel:
+          type: string
+          maxLength: 20
+
+    MarketResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        questionTitle:
+          type: string
+        description:
+          type: string
+        outcomeType:
+          type: string
+        resolutionDateTime:
+          type: string
+          format: date-time
+        creatorUsername:
+          type: string
+        yesLabel:
+          type: string
+        noLabel:
+          type: string
+        status:
+          type: string
+        isResolved:
+          type: boolean
+        resolutionResult:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    CreatorResponse:
+      type: object
+      properties:
+        username:
+          type: string
+        personalEmoji:
+          type: string
+        displayname:
+          type: string
+
+    MarketOverviewResponse:
+      type: object
+      properties:
+        market:
+          $ref: '#/components/schemas/MarketResponse'
+        creator:
+          $ref: '#/components/schemas/CreatorResponse'
+        lastProbability:
+          type: number
+          format: float
+        numUsers:
+          type: integer
+        totalVolume:
+          type: integer
+          format: int64
+        marketDust:
+          type: integer
+          format: int64
+
+    ListMarketsResponse:
+      type: object
+      properties:
+        markets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketOverviewResponse'
+        total:
+          type: integer
+
+    MarketDetailsResponse:
+      type: object
+      properties:
+        market:
+          $ref: '#/components/schemas/PublicMarketResponse'
+        creator:
+          $ref: '#/components/schemas/CreatorResponse'
+        probabilityChanges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProbabilityChange'
+        numUsers:
+          type: integer
+        totalVolume:
+          type: integer
+          format: int64
+        marketDust:
+          type: integer
+          format: int64
+
+    PublicMarketResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        questionTitle:
+          type: string
+        description:
+          type: string
+        outcomeType:
+          type: string
+        resolutionDateTime:
+          type: string
+          format: date-time
+        finalResolutionDateTime:
+          type: string
+          format: date-time
+        utcOffset:
+          type: integer
+        isResolved:
+          type: boolean
+        resolutionResult:
+          type: string
+        initialProbability:
+          type: number
+          format: float
+        creatorUsername:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        yesLabel:
+          type: string
+        noLabel:
+          type: string
+
+    ProbabilityChange:
+      type: object
+      properties:
+        probability:
+          type: number
+          format: float
+        timestamp:
+          type: string
+          format: date-time
+
+    SearchResponse:
+      type: object
+      properties:
+        primaryResults:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketOverviewResponse'
+        fallbackResults:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketOverviewResponse'
+        query:
+          type: string
+        primaryStatus:
+          type: string
+        primaryCount:
+          type: integer
+        fallbackCount:
+          type: integer
+        totalCount:
+          type: integer
+        fallbackUsed:
+          type: boolean
+
+    ResolveMarketRequest:
+      type: object
+      required: [resolution]
+      properties:
+        resolution:
+          type: string
+          enum: [yes, no]
+
+    MarketLeaderboardResponse:
+      type: object
+      properties:
+        marketId:
+          type: integer
+          format: int64
+        leaderboard:
+          type: array
+          items:
+            $ref: '#/components/schemas/LeaderboardRow'
+        total:
+          type: integer
+
+    LeaderboardRow:
+      type: object
+      properties:
+        username:
+          type: string
+        profit:
+          type: integer
+          format: int64
+        currentValue:
+          type: integer
+          format: int64
+        totalSpent:
+          type: integer
+          format: int64
+        position:
+          type: string
+        yesSharesOwned:
+          type: integer
+          format: int64
+        noSharesOwned:
+          type: integer
+          format: int64
+        rank:
+          type: integer
+
+    ProbabilityProjectionResponse:
+      type: object
+      properties:
+        marketId:
+          type: integer
+          format: int64
+        currentProbability:
+          type: number
+          format: float
+        projectedProbability:
+          type: number
+          format: float
+        amount:
+          type: integer
+          format: int64
+        outcome:
+          type: string
+
+    PlaceBetRequest:
+      type: object
+      properties:
+        marketId:
+          type: integer
+        amount:
+          type: integer
+          format: int64
+        outcome:
+          type: string
+
+    PlaceBetResponse:
+      type: object
+      properties:
+        username:
+          type: string
+        marketId:
+          type: integer
+        amount:
+          type: integer
+          format: int64
+        outcome:
+          type: string
+        placedAt:
+          type: string
+          format: date-time
+
+    SellBetRequest:
+      type: object
+      properties:
+        marketId:
+          type: integer
+        amount:
+          type: integer
+          format: int64
+        outcome:
+          type: string
+
+    SellBetResponse:
+      type: object
+      properties:
+        username:
+          type: string
+        marketId:
+          type: integer
+        sharesSold:
+          type: integer
+          format: int64
+        saleValue:
+          type: integer
+          format: int64
+        dust:
+          type: integer
+          format: int64
+        outcome:
+          type: string
+        transactionAt:
+          type: string
+          format: date-time
+
+    MarketPosition:
+      type: object
+      properties:
+        username:
+          type: string
+        yesSharesOwned:
+          type: integer
+          format: int64
+        noSharesOwned:
+          type: integer
+          format: int64
+        value:
+          type: integer
+          format: int64
+
+    UserPosition:
+      type: object
+      properties:
+        username:
+          type: string
+        marketId:
+          type: integer
+          format: int64
+        yesSharesOwned:
+          type: integer
+          format: int64
+        noSharesOwned:
+          type: integer
+          format: int64
+        value:
+          type: integer
+          format: int64
+        totalSpent:
+          type: integer
+          format: int64
+        totalSpentInPlay:
+          type: integer
+          format: int64
+        isResolved:
+          type: boolean
+        resolutionResult:
+          type: string
+
+    MarketBet:
+      type: object
+      properties:
+        username:
+          type: string
+        marketId:
+          type: integer
+          format: int64
+        amount:
+          type: integer
+          format: int64
+        outcome:
+          type: string
+        placedAt:
+          type: string
+          format: date-time
+
+    PrivateUserResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        displayname:
+          type: string
+        usertype:
+          type: string
+        initialAccountBalance:
+          type: integer
+          format: int64
+        accountBalance:
+          type: integer
+          format: int64
+        personalEmoji:
+          type: string
+        description:
+          type: string
+        personalink1:
+          type: string
+        personalink2:
+          type: string
+        personalink3:
+          type: string
+        personalink4:
+          type: string
+        email:
+          type: string
+        apiKey:
+          type: string
+        mustChangePassword:
+          type: boolean
+
+    PublicUserResponse:
+      type: object
+      properties:
+        username:
+          type: string
+        displayname:
+          type: string
+        usertype:
+          type: string
+        initialAccountBalance:
+          type: integer
+          format: int64
+        accountBalance:
+          type: integer
+          format: int64
+        personalEmoji:
+          type: string
+        description:
+          type: string
+        personalink1:
+          type: string
+        personalink2:
+          type: string
+        personalink3:
+          type: string
+        personalink4:
+          type: string
+
+    UserCreditResponse:
+      type: object
+      properties:
+        credit:
+          type: integer
+          format: int64
+
+    PortfolioItem:
+      type: object
+      properties:
+        marketId:
+          type: integer
+        questionTitle:
+          type: string
+        yesSharesOwned:
+          type: integer
+          format: int64
+        noSharesOwned:
+          type: integer
+          format: int64
+        lastBetPlaced:
+          type: string
+          format: date-time
+
+    PortfolioResponse:
+      type: object
+      properties:
+        portfolioItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortfolioItem'
+        totalSharesOwned:
+          type: integer
+          format: int64
+
+    AdminCreateUserRequest:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Desired username for the new user.
+
+    AdminCreateUserResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        username:
+          type: string
+        password:
+          type: string
+        usertype:
+          type: string
+
+    UserFinancialResponse:
+      type: object
+      properties:
+        financial:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int64
+
+    ChangeDescriptionRequest:
+      type: object
+      properties:
+        description:
+          type: string
+
+    ChangeDisplayNameRequest:
+      type: object
+      properties:
+        displayName:
+          type: string
+
+    ChangeEmojiRequest:
+      type: object
+      properties:
+        emoji:
+          type: string
+
+    ChangePersonalLinksRequest:
+      type: object
+      properties:
+        personalLink1:
+          type: string
+        personalLink2:
+          type: string
+        personalLink3:
+          type: string
+        personalLink4:
+          type: string
+
+    ChangePasswordRequest:
+      type: object
+      properties:
+        currentPassword:
+          type: string
+        newPassword:
+          type: string
+
+    Economics:
+      type: object
+      properties:
+        marketcreation:
+          $ref: '#/components/schemas/MarketCreation'
+        marketincentives:
+          $ref: '#/components/schemas/MarketIncentives'
+        user:
+          $ref: '#/components/schemas/UserEconomics'
+        betting:
+          $ref: '#/components/schemas/Betting'
+
+    MarketCreation:
+      type: object
+      properties:
+        initialMarketProbability:
+          type: number
+          format: float
+        initialMarketSubsidization:
+          type: integer
+          format: int64
+        initialMarketYes:
+          type: integer
+          format: int64
+        initialMarketNo:
+          type: integer
+          format: int64
+        minimumFutureHours:
+          type: number
+          format: float
+
+    MarketIncentives:
+      type: object
+      properties:
+        createMarketCost:
+          type: integer
+          format: int64
+        traderBonus:
+          type: integer
+          format: int64
+
+    UserEconomics:
+      type: object
+      properties:
+        initialAccountBalance:
+          type: integer
+          format: int64
+        maximumDebtAllowed:
+          type: integer
+          format: int64
+
+    BetFees:
+      type: object
+      properties:
+        initialBetFee:
+          type: integer
+          format: int64
+        buySharesFee:
+          type: integer
+          format: int64
+        sellSharesFee:
+          type: integer
+          format: int64
+
+    Betting:
+      type: object
+      properties:
+        minimumBet:
+          type: integer
+          format: int64
+        maxDustPerSale:
+          type: integer
+          format: int64
+        betFees:
+          $ref: '#/components/schemas/BetFees'
+
+    FrontendConfig:
+      type: object
+      properties:
+        charts:
+          $ref: '#/components/schemas/FrontendCharts'
+
+    FrontendCharts:
+      type: object
+      properties:
+        sigFigs:
+          type: integer
+
+    GlobalLeaderboardEntry:
+      type: object
+      properties:
+        username:
+          type: string
+        totalProfit:
+          type: integer
+          format: int64
+        totalCurrentValue:
+          type: integer
+          format: int64
+        totalSpent:
+          type: integer
+          format: int64
+        activeMarkets:
+          type: integer
+        resolvedMarkets:
+          type: integer
+        earliestBet:
+          type: string
+          format: date-time
+        rank:
+          type: integer
+
+    HomeContent:
+      type: object
+      properties:
+        title:
+          type: string
+        format:
+          type: string
+        html:
+          type: string
+        markdown:
+          type: string
+        version:
+          type: integer
+          format: int64
+        updatedAt:
+          type: string
+          format: date-time
+
+    HomeContentUpdateRequest:
+      type: object
+      properties:
+        title:
+          type: string
+        format:
+          type: string
+        markdown:
+          type: string
+        html:
+          type: string
+        version:
+          type: integer
+          format: int64


### PR DESCRIPTION
* Documented actual unauthenticated endpoints by removing bearerAuth from public routes (setup, market listing/search/status/detail/projection/leaderboard/history/positions, public user info/credit/portfolio/financial, stats/system/global leaderboards) in backend/docs/openapi.yaml.
* Aligned error response content with observed behavior: routes that emit raw errors now declare text/plain bodies (bets place/sell, market positions, user position lookup, admin homepage update, display name update, stats/system metrics).
Kept other contract details intact; spec validates with YAML parser.

* No testing, spec/doc only.