### PR TITLE
ISP for analytics, bets, markets and math. 

### DIFF
--- a/backend/internal/domain/analytics/repository.go
+++ b/backend/internal/domain/analytics/repository.go
@@ -233,3 +233,12 @@ func (r *GormRepository) calculateUserPositions(username string, marketIDs []uin
 
 	return positions, nil
 }
+
+var (
+	_ Repository            = (*GormRepository)(nil)
+	_ LeaderboardRepository = (*GormRepository)(nil)
+	_ FinancialsRepository  = (*GormRepository)(nil)
+	_ DebtRepository        = (*GormRepository)(nil)
+	_ VolumeRepository      = (*GormRepository)(nil)
+	_ FeeRepository         = (*GormRepository)(nil)
+)

--- a/backend/internal/domain/analytics/system_metrics.go
+++ b/backend/internal/domain/analytics/system_metrics.go
@@ -55,7 +55,7 @@ func (s *Service) ComputeSystemMetrics(ctx context.Context) (*SystemMetrics, err
 // DefaultDebtCalculator implements the existing debt policy.
 type DefaultDebtCalculator struct{}
 
-func (c DefaultDebtCalculator) Calculate(ctx context.Context, repo Repository, econ *setup.EconomicConfig) (*DebtStats, error) {
+func (c DefaultDebtCalculator) Calculate(ctx context.Context, repo DebtRepository, econ *setup.EconomicConfig) (*DebtStats, error) {
 	users, err := repo.ListUsers(ctx)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (c DefaultDebtCalculator) Calculate(ctx context.Context, repo Repository, e
 // DefaultVolumeCalculator implements the existing volume policy.
 type DefaultVolumeCalculator struct{}
 
-func (c DefaultVolumeCalculator) Calculate(ctx context.Context, repo Repository, econ *setup.EconomicConfig) (*MarketVolumeStats, error) {
+func (c DefaultVolumeCalculator) Calculate(ctx context.Context, repo VolumeRepository, econ *setup.EconomicConfig) (*MarketVolumeStats, error) {
 	markets, err := repo.ListMarkets(ctx)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func (c DefaultVolumeCalculator) Calculate(ctx context.Context, repo Repository,
 // DefaultFeeCalculator implements the existing participation fee policy.
 type DefaultFeeCalculator struct{}
 
-func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, repo Repository, econ *setup.EconomicConfig) (int64, error) {
+func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, repo FeeRepository, econ *setup.EconomicConfig) (int64, error) {
 	betsOrdered, err := repo.ListBetsOrdered(ctx)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
### ISP

* Implemented ISP-focused refactors: split analytics service dependencies into role-specific repos (debt/volume/fee/leaderboard/financials) and updated calculators; added interface assertions for the Gorm repository. In markets, separated repo responsibilities into read/write/position/bet groups and narrowed resolution flows to a dedicated ResolutionRepository. Behavior unchanged; tests not run.

Area	File	Assignee	Status
analytics	backend/internal/domain/analytics/financialsnapshot_test.go	Patrick	[ ]
analytics	backend/internal/domain/analytics/leaderboard_test.go	Patrick	[ ]
analytics	backend/internal/domain/analytics/models.go	Patrick	[ ]
analytics	backend/internal/domain/analytics/repository.go	Patrick	✅
analytics	backend/internal/domain/analytics/service.go	Patrick	✅
analytics	backend/internal/domain/analytics/systemmetrics_integration_test.go	Patrick	[ ]
analytics	backend/internal/domain/analytics/systemmetrics_test.go	Patrick	[ ]
bets	backend/internal/domain/bets/errors.go	Patrick	[ ]
bets	backend/internal/domain/bets/models.go	Patrick	[ ]
bets	backend/internal/domain/bets/service_helpers_test.go	Patrick	[ ]
bets	backend/internal/domain/bets/service_test.go	Patrick	[ ]
bets	backend/internal/domain/bets/service.go	Patrick	[ ]
markets	backend/internal/domain/markets/errors.go	Patrick	[ ]
markets	backend/internal/domain/markets/models.go	Patrick	[ ]
markets	backend/internal/domain/markets/service_details_test.go	Patrick	[ ]
markets	backend/internal/domain/markets/service_listbystatus_test.go	Patrick	[ ]
markets	backend/internal/domain/markets/service_marketbets_test.go	Patrick	[ ]
markets	backend/internal/domain/markets/service_probability_test.go	Patrick	[ ]
markets	backend/internal/domain/markets/service_resolve_test.go	Patrick	[ ]
markets	backend/internal/domain/markets/service_search_test.go	Patrick	[ ]
markets	backend/internal/domain/markets/service.go	Patrick	✅
math	backend/internal/domain/math/market/dust_test.go	Patrick	[ ]
math	backend/internal/domain/math/market/dust.go	Patrick	[ ]
math	backend/internal/domain/math/market/marketvolume_test.go	Patrick	[ ]
math	backend/internal/domain/math/market/marketvolume.go	Patrick	[ ]
math	backend/internal/domain/math/outcomes/dbpm/marketshares_test.go	Patrick	[ ]
math	backend/internal/domain/math/outcomes/dbpm/marketshares.go	Patrick	[ ]
math	backend/internal/domain/math/positions/adjust_valuation_test.go	Patrick	[ ]
math	backend/internal/domain/math/positions/adjust_valuation.go	Patrick	[ ]
math	backend/internal/domain/math/positions/positionsmath_test.go	Patrick	[ ]
math	backend/internal/domain/math/positions/positionsmath.go	Patrick	[ ]
math	backend/internal/domain/math/positions/profitability_test.go	Patrick	[ ]
math	backend/internal/domain/math/positions/profitability.go	Patrick	[ ]
math	backend/internal/domain/math/positions/valuation_test.go	Patrick	[ ]
math	backend/internal/domain/math/positions/valuation.go	Patrick	[ ]
math	backend/internal/domain/math/probabilities/wpam/wpam_current_test.go	Patrick	[ ]
math	backend/internal/domain/math/probabilities/wpam/wpam_current.go	Patrick	[ ]
math	backend/internal/domain/math/probabilities/wpam/wpam_marketprobabilities_test.go	Patrick	[ ]
math	backend/internal/domain/math/probabilities/wpam/wpam_marketprobabilities.go	Patrick	[ ]
users	backend/internal/domain/users/errors.go	Osnat	[ ]
users	backend/internal/domain/users/models.go	Osnat	[ ]
users	backend/internal/domain/users/service_profile_test.go	Osnat	[ ]
users	backend/internal/domain/users/service_transactions_test.go	Osnat	[ ]
users	backend/internal/domain/users/service.go	Osnat	[ ]
users	backend/internal/domain/users/transactions.go	Osnat	[ ]
