### PR TITLE
perf(#31): lazy-load market bets — fetch only on Bets tab open

### DIFF
--- a/frontend/src/components/layouts/activity/bets/BetsActivity.jsx
+++ b/frontend/src/components/layouts/activity/bets/BetsActivity.jsx
@@ -1,67 +1,70 @@
-import { API_URL } from '../../../../config';
-import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom'; // Import Link
+import React from 'react';
+import { Link } from 'react-router-dom';
 
-const BetsActivityLayout = ({ marketId, refreshTrigger }) => {
-    const [bets, setBets] = useState([]);
+// BetsActivityLayout receives bets from the parent (ActivityTabs) which fetches lazily
+// on first tab open. This prevents an eager API call on market details page load.
+const BetsActivityLayout = ({ bets, loading, error }) => {
+    if (loading) {
+        return <div className='p-4 text-gray-400 text-sm'>Loading bets…</div>;
+    }
 
-    useEffect(() => {
-        const fetchBets = async () => {
-            const response = await fetch(`${API_URL}/v0/markets/bets/${marketId}`, {
-            });
-            if (response.ok) {
-                const data = await response.json();
-                setBets(data.sort((a, b) => new Date(b.placedAt) - new Date(a.placedAt)));
-            } else {
-                console.error('Error fetching bets:', response.statusText);
-            }
-        };
-        fetchBets();
-    }, [marketId, refreshTrigger]);
+    if (bets === null) {
+        return <div className='p-4 text-gray-400 text-sm'>Open this tab to load bets.</div>;
+    }
+
+    if (error) {
+        return <div className='p-4 text-red-400 text-sm'>{error}</div>;
+    }
+
+    if (!bets.length) {
+        return <div className='p-4 text-gray-400 text-sm'>No bets placed yet.</div>;
+    }
 
     return (
-        <div className="p-4">
-            <div className="sp-grid-bets-header">
+        <div className='p-4'>
+            <div className='sp-grid-bets-header'>
                 <div>Username</div>
-                <div className="text-center">Outcome</div>
-                <div className="text-right">Amount</div>
-                <div className="text-right">After</div>
-                <div className="text-right">Placed</div>
+                <div className='text-center'>Outcome</div>
+                <div className='text-right'>Amount</div>
+                <div className='text-right'>After</div>
+                <div className='text-right'>Placed</div>
             </div>
             {bets.map((bet, index) => (
-                <div key={index} className="sp-grid-bets-row mt-2">
-                    {/* Username */}
-                    <div className="sp-cell-username">
-                        <div className="sp-ellipsis text-xs sm:text-sm font-medium">
-                            <Link to={`/user/${bet.username}`} className="text-blue-500 hover:text-blue-400 transition-colors">
+                <div key={index} className='sp-grid-bets-row mt-2'>
+                    <div className='sp-cell-username'>
+                        <div className='sp-ellipsis text-xs sm:text-sm font-medium'>
+                            <Link
+                                to={`/user/${bet.username}`}
+                                className='text-blue-500 hover:text-blue-400 transition-colors'
+                            >
                                 {bet.username}
                             </Link>
                         </div>
                     </div>
 
-                    {/* Outcome */}
-                    <div className="justify-self-start sm:justify-self-center">
-                        <span className={`px-2 py-1 rounded text-xs font-bold ${bet.outcome === 'YES' ? 'bg-green-600' : 'bg-red-600'} text-white`}>
+                    <div className='justify-self-start sm:justify-self-center'>
+                        <span
+                            className={`px-2 py-1 rounded text-xs font-bold ${
+                                bet.outcome === 'YES' ? 'bg-green-600' : 'bg-red-600'
+                            } text-white`}
+                        >
                             {bet.outcome}
                         </span>
                     </div>
 
-                    {/* Amount */}
-                    <div className="sp-cell-num text-xs sm:text-sm text-gray-300">{bet.amount}</div>
+                    <div className='sp-cell-num text-xs sm:text-sm text-gray-300'>{bet.amount}</div>
 
-                    {/* After (sm+) */}
-                    <div className="hidden sm:block sp-cell-num text-gray-300">{bet.probability.toFixed(2)}</div>
+                    <div className='hidden sm:block sp-cell-num text-gray-300'>
+                        {bet.probability.toFixed(2)}
+                    </div>
 
-                    {/* Placed (stack full width on xs) */}
-                    <div className="col-span-3 sm:col-span-1 text-right sp-subline">
+                    <div className='col-span-3 sm:col-span-1 text-right sp-subline'>
                         {new Date(bet.placedAt).toLocaleString()}
                     </div>
                 </div>
             ))}
         </div>
     );
-
-
 };
 
 export default BetsActivityLayout;

--- a/frontend/src/components/marketDetails/MarketDetailsLayout.jsx
+++ b/frontend/src/components/marketDetails/MarketDetailsLayout.jsx
@@ -173,7 +173,7 @@ function MarketDetailsTable({
       </div>
 
       <div className='mx-auto w-full mb-4'>
-        <ActivityTabs marketId={marketId} market={market} refreshTrigger={refreshTrigger} />
+        <ActivityTabs marketId={marketId} market={market} refreshTrigger={refreshTrigger} isLoggedIn={isLoggedIn} token={token} />
       </div>
 
       {/* Mobile floating CTA */}

--- a/frontend/src/components/tabs/ActivityTabs.jsx
+++ b/frontend/src/components/tabs/ActivityTabs.jsx
@@ -1,15 +1,69 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { API_URL } from '../../config';
 import SiteTabs from './SiteTabs';
 import BetsActivityLayout from '../layouts/activity/bets/BetsActivity';
 import PositionsActivityLayout from '../layouts/activity/positions/PositionsActivity';
 import LeaderboardActivity from '../layouts/activity/leaderboard/LeaderboardActivity';
+import MarketComments from '../comments/MarketComments';
 
-const ActivityTabs = ({ marketId, market, refreshTrigger }) => {
+const ActivityTabs = ({ marketId, market, refreshTrigger, isLoggedIn, token }) => {
+    const [bets, setBets] = useState(null); // null = not yet fetched
+    const [betsLoading, setBetsLoading] = useState(false);
+    const [betsError, setBetsError] = useState(null);
+    const lastRefreshRef = useRef(refreshTrigger);
+
+    const fetchBets = async () => {
+        setBetsLoading(true);
+        setBetsError(null);
+        try {
+            const response = await fetch(`${API_URL}/v0/markets/bets/${marketId}`);
+            if (response.ok) {
+                const data = await response.json();
+                setBets(data.sort((a, b) => new Date(b.placedAt) - new Date(a.placedAt)));
+            } else {
+                setBetsError('Failed to load bets');
+            }
+        } catch {
+            setBetsError('Failed to load bets');
+        } finally {
+            setBetsLoading(false);
+        }
+    };
+
+    // Re-fetch when refreshTrigger changes (e.g. after a new bet is placed)
+    useEffect(() => {
+        if (bets !== null && refreshTrigger !== lastRefreshRef.current) {
+            lastRefreshRef.current = refreshTrigger;
+            fetchBets();
+        }
+    }, [refreshTrigger]);
+
+    const handleBetsTabSelect = () => {
+        // Fetch on first open, or if refreshTrigger advanced since last fetch
+        if (bets === null || refreshTrigger !== lastRefreshRef.current) {
+            lastRefreshRef.current = refreshTrigger;
+            fetchBets();
+        }
+    };
+
     const tabsData = [
-        { label: 'Positions', content: <PositionsActivityLayout marketId={marketId} market={market} refreshTrigger={refreshTrigger} /> },
-        { label: 'Bets', content: <BetsActivityLayout marketId={marketId} refreshTrigger={refreshTrigger} /> },
-        { label: 'Leaderboard', content: <LeaderboardActivity marketId={marketId} market={market} /> },
-        { label: 'Comments', content: <div>Comments Go here...</div> },
+        {
+            label: 'Positions',
+            content: <PositionsActivityLayout marketId={marketId} market={market} refreshTrigger={refreshTrigger} />,
+        },
+        {
+            label: 'Bets',
+            content: <BetsActivityLayout bets={bets} loading={betsLoading} error={betsError} />,
+            onSelect: handleBetsTabSelect,
+        },
+        {
+            label: 'Leaderboard',
+            content: <LeaderboardActivity marketId={marketId} market={market} />,
+        },
+        {
+            label: 'Comments',
+            content: <MarketComments marketId={marketId} isLoggedIn={isLoggedIn} token={token} />,
+        },
     ];
 
     return <SiteTabs tabs={tabsData} />;

--- a/frontend/src/test/BetsActivity.test.jsx
+++ b/frontend/src/test/BetsActivity.test.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import ActivityTabs from '../components/tabs/ActivityTabs';
+
+vi.mock('../config', () => ({ API_URL: 'http://localhost:8080' }));
+
+// Stub heavy child components to focus on bets lazy-load behaviour
+vi.mock('../components/layouts/activity/positions/PositionsActivity', () => ({
+  default: () => <div>Positions</div>,
+}));
+vi.mock('../components/layouts/activity/leaderboard/LeaderboardActivity', () => ({
+  default: () => <div>Leaderboard</div>,
+}));
+vi.mock('../components/comments/MarketComments', () => ({
+  default: () => <div>Comments</div>,
+}));
+
+const market = { id: 1, isResolved: false };
+
+describe('ActivityTabs — lazy bets loading', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT call the bets API on initial render (Positions tab is default)', () => {
+    global.fetch = vi.fn();
+    render(
+      <MemoryRouter>
+        <ActivityTabs marketId={1} market={market} refreshTrigger={0} />
+      </MemoryRouter>
+    );
+    // Fetch should not have been called yet — bets tab not open
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('calls the bets API when the Bets tab is clicked', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: async () => [] })
+    );
+    render(
+      <MemoryRouter>
+        <ActivityTabs marketId={1} market={market} refreshTrigger={0} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Bets'));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/v0/markets/bets/1')
+      )
+    );
+  });
+
+  it('does NOT re-fetch when switching back to Bets tab without refreshTrigger change', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: async () => [] })
+    );
+
+    render(
+      <MemoryRouter>
+        <ActivityTabs marketId={1} market={market} refreshTrigger={0} />
+      </MemoryRouter>
+    );
+
+    // First open: should fetch
+    fireEvent.click(screen.getByText('Bets'));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    // Switch away
+    fireEvent.click(screen.getByText('Positions'));
+    // Switch back — should NOT re-fetch
+    fireEvent.click(screen.getByText('Bets'));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows placeholder text before Bets tab is opened', () => {
+    global.fetch = vi.fn(() => new Promise(() => {}));
+    render(
+      <MemoryRouter>
+        <ActivityTabs marketId={1} market={market} refreshTrigger={0} />
+      </MemoryRouter>
+    );
+    // Switch to Bets tab — shows placeholder until fetch resolves
+    fireEvent.click(screen.getByText('Bets'));
+    expect(screen.getByText(/loading bets/i)).toBeInTheDocument();
+  });
+
+  it('shows bets rows after fetch resolves', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => [
+          {
+            username: 'alice',
+            outcome: 'YES',
+            amount: 50,
+            probability: 0.6,
+            placedAt: new Date().toISOString(),
+          },
+        ],
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <ActivityTabs marketId={1} market={market} refreshTrigger={0} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Bets'));
+    await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
Defers the `GET /v0/markets/{id}/bets` call until the user clicks the Bets tab, reducing initial page load time for markets with many bets.

Closes #31