### PR TITLE
fix(#23): wrap profile tables with overflow-x-auto for mobile

### DIFF
--- a/frontend/src/components/layouts/profile/public/PublicUserPortfolioLayout.jsx
+++ b/frontend/src/components/layouts/profile/public/PublicUserPortfolioLayout.jsx
@@ -62,6 +62,7 @@ const PublicUserPortfolioLayout = ({ username, userData }) => {
             </div>
             <div className="p-6">
                 <h3 className="text-lg font-medium text-gray-700 mb-2">Portfolio</h3>
+                <div className="overflow-x-auto">
                 <table className="w-full divide-y divide-gray-200 bg-primary-background">
                     <thead className="bg-gray-50">
                         <tr>
@@ -84,6 +85,7 @@ const PublicUserPortfolioLayout = ({ username, userData }) => {
                         ))}
                     </tbody>
                 </table>
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/components/layouts/profile/public/UserFinancialStatementsLayout.jsx
+++ b/frontend/src/components/layouts/profile/public/UserFinancialStatementsLayout.jsx
@@ -46,7 +46,8 @@ const UserFinancialStatementsLayout = ({ username }) => {
             <h4 className={`text-lg font-semibold text-white mb-4 p-3 ${bgColor} rounded-t-lg`}>
                 {title}
             </h4>
-            <table className="w-full divide-y divide-gray-200 bg-primary-background rounded-b-lg overflow-hidden">
+            <div className="overflow-x-auto rounded-b-lg">
+            <table className="w-full divide-y divide-gray-200 bg-primary-background">
                 <thead className="bg-gray-50">
                     <tr>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -82,6 +83,7 @@ const UserFinancialStatementsLayout = ({ username }) => {
                     ))}
                 </tbody>
             </table>
+            </div>
         </div>
     );
 


### PR DESCRIPTION
Wraps the markets and bets tables on profile pages with `overflow-x-auto` so they scroll horizontally on small screens instead of breaking the layout.

Closes #23