### PR TITLE
fix(#569): return 404 and show friendly message for non-existent user profiles

### DIFF
--- a/backend/handlers/users/publicuser/publicuser.go
+++ b/backend/handlers/users/publicuser/publicuser.go
@@ -2,6 +2,7 @@ package publicuser
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"socialpredict/models"
 	"socialpredict/util"
@@ -17,10 +18,18 @@ func GetPublicUserResponse(w http.ResponseWriter, r *http.Request) {
 
 	db := util.GetDB()
 
-	response := GetPublicUserInfo(db, username)
+	var user models.User
+	if err := db.Where("username = ?", username).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			http.Error(w, "User not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Error fetching user", http.StatusInternalServerError)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	json.NewEncoder(w).Encode(user.PublicUser)
 }
 
 // Function to get the users public info From the Database

--- a/backend/handlers/users/publicuser/publicuser_test.go
+++ b/backend/handlers/users/publicuser/publicuser_test.go
@@ -1,10 +1,14 @@
 package publicuser
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"socialpredict/models"
 	"socialpredict/models/modelstesting"
-
+	"socialpredict/util"
 	"testing"
+
+	"github.com/gorilla/mux"
 )
 
 func TestGetPublicUserInfo(t *testing.T) {
@@ -54,5 +58,38 @@ func TestGetPublicUserInfo(t *testing.T) {
 
 	if retrievedUser != expectedUser {
 		t.Errorf("GetPublicUserInfo(db, 'testuser') = %+v, want %+v", retrievedUser, expectedUser)
+	}
+}
+
+func TestGetPublicUserResponse_NotFound(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	util.DB = db
+
+	req, _ := http.NewRequest("GET", "/v0/userinfo/ghostuser", nil)
+	req = mux.SetURLVars(req, map[string]string{"username": "ghostuser"})
+	rr := httptest.NewRecorder()
+
+	GetPublicUserResponse(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown user, got %d", rr.Code)
+	}
+}
+
+func TestGetPublicUserResponse_Found(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	util.DB = db
+
+	user := modelstesting.GenerateUser("knownuser", 500)
+	db.Create(&user)
+
+	req, _ := http.NewRequest("GET", "/v0/userinfo/knownuser", nil)
+	req = mux.SetURLVars(req, map[string]string{"username": "knownuser"})
+	rr := httptest.NewRecorder()
+
+	GetPublicUserResponse(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 for existing user, got %d", rr.Code)
 	}
 }

--- a/frontend/src/pages/user/User.jsx
+++ b/frontend/src/pages/user/User.jsx
@@ -9,16 +9,31 @@ import UserFinancialStatementsLayout from '../../components/layouts/profile/publ
 
 const User = () => {
   const [userData, setUserData] = useState(null);
+  const [notFound, setNotFound] = useState(false);
   const { username } = useParams();
   const { isLoggedIn, username: loggedInUsername } = useAuth();
   const history = useHistory();
 
   useEffect(() => {
     fetch(`${API_URL}/v0/userinfo/${username}`)
-      .then((response) => response.json())
-      .then((data) => setUserData(data))
+      .then((response) => {
+        if (response.status === 404) {
+          setNotFound(true);
+          return null;
+        }
+        return response.json();
+      })
+      .then((data) => { if (data) setUserData(data); })
       .catch((error) => console.error('Error fetching user data:', error));
   }, [username]);
+
+  if (notFound) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-primary-background">
+        <div className="text-white text-lg">User not found.</div>
+      </div>
+    );
+  }
 
   if (!userData) {
     return (

--- a/frontend/src/test/User.notfound.test.jsx
+++ b/frontend/src/test/User.notfound.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+
+vi.mock('../config', () => ({ API_URL: 'http://localhost:8080' }));
+vi.mock('../helpers/AuthContent', () => ({
+  useAuth: () => ({ isLoggedIn: false, username: null }),
+}));
+
+// Stub sub-components so the test stays focused on the not-found path
+vi.mock('../components/tabs/SiteTabs', () => ({ default: () => <div>Tabs</div> }));
+vi.mock('../components/layouts/profile/public/UserInfoTabContent', () => ({ default: () => null }));
+vi.mock('../components/layouts/profile/public/PortfolioTabContent', () => ({ default: () => null }));
+vi.mock('../components/layouts/profile/public/UserFinancialStatementsLayout', () => ({ default: () => null }));
+vi.mock('../components/layouts/profile/public/BetHistoryTabContent', () => ({ default: () => null }));
+
+import User from '../pages/user/User';
+
+function renderUser(username) {
+  return render(
+    <MemoryRouter initialEntries={[`/user/${username}`]}>
+      <Route path="/user/:username">
+        <User />
+      </Route>
+    </MemoryRouter>
+  );
+}
+
+describe('User page — not found (#569)', () => {
+  it('shows "User not found" when API returns 404', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 404, json: vi.fn() });
+
+    renderUser('ghostuser');
+
+    await waitFor(() =>
+      expect(screen.getByText('User not found.')).toBeTruthy()
+    );
+  });
+
+  it('shows loading state initially', () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
+
+    renderUser('slowuser');
+
+    expect(screen.getByText('Loading user profile...')).toBeTruthy();
+  });
+
+  it('renders profile when API returns user data', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        username: 'alice',
+        displayname: 'Alice',
+        personalEmoji: '🙂',
+        usertype: 'regular',
+        accountBalance: 1000,
+        initialAccountBalance: 1000,
+      }),
+    });
+
+    renderUser('alice');
+
+    await waitFor(() => expect(screen.getByText('Tabs')).toBeTruthy());
+  });
+});


### PR DESCRIPTION
The `GET /v0/users/{username}` handler now returns `404` instead of an empty object when the user doesn't exist. The frontend `UserProfile` page detects the 404 and renders a "User not found" message instead of a blank page.

Closes #569