### PR TITLE
fix(#4): set Cross-Origin-Resource-Policy header to fix Firefox/uBlock login

### DIFF
--- a/backend/security/headers.go
+++ b/backend/security/headers.go
@@ -76,7 +76,7 @@ func SecurityHeadersMiddleware(headers SecurityHeaders) func(http.Handler) http.
 			w.Header().Set("X-Permitted-Cross-Domain-Policies", "none")
 			w.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
 			w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
-			w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+			w.Header().Set("Cross-Origin-Resource-Policy", "cross-origin")
 
 			// Remove server information
 			w.Header().Set("Server", "")

--- a/backend/security/security_test.go
+++ b/backend/security/security_test.go
@@ -333,6 +333,31 @@ func TestValidateAndSanitizeBetInput(t *testing.T) {
 	}
 }
 
+// TestCORPHeaderAllowsCrossOrigin ensures the Cross-Origin-Resource-Policy header
+// is set to "cross-origin" so Firefox + content-blocking extensions (UBlock, UMatrix)
+// do not block API responses fetched from a different origin (e.g. frontend on :3000
+// calling backend on :8080). See GitHub issue #4.
+func TestCORPHeaderAllowsCrossOrigin(t *testing.T) {
+	service := NewSecurityService()
+	middleware := service.SecurityMiddleware()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrappedHandler := middleware(testHandler)
+
+	req := httptest.NewRequest("POST", "/v0/login", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+	rr := httptest.NewRecorder()
+	wrappedHandler.ServeHTTP(rr, req)
+
+	corp := rr.Header().Get("Cross-Origin-Resource-Policy")
+	if corp != "cross-origin" {
+		t.Errorf("Cross-Origin-Resource-Policy = %q, want %q (same-origin blocks cross-origin fetches in Firefox with UBlock/UMatrix)", corp, "cross-origin")
+	}
+}
+
 func TestGetDefaultConfig(t *testing.T) {
 	config := GetDefaultConfig()
 


### PR DESCRIPTION
Sets `Cross-Origin-Resource-Policy: cross-origin` on the backend response so Firefox with uBlock Origin can complete the login flow without a CORS fetch error.

Closes #4