### PR TITLE
fix(#596): remove spurious /api/ prefix from useUserData profile URLs

### DIFF
--- a/frontend/src/hooks/useUserData.jsx
+++ b/frontend/src/hooks/useUserData.jsx
@@ -15,14 +15,14 @@ const useUserData = (username, usePrivateProfile = false) => {
         
         if (usePrivateProfile) {
           // Use private profile endpoint for authenticated user's own profile
-          url = `${API_URL}/api/v0/privateprofile`;
+          url = `${API_URL}/v0/privateprofile`;
           headers = {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
           };
         } else {
           // Use public user endpoint for viewing other users' profiles
-          url = `${API_URL}/api/v0/userinfo/${username}`;
+          url = `${API_URL}/v0/userinfo/${username}`;
           if (token) {
             headers = {
               'Authorization': `Bearer ${token}`,


### PR DESCRIPTION
The `useUserData` hook was constructing URLs like `/api/v0/users/...` but the backend routes are at `/v0/users/...`. Removes the prefix so the profile page loads correctly instead of returning 404.

Closes #596