### PR TITLE
Refactor config loading and fix analytics response handling

### DIFF
--- a/backend/handlers/metrics/getgloballeaderboard_test.go
+++ b/backend/handlers/metrics/getgloballeaderboard_test.go
@@ -66,7 +66,7 @@ func TestGetGlobalLeaderboardHandler_Success(t *testing.T) {
 		},
 	}
 
-	svc := analytics.NewService(repo, nil)
+	svc := analytics.NewService(repo, analytics.Config{})
 	handler := GetGlobalLeaderboardHandler(svc)
 
 	req := httptest.NewRequest(http.MethodGet, "/v0/global/leaderboard", nil)
@@ -118,7 +118,7 @@ type assertError string
 func (e assertError) Error() string { return string(e) }
 
 func TestGetGlobalLeaderboardHandler_Error(t *testing.T) {
-	svc := analytics.NewService(failingRepo{}, nil)
+	svc := analytics.NewService(failingRepo{}, analytics.Config{})
 	handler := GetGlobalLeaderboardHandler(svc)
 
 	req := httptest.NewRequest(http.MethodGet, "/v0/global/leaderboard", nil)

--- a/backend/handlers/metrics/getsystemmetrics_test.go
+++ b/backend/handlers/metrics/getsystemmetrics_test.go
@@ -13,7 +13,6 @@ import (
 	"socialpredict/internal/domain/boundary"
 	positionsmath "socialpredict/internal/domain/math/positions"
 	"socialpredict/models/modelstesting"
-	"socialpredict/setup"
 
 	"gorm.io/gorm"
 )
@@ -21,8 +20,11 @@ import (
 func newAnalyticsService(t *testing.T, db *gorm.DB) *analytics.Service {
 	t.Helper()
 	cfg := modelstesting.GenerateEconomicConfig()
-	loader := func() *setup.EconomicConfig { return cfg }
-	return analytics.NewService(analytics.NewGormRepository(db), loader)
+	return analytics.NewService(analytics.NewGormRepository(db), analytics.Config{
+		MaximumDebtAllowed: cfg.Economics.User.MaximumDebtAllowed,
+		CreateMarketCost:   cfg.Economics.MarketIncentives.CreateMarketCost,
+		InitialBetFee:      cfg.Economics.Betting.BetFees.InitialBetFee,
+	})
 }
 
 func TestGetSystemMetricsHandler_Success(t *testing.T) {
@@ -81,8 +83,11 @@ func (failingAnalyticsRepo) UserMarketPositions(context.Context, string) ([]posi
 
 func TestGetSystemMetricsHandler_Error(t *testing.T) {
 	cfg := modelstesting.GenerateEconomicConfig()
-	loader := func() *setup.EconomicConfig { return cfg }
-	svc := analytics.NewService(failingAnalyticsRepo{}, loader)
+	svc := analytics.NewService(failingAnalyticsRepo{}, analytics.Config{
+		MaximumDebtAllowed: cfg.Economics.User.MaximumDebtAllowed,
+		CreateMarketCost:   cfg.Economics.MarketIncentives.CreateMarketCost,
+		InitialBetFee:      cfg.Economics.Betting.BetFees.InitialBetFee,
+	})
 
 	handler := GetSystemMetricsHandler(svc)
 	req := httptest.NewRequest("GET", "/v0/system/metrics", nil)

--- a/backend/handlers/setup/setuphandler_test.go
+++ b/backend/handlers/setup/setuphandler_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestGetSetupHandler(t *testing.T) {
+	ownedConfig := configsvc.FromSetup(loadSetupConfig(t))
+
 	tests := []struct {
 		Name             string
 		ConfigService    configsvc.Service
@@ -22,7 +24,7 @@ func TestGetSetupHandler(t *testing.T) {
 	}{
 		{
 			Name:           "successful load",
-			ConfigService:  configsvc.NewStaticService(loadSetupConfig(t)),
+			ConfigService:  economicsOnlyConfigService{economics: ownedConfig.Economics},
 			ExpectedStatus: http.StatusOK,
 			ExpectedResponse: `{
 				"marketcreation":{"initialMarketProbability":0.5,"initialMarketSubsidization":10,"initialMarketYes":0,"initialMarketNo":0,"minimumFutureHours":1},
@@ -107,6 +109,27 @@ func TestGetFrontendSetupHandler(t *testing.T) {
 	}
 }
 
+func TestGetFrontendSetupHandlerUsesChartSigFigsAccessor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/setup/frontend", nil)
+	rr := httptest.NewRecorder()
+
+	handler := http.HandlerFunc(GetFrontendSetupHandler(chartSigFigsOnlyConfigService{chartSigFigs: 9}))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	var response map[string]map[string]int
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if got := response["charts"]["sigFigs"]; got != 9 {
+		t.Fatalf("expected sig figs 9, got %d", got)
+	}
+}
+
 func loadSetupConfig(t *testing.T) *setup.EconomicConfig {
 	t.Helper()
 
@@ -124,4 +147,44 @@ func jsonEqual(a, b map[string]interface{}) bool {
 func jsonString(v interface{}) string {
 	bytes, _ := json.Marshal(v)
 	return string(bytes)
+}
+
+type economicsOnlyConfigService struct {
+	economics configsvc.Economics
+}
+
+func (s economicsOnlyConfigService) Current() *configsvc.AppConfig {
+	panic("Current should not be called")
+}
+
+func (s economicsOnlyConfigService) Economics() configsvc.Economics {
+	return s.economics
+}
+
+func (economicsOnlyConfigService) Frontend() configsvc.Frontend {
+	panic("Frontend should not be called")
+}
+
+func (economicsOnlyConfigService) ChartSigFigs() int {
+	panic("ChartSigFigs should not be called")
+}
+
+type chartSigFigsOnlyConfigService struct {
+	chartSigFigs int
+}
+
+func (chartSigFigsOnlyConfigService) Current() *configsvc.AppConfig {
+	panic("Current should not be called")
+}
+
+func (chartSigFigsOnlyConfigService) Economics() configsvc.Economics {
+	panic("Economics should not be called")
+}
+
+func (chartSigFigsOnlyConfigService) Frontend() configsvc.Frontend {
+	panic("Frontend should not be called")
+}
+
+func (s chartSigFigsOnlyConfigService) ChartSigFigs() int {
+	return s.chartSigFigs
 }

--- a/backend/handlers/stats/statshandler.go
+++ b/backend/handlers/stats/statshandler.go
@@ -52,13 +52,15 @@ func StatsHandler(db *gorm.DB, configService configsvc.Service) http.HandlerFunc
 			return
 		}
 
-		financialStats, err := calculateFinancialStats(db, configService)
+		economics := configService.Economics()
+
+		financialStats, err := calculateFinancialStats(db, economics)
 		if err != nil {
 			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
 			return
 		}
 
-		setupConfig := loadSetupConfiguration(configService.Current())
+		setupConfig := loadSetupConfiguration(economics)
 
 		response := StatsResponse{
 			FinancialStats:     financialStats,
@@ -71,10 +73,10 @@ func StatsHandler(db *gorm.DB, configService configsvc.Service) http.HandlerFunc
 	}
 }
 
-func calculateFinancialStats(db *gorm.DB, configService configsvc.Service) (FinancialStats, error) {
+func calculateFinancialStats(db *gorm.DB, economics configsvc.Economics) (FinancialStats, error) {
 	var result FinancialStats
 
-	totalMoney, err := calculateTotalMoney(db, configService.Current())
+	totalMoney, err := calculateTotalMoney(db, economics.User)
 	if err != nil {
 		return result, err
 	}
@@ -90,32 +92,32 @@ func calculateFinancialStats(db *gorm.DB, configService configsvc.Service) (Fina
 	return result, nil
 }
 
-func calculateTotalMoney(db *gorm.DB, economicConfig *configsvc.AppConfig) (int64, error) {
+func calculateTotalMoney(db *gorm.DB, userConfig configsvc.User) (int64, error) {
 	var userCount int64
 	if err := db.Model(&models.User{}).Where("user_type = ?", "REGULAR").Count(&userCount).Error; err != nil {
 		return 0, err
 	}
 
-	totalMoney := economicConfig.Economics.User.InitialAccountBalance * userCount
+	totalMoney := userConfig.InitialAccountBalance * userCount
 	return totalMoney, nil
 }
 
-func loadSetupConfiguration(economicConfig *configsvc.AppConfig) SetupConfiguration {
+func loadSetupConfiguration(economics configsvc.Economics) SetupConfiguration {
 	var result SetupConfiguration
 
-	result.InitialMarketProbability = economicConfig.Economics.MarketCreation.InitialMarketProbability
-	result.InitialMarketSubsidization = economicConfig.Economics.MarketCreation.InitialMarketSubsidization
-	result.InitialMarketYes = economicConfig.Economics.MarketCreation.InitialMarketYes
-	result.InitialMarketNo = economicConfig.Economics.MarketCreation.InitialMarketNo
-	result.CreateMarketCost = economicConfig.Economics.MarketIncentives.CreateMarketCost
-	result.TraderBonus = economicConfig.Economics.MarketIncentives.TraderBonus
-	result.InitialAccountBalance = economicConfig.Economics.User.InitialAccountBalance
-	result.MaximumDebtAllowed = economicConfig.Economics.User.MaximumDebtAllowed
-	result.MinimumBet = economicConfig.Economics.Betting.MinimumBet
-	result.MaxDustPerSale = economicConfig.Economics.Betting.MaxDustPerSale
-	result.InitialBetFee = economicConfig.Economics.Betting.BetFees.InitialBetFee
-	result.BuySharesFee = economicConfig.Economics.Betting.BetFees.BuySharesFee
-	result.SellSharesFee = economicConfig.Economics.Betting.BetFees.SellSharesFee
+	result.InitialMarketProbability = economics.MarketCreation.InitialMarketProbability
+	result.InitialMarketSubsidization = economics.MarketCreation.InitialMarketSubsidization
+	result.InitialMarketYes = economics.MarketCreation.InitialMarketYes
+	result.InitialMarketNo = economics.MarketCreation.InitialMarketNo
+	result.CreateMarketCost = economics.MarketIncentives.CreateMarketCost
+	result.TraderBonus = economics.MarketIncentives.TraderBonus
+	result.InitialAccountBalance = economics.User.InitialAccountBalance
+	result.MaximumDebtAllowed = economics.User.MaximumDebtAllowed
+	result.MinimumBet = economics.Betting.MinimumBet
+	result.MaxDustPerSale = economics.Betting.MaxDustPerSale
+	result.InitialBetFee = economics.Betting.BetFees.InitialBetFee
+	result.BuySharesFee = economics.Betting.BetFees.BuySharesFee
+	result.SellSharesFee = economics.Betting.BetFees.SellSharesFee
 
 	return result
 }

--- a/backend/handlers/stats/statshandler_test.go
+++ b/backend/handlers/stats/statshandler_test.go
@@ -35,7 +35,9 @@ func TestStatsHandlerReturnsServiceBackedConfiguration(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v0/stats", nil)
 	rr := httptest.NewRecorder()
 
-	StatsHandler(db, configsvc.NewStaticService(config)).ServeHTTP(rr, req)
+	StatsHandler(db, economicsOnlyConfigService{
+		economics: configsvc.FromSetup(config).Economics,
+	}).ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d with body %s", rr.Code, rr.Body.String())
@@ -104,4 +106,24 @@ func TestStatsHandlerSanitizesDatabaseErrors(t *testing.T) {
 	if response.Reason != string(handlers.ReasonInternalError) {
 		t.Fatalf("expected reason %q, got %q", handlers.ReasonInternalError, response.Reason)
 	}
+}
+
+type economicsOnlyConfigService struct {
+	economics configsvc.Economics
+}
+
+func (s economicsOnlyConfigService) Current() *configsvc.AppConfig {
+	panic("Current should not be called")
+}
+
+func (s economicsOnlyConfigService) Economics() configsvc.Economics {
+	return s.economics
+}
+
+func (economicsOnlyConfigService) Frontend() configsvc.Frontend {
+	panic("Frontend should not be called")
+}
+
+func (economicsOnlyConfigService) ChartSigFigs() int {
+	panic("ChartSigFigs should not be called")
 }

--- a/backend/internal/app/container.go
+++ b/backend/internal/app/container.go
@@ -86,7 +86,6 @@ func (c *Container) InitializeRepositories() {
 func (c *Container) InitializeServices() {
 	// Users service depends on users repository and configuration
 	securityService := security.NewSecurityService()
-	configLoader := func() *configsvc.AppConfig { return c.config }
 
 	wpamSeeds := wpam.Seeds{
 		InitialProbability:     c.config.Economics.MarketCreation.InitialMarketProbability,
@@ -101,9 +100,20 @@ func (c *Container) InitializeServices() {
 	)
 
 	positionCalcAdapter := analytics.NewMarketPositionCalculator(positionCalculator)
+	analyticsConfig := analytics.Config{
+		MaximumDebtAllowed: c.config.Economics.User.MaximumDebtAllowed,
+		CreateMarketCost:   c.config.Economics.MarketIncentives.CreateMarketCost,
+		InitialBetFee:      c.config.Economics.Betting.BetFees.InitialBetFee,
+	}
+	betsConfig := dbets.Config{
+		InitialBetFee:      c.config.Economics.Betting.BetFees.InitialBetFee,
+		BuySharesFee:       c.config.Economics.Betting.BetFees.BuySharesFee,
+		MaxDustPerSale:     c.config.Economics.Betting.MaxDustPerSale,
+		MaximumDebtAllowed: c.config.Economics.User.MaximumDebtAllowed,
+	}
 
 	c.analyticsRepo = *analytics.NewGormRepository(c.db, analytics.WithRepositoryPositionCalculator(positionCalcAdapter))
-	c.analyticsService = analytics.NewService(&c.analyticsRepo, configLoader, analytics.WithPositionCalculator(positionCalcAdapter))
+	c.analyticsService = analytics.NewService(&c.analyticsRepo, analyticsConfig, analytics.WithPositionCalculator(positionCalcAdapter))
 	c.usersService = dusers.NewService(&c.usersRepo, c.analyticsService, securityService.Sanitizer)
 	c.authService = authsvc.NewAuthService(c.usersService)
 
@@ -122,7 +132,7 @@ func (c *Container) InitializeServices() {
 		dmarkets.WithProbabilityEngine(dmarkets.DefaultProbabilityEngine(wpamCalculator)),
 	)
 
-	c.betsService = dbets.NewService(&c.betsRepo, c.marketsService, c.usersService, c.config, c.clock)
+	c.betsService = dbets.NewService(&c.betsRepo, c.marketsService, c.usersService, betsConfig, c.clock)
 }
 
 // InitializeHandlers sets up all HTTP handlers with their service dependencies
@@ -184,7 +194,7 @@ func BuildApplicationWithConfigService(db *gorm.DB, configService configsvc.Serv
 	return container
 }
 
-// BuildApplication preserves older call sites that still provide a raw config snapshot.
-func BuildApplication(db *gorm.DB, config *configsvc.AppConfig) *Container {
+// BuildApplication preserves older call sites that still provide an owned or legacy raw config snapshot.
+func BuildApplication(db *gorm.DB, config any) *Container {
 	return BuildApplicationWithConfigService(db, configsvc.NewStaticService(config))
 }

--- a/backend/internal/app/runtime/config.go
+++ b/backend/internal/app/runtime/config.go
@@ -2,10 +2,17 @@ package runtime
 
 import (
 	configsvc "socialpredict/internal/service/config"
-	"socialpredict/setup"
 )
 
-// LoadConfigService initializes runtime configuration from the embedded setup source.
-func LoadConfigService() (configsvc.Service, error) {
-	return configsvc.NewService(configsvc.LoaderFunc(setup.LoadEconomicsConfig))
+// LoadConfigService initializes runtime configuration from an explicit source asset.
+func LoadConfigService(source configsvc.Source) (configsvc.Service, error) {
+	return loadConfigService(configsvc.NewYAMLLoader(source))
+}
+
+func loadConfigService(loader configsvc.Loader) (configsvc.Service, error) {
+	service, err := configsvc.NewService(loader)
+	if err != nil {
+		return nil, err
+	}
+	return service, nil
 }

--- a/backend/internal/app/runtime/config_test.go
+++ b/backend/internal/app/runtime/config_test.go
@@ -1,16 +1,89 @@
 package runtime
 
-import "testing"
+import (
+	"errors"
+	"testing"
 
-func TestLoadConfigService(t *testing.T) {
-	service, err := LoadConfigService()
+	configsvc "socialpredict/internal/service/config"
+	"socialpredict/setup"
+)
+
+func TestLoadConfigServiceUsesEmbeddedSource(t *testing.T) {
+	service, err := LoadConfigService(setup.EmbeddedSource{})
 	if err != nil {
 		t.Fatalf("LoadConfigService returned error: %v", err)
 	}
 	if service == nil {
 		t.Fatalf("expected config service, got nil")
 	}
-	if service.Current() == nil {
+	if got := service.Current().Economics.User.MaximumDebtAllowed; got != 500 {
+		t.Fatalf("maximum debt allowed = %d, want 500", got)
+	}
+	if got := service.ChartSigFigs(); got != 2 {
+		t.Fatalf("chart sig figs = %d, want 2", got)
+	}
+}
+
+func TestLoadConfigServiceUsesExplicitSource(t *testing.T) {
+	service, err := LoadConfigService(configsvc.SourceFunc(func() ([]byte, error) {
+		return []byte(`
+economics:
+  user:
+    initialAccountBalance: 400
+    maximumDebtAllowed: 120
+frontend:
+  charts:
+    sigFigs: 8
+`), nil
+	}))
+	if err != nil {
+		t.Fatalf("LoadConfigService returned error: %v", err)
+	}
+	if service == nil {
+		t.Fatalf("expected config service, got nil")
+	}
+	current := service.Current()
+	if current == nil {
 		t.Fatalf("expected current config, got nil")
+	}
+	if current.Economics.User.InitialAccountBalance != 400 {
+		t.Fatalf("initial account balance = %d, want 400", current.Economics.User.InitialAccountBalance)
+	}
+	if current.Frontend.Charts.SigFigs != 8 {
+		t.Fatalf("sig figs = %d, want 8", current.Frontend.Charts.SigFigs)
+	}
+}
+
+func TestLoadConfigServiceFreezesRuntimeSnapshot(t *testing.T) {
+	service, err := LoadConfigService(configsvc.SourceFunc(func() ([]byte, error) {
+		return []byte(`
+economics:
+  user:
+    maximumDebtAllowed: 120
+`), nil
+	}))
+	if err != nil {
+		t.Fatalf("LoadConfigService returned error: %v", err)
+	}
+
+	current := service.Current()
+	current.Economics.User.MaximumDebtAllowed = 999
+
+	if got := service.Current().Economics.User.MaximumDebtAllowed; got != 120 {
+		t.Fatalf("runtime snapshot mutated to %d, want frozen 120", got)
+	}
+}
+
+func TestLoadConfigServicePropagatesSourceError(t *testing.T) {
+	wantErr := errors.New("load failed")
+
+	service, err := LoadConfigService(configsvc.SourceFunc(func() ([]byte, error) {
+		return nil, wantErr
+	}))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("LoadConfigService error = %v, want %v", err, wantErr)
+	}
+	if service != nil {
+		t.Fatalf("expected nil service on source error")
 	}
 }

--- a/backend/internal/domain/analytics/financials.go
+++ b/backend/internal/domain/analytics/financials.go
@@ -15,20 +15,14 @@ func (s *Service) ComputeUserFinancials(ctx context.Context, req FinancialSnapsh
 		return nil, errors.New("repository not provided")
 	}
 
-	if s.econLoader == nil {
-		return nil, errors.New("economic configuration loader not provided")
-	}
-
 	positions, err := s.repo.UserMarketPositions(ctx, req.Username)
 	if err != nil {
 		return nil, err
 	}
 
-	econConfig := s.econLoader()
-
 	snapshot := &FinancialSnapshot{
 		AccountBalance:     req.AccountBalance,
-		MaximumDebtAllowed: econConfig.Economics.User.MaximumDebtAllowed,
+		MaximumDebtAllowed: s.config.MaximumDebtAllowed,
 	}
 
 	for _, pos := range positions {

--- a/backend/internal/domain/analytics/financialsnapshot_test.go
+++ b/backend/internal/domain/analytics/financialsnapshot_test.go
@@ -36,6 +36,14 @@ func withAnalyticsServiceOption(opt ServiceOption) analyticsServiceTestOption {
 	}
 }
 
+func analyticsConfigFromSetup(econ *setup.EconomicConfig) Config {
+	return Config{
+		MaximumDebtAllowed: econ.Economics.User.MaximumDebtAllowed,
+		CreateMarketCost:   econ.Economics.MarketIncentives.CreateMarketCost,
+		InitialBetFee:      econ.Economics.Betting.BetFees.InitialBetFee,
+	}
+}
+
 func newAnalyticsService(t *testing.T, db *gorm.DB, econ *setup.EconomicConfig, opts ...analyticsServiceTestOption) *Service {
 	t.Helper()
 
@@ -50,10 +58,9 @@ func newAnalyticsService(t *testing.T, db *gorm.DB, econ *setup.EconomicConfig, 
 	)
 	cfg.repoOptions = append(cfg.repoOptions, WithRepositoryPositionCalculator(NewMarketPositionCalculator(positionCalculator)))
 	repo := NewGormRepository(db, cfg.repoOptions...)
-	loader := func() *setup.EconomicConfig { return econ }
 	cfg.serviceOptions = append(cfg.serviceOptions, WithPositionCalculator(NewMarketPositionCalculator(positionCalculator)))
 
-	return NewService(repo, loader, cfg.serviceOptions...)
+	return NewService(repo, analyticsConfigFromSetup(econ), cfg.serviceOptions...)
 }
 
 func requireFinancialSnapshot(t *testing.T, svc financialSnapshotComputer, user models.User) *FinancialSnapshot {

--- a/backend/internal/domain/analytics/service.go
+++ b/backend/internal/domain/analytics/service.go
@@ -5,7 +5,6 @@ import (
 
 	"socialpredict/internal/domain/boundary"
 	positionsmath "socialpredict/internal/domain/math/positions"
-	"socialpredict/setup"
 )
 
 // DebtRepository exposes only the user data needed for debt calculations.
@@ -35,24 +34,33 @@ type FinancialsRepository interface {
 	UserMarketPositions(ctx context.Context, username string) ([]positionsmath.MarketPosition, error)
 }
 
+// Config captures the accounting-relevant policy slice required by analytics.
+// It is a process-start snapshot; historically exact fee or cost reporting across
+// future economics rollouts still requires durable per-market or per-bet policy capture.
+type Config struct {
+	MaximumDebtAllowed int64
+	CreateMarketCost   int64
+	InitialBetFee      int64
+}
+
 // DebtCalculator calculates debt-related metrics.
 type DebtCalculator interface {
-	Calculate(ctx context.Context, repo DebtRepository, econ *setup.EconomicConfig) (*DebtStats, error)
+	Calculate(ctx context.Context, repo DebtRepository, config Config) (*DebtStats, error)
 }
 
 // VolumeCalculator calculates market volume metrics.
 type VolumeCalculator interface {
-	Calculate(ctx context.Context, repo VolumeRepository, econ *setup.EconomicConfig) (*MarketVolumeStats, error)
+	Calculate(ctx context.Context, repo VolumeRepository, config Config) (*MarketVolumeStats, error)
 }
 
 // FeeCalculator calculates betting fee metrics.
 type FeeCalculator interface {
-	CalculateParticipationFees(ctx context.Context, repo FeeRepository, econ *setup.EconomicConfig) (int64, error)
+	CalculateParticipationFees(ctx context.Context, repo FeeRepository, config Config) (int64, error)
 }
 
 // MetricsAssembler combines calculator outputs into the final DTO.
 type MetricsAssembler interface {
-	Assemble(econ *setup.EconomicConfig, debt *DebtStats, volume *MarketVolumeStats, participationFees int64) *SystemMetrics
+	Assemble(debt *DebtStats, volume *MarketVolumeStats, participationFees int64) *SystemMetrics
 }
 
 // MarketPositionCalculator calculates market positions for analytics consumers.
@@ -75,7 +83,7 @@ type Service struct {
 	feeRepo          FeeRepository
 	leaderboardRepo  LeaderboardRepository
 	financialsRepo   FinancialsRepository
-	econLoader       setup.EconConfigLoader
+	config           Config
 	debtCalculator   DebtCalculator
 	volumeCalculator VolumeCalculator
 	feeCalculator    FeeCalculator
@@ -199,9 +207,9 @@ func WithPositionCalculator(c MarketPositionCalculator) ServiceOption {
 }
 
 // NewService constructs an analytics service with optional strategy overrides.
-func NewService(repo Repository, econLoader setup.EconConfigLoader, opts ...ServiceOption) *Service {
+func NewService(repo Repository, config Config, opts ...ServiceOption) *Service {
 	service := &Service{
-		econLoader: econLoader,
+		config: config,
 	}
 	service.setRepository(repo)
 

--- a/backend/internal/domain/analytics/system_metrics.go
+++ b/backend/internal/domain/analytics/system_metrics.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	marketmath "socialpredict/internal/domain/math/market"
-	"socialpredict/setup"
 )
 
 // DebtStats represents aggregated debt metrics.
@@ -27,35 +26,31 @@ func (s *Service) ComputeSystemMetrics(ctx context.Context) (*SystemMetrics, err
 	if s.repo == nil {
 		return nil, errors.New("repository not provided")
 	}
-	if s.econLoader == nil {
-		return nil, errors.New("economic configuration loader not provided")
-	}
 
 	s.ensureStrategyDefaults()
-	econ := s.econLoader()
 
-	debtStats, err := s.debtCalculator.Calculate(ctx, s.repo, econ)
+	debtStats, err := s.debtCalculator.Calculate(ctx, s.repo, s.config)
 	if err != nil {
 		return nil, err
 	}
 
-	volumeStats, err := s.volumeCalculator.Calculate(ctx, s.repo, econ)
+	volumeStats, err := s.volumeCalculator.Calculate(ctx, s.repo, s.config)
 	if err != nil {
 		return nil, err
 	}
 
-	participationFees, err := s.feeCalculator.CalculateParticipationFees(ctx, s.repo, econ)
+	participationFees, err := s.feeCalculator.CalculateParticipationFees(ctx, s.repo, s.config)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.metricsAssembler.Assemble(econ, debtStats, volumeStats, participationFees), nil
+	return s.metricsAssembler.Assemble(debtStats, volumeStats, participationFees), nil
 }
 
 // DefaultDebtCalculator implements the existing debt policy.
 type DefaultDebtCalculator struct{}
 
-func (c DefaultDebtCalculator) Calculate(ctx context.Context, repo DebtRepository, econ *setup.EconomicConfig) (*DebtStats, error) {
+func (c DefaultDebtCalculator) Calculate(ctx context.Context, repo DebtRepository, config Config) (*DebtStats, error) {
 	users, err := repo.ListUsers(ctx)
 	if err != nil {
 		return nil, err
@@ -74,24 +69,24 @@ func (c DefaultDebtCalculator) Calculate(ctx context.Context, repo DebtRepositor
 		if balance < 0 {
 			usedDebt = -balance
 		}
-		stats.UnusedDebt += econ.Economics.User.MaximumDebtAllowed - usedDebt
+		stats.UnusedDebt += config.MaximumDebtAllowed - usedDebt
 	}
 
-	stats.TotalDebtCapacity = econ.Economics.User.MaximumDebtAllowed * stats.UserCount
+	stats.TotalDebtCapacity = config.MaximumDebtAllowed * stats.UserCount
 	return stats, nil
 }
 
 // DefaultVolumeCalculator implements the existing volume policy.
 type DefaultVolumeCalculator struct{}
 
-func (c DefaultVolumeCalculator) Calculate(ctx context.Context, repo VolumeRepository, econ *setup.EconomicConfig) (*MarketVolumeStats, error) {
+func (c DefaultVolumeCalculator) Calculate(ctx context.Context, repo VolumeRepository, config Config) (*MarketVolumeStats, error) {
 	markets, err := repo.ListMarkets(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	stats := &MarketVolumeStats{
-		MarketCreationFees: int64(len(markets)) * econ.Economics.MarketIncentives.CreateMarketCost,
+		MarketCreationFees: int64(len(markets)) * config.CreateMarketCost,
 	}
 
 	for _, market := range markets {
@@ -112,7 +107,7 @@ func (c DefaultVolumeCalculator) Calculate(ctx context.Context, repo VolumeRepos
 // DefaultFeeCalculator implements the existing participation fee policy.
 type DefaultFeeCalculator struct{}
 
-func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, repo FeeRepository, econ *setup.EconomicConfig) (int64, error) {
+func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, repo FeeRepository, config Config) (int64, error) {
 	betsOrdered, err := repo.ListBetsOrdered(ctx)
 	if err != nil {
 		return 0, err
@@ -132,7 +127,7 @@ func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, re
 		}
 		key := userMarket{marketID: b.MarketID, username: b.Username}
 		if !seen[key] {
-			participationFees += econ.Economics.Betting.BetFees.InitialBetFee
+			participationFees += config.InitialBetFee
 			seen[key] = true
 		}
 	}
@@ -143,7 +138,7 @@ func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, re
 // DefaultMetricsAssembler builds the SystemMetrics DTO from calculator outputs.
 type DefaultMetricsAssembler struct{}
 
-func (a DefaultMetricsAssembler) Assemble(econ *setup.EconomicConfig, debt *DebtStats, volume *MarketVolumeStats, participationFees int64) *SystemMetrics {
+func (a DefaultMetricsAssembler) Assemble(debt *DebtStats, volume *MarketVolumeStats, participationFees int64) *SystemMetrics {
 	bonusesPaid := debt.RealizedProfits
 	totalUtilized := debt.UnusedDebt + volume.ActiveBetVolume + volume.MarketCreationFees + participationFees + bonusesPaid
 	surplus := debt.TotalDebtCapacity - totalUtilized

--- a/backend/internal/domain/analytics/systemmetrics_integration_test.go
+++ b/backend/internal/domain/analytics/systemmetrics_integration_test.go
@@ -16,9 +16,17 @@ import (
 	"gorm.io/gorm"
 )
 
-func newAnalyticsMetricsService(db *gorm.DB, loadEcon setup.EconConfigLoader, opts ...analytics.ServiceOption) *analytics.Service {
+func analyticsConfigFromSetup(cfg *setup.EconomicConfig) analytics.Config {
+	return analytics.Config{
+		MaximumDebtAllowed: cfg.Economics.User.MaximumDebtAllowed,
+		CreateMarketCost:   cfg.Economics.MarketIncentives.CreateMarketCost,
+		InitialBetFee:      cfg.Economics.Betting.BetFees.InitialBetFee,
+	}
+}
+
+func newAnalyticsMetricsService(db *gorm.DB, config analytics.Config, opts ...analytics.ServiceOption) *analytics.Service {
 	repo := analytics.NewGormRepository(db)
-	return analytics.NewService(repo, loadEcon, opts...)
+	return analytics.NewService(repo, config, opts...)
 }
 
 type analyticsSystemMetricsComputer interface {
@@ -67,7 +75,7 @@ func calculateParticipationFees(cfg *setup.EconomicConfig, bets []boundary.Bet) 
 
 func TestComputeSystemMetrics_BalancedAfterFinalLockedBet(t *testing.T) {
 	db := modelstesting.NewFakeDB(t)
-	econConfig, loadEcon := modelstesting.UseStandardTestEconomics(t)
+	econConfig, _ := modelstesting.UseStandardTestEconomics(t)
 
 	users := []models.User{
 		modelstesting.GenerateUser("alice", 0),
@@ -111,7 +119,7 @@ func TestComputeSystemMetrics_BalancedAfterFinalLockedBet(t *testing.T) {
 	placeBet("bob", 10, "NO")
 	placeBet("carol", 30, "YES")
 
-	svc := newAnalyticsMetricsService(db, loadEcon)
+	svc := newAnalyticsMetricsService(db, analyticsConfigFromSetup(econConfig))
 	metrics := requireAnalyticsSystemMetrics(t, svc)
 
 	maxDebt := econConfig.Economics.User.MaximumDebtAllowed
@@ -169,7 +177,7 @@ func TestComputeSystemMetrics_BalancedAfterFinalLockedBet(t *testing.T) {
 
 func TestResolveMarket_DistributesAllBetVolume(t *testing.T) {
 	db := modelstesting.NewFakeDB(t)
-	econConfig, loadEcon := modelstesting.UseStandardTestEconomics(t)
+	econConfig, _ := modelstesting.UseStandardTestEconomics(t)
 
 	users := []models.User{
 		modelstesting.GenerateUser("patrick", 0),
@@ -218,7 +226,7 @@ func TestResolveMarket_DistributesAllBetVolume(t *testing.T) {
 	}
 
 	repo := analytics.NewGormRepository(db)
-	metricsSvc := newAnalyticsMetricsService(db, loadEcon)
+	metricsSvc := newAnalyticsMetricsService(db, analyticsConfigFromSetup(econConfig))
 	metrics := requireAnalyticsSystemMetrics(t, metricsSvc)
 
 	if surplus := metrics.Verification.SurplusValue(); surplus != 0 {

--- a/backend/internal/domain/analytics/systemmetrics_test.go
+++ b/backend/internal/domain/analytics/systemmetrics_test.go
@@ -92,3 +92,54 @@ func TestComputeSystemMetrics_WithData(t *testing.T) {
 		t.Errorf("expected participation fees 10, got %d", val)
 	}
 }
+
+func TestComputeSystemMetrics_UsesInjectedSnapshot(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	econ := modelstesting.GenerateEconomicConfig()
+	econ.Economics.MarketIncentives.CreateMarketCost = 50
+	econ.Economics.Betting.BetFees.InitialBetFee = 5
+	econ.Economics.User.MaximumDebtAllowed = 500
+
+	users := []models.User{
+		modelstesting.GenerateUser("user1", 0),
+		modelstesting.GenerateUser("user2", 0),
+	}
+	for i := range users {
+		if err := db.Create(&users[i]).Error; err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+	}
+
+	market := modelstesting.GenerateMarket(1, users[0].Username)
+	market.IsResolved = false
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+
+	bet := modelstesting.GenerateBet(50, "YES", "user1", uint(market.ID), 0)
+	if err := db.Create(&bet).Error; err != nil {
+		t.Fatalf("create bet: %v", err)
+	}
+
+	snapshot := Config{
+		MaximumDebtAllowed: econ.Economics.User.MaximumDebtAllowed,
+		CreateMarketCost:   econ.Economics.MarketIncentives.CreateMarketCost,
+		InitialBetFee:      econ.Economics.Betting.BetFees.InitialBetFee,
+	}
+	svc := NewService(NewGormRepository(db), snapshot)
+
+	econ.Economics.User.MaximumDebtAllowed = 999
+	econ.Economics.MarketIncentives.CreateMarketCost = 999
+	econ.Economics.Betting.BetFees.InitialBetFee = 999
+
+	metrics := requireSystemMetrics(t, svc)
+	if val := requireMetricInt64(t, metrics.MoneyCreated.UserDebtCapacity); val != 1000 {
+		t.Fatalf("expected frozen user debt capacity 1000, got %d", val)
+	}
+	if val := requireMetricInt64(t, metrics.MoneyUtilized.MarketCreationFees); val != 50 {
+		t.Fatalf("expected frozen market creation fees 50, got %d", val)
+	}
+	if val := requireMetricInt64(t, metrics.MoneyUtilized.ParticipationFees); val != 5 {
+		t.Fatalf("expected frozen participation fees 5, got %d", val)
+	}
+}

--- a/backend/internal/domain/bets/bet_support.go
+++ b/backend/internal/domain/bets/bet_support.go
@@ -8,7 +8,6 @@ import (
 	"socialpredict/internal/domain/boundary"
 	dmarkets "socialpredict/internal/domain/markets"
 	dusers "socialpredict/internal/domain/users"
-	"socialpredict/setup"
 )
 
 func normalizeOutcome(outcome string) string {
@@ -84,16 +83,16 @@ func ensureMarketOpen(market *dmarkets.Market, now time.Time) error {
 }
 
 type feeCalculator struct {
-	econ *setup.EconomicConfig
+	config Config
 }
 
 func (f feeCalculator) Calculate(hasBet bool, amount int64) betFees {
 	fees := betFees{
 		initialFee:     0,
-		transactionFee: int64(f.econ.Economics.Betting.BetFees.BuySharesFee),
+		transactionFee: f.config.BuySharesFee,
 	}
 	if !hasBet {
-		fees.initialFee = int64(f.econ.Economics.Betting.BetFees.InitialBetFee)
+		fees.initialFee = f.config.InitialBetFee
 	}
 	fees.totalCost = amount + fees.initialFee + fees.transactionFee
 	return fees

--- a/backend/internal/domain/bets/service.go
+++ b/backend/internal/domain/bets/service.go
@@ -7,7 +7,6 @@ import (
 	"socialpredict/internal/domain/boundary"
 	dmarkets "socialpredict/internal/domain/markets"
 	dusers "socialpredict/internal/domain/users"
-	"socialpredict/setup"
 )
 
 // Repository exposes the persistence layer needed by the bets domain service.
@@ -99,6 +98,14 @@ type Clock interface {
 	Now() time.Time
 }
 
+// Config holds the narrow economics policy slice required by the bets domain.
+type Config struct {
+	InitialBetFee      int64
+	BuySharesFee       int64
+	MaxDustPerSale     int64
+	MaximumDebtAllowed int64
+}
+
 type serviceClock struct{}
 
 func (serviceClock) Now() time.Time { return time.Now() }
@@ -114,7 +121,7 @@ type Service struct {
 	repo    Repository
 	markets MarketService
 	users   UserService
-	econ    *setup.EconomicConfig
+	config  Config
 	clock   Clock
 
 	placeValidator PlaceValidator
@@ -151,22 +158,20 @@ func defaultMarketGateStrategy(markets MarketReader, clock Clock) MarketGate {
 	return marketGate{markets: markets, clock: clock}
 }
 
-func defaultFeeCalculatorStrategy(econ *setup.EconomicConfig) FeeCalculator {
-	return feeCalculator{econ: econOrDefault(econ)}
+func defaultFeeCalculatorStrategy(config Config) FeeCalculator {
+	return feeCalculator{config: config}
 }
 
-func defaultBalanceGuardStrategy(econ *setup.EconomicConfig) BalanceGuard {
-	econ = econOrDefault(econ)
-	return balanceGuard{maxDebtAllowed: int64(econ.Economics.User.MaximumDebtAllowed)}
+func defaultBalanceGuardStrategy(config Config) BalanceGuard {
+	return balanceGuard{maxDebtAllowed: config.MaximumDebtAllowed}
 }
 
 func defaultBetLedgerStrategy(repo BetWriter, users TransactionRecorder) BetLedger {
 	return betLedger{repo: repo, users: users}
 }
 
-func defaultSaleCalculatorStrategy(econ *setup.EconomicConfig) SaleCalculator {
-	econ = econOrDefault(econ)
-	return saleCalculator{maxDustPerSale: int64(econ.Economics.Betting.MaxDustPerSale)}
+func defaultSaleCalculatorStrategy(config Config) SaleCalculator {
+	return saleCalculator{maxDustPerSale: config.MaxDustPerSale}
 }
 
 func clockOrDefault(clock Clock) Clock {
@@ -174,13 +179,6 @@ func clockOrDefault(clock Clock) Clock {
 		return defaultClock()
 	}
 	return clock
-}
-
-func econOrDefault(econ *setup.EconomicConfig) *setup.EconomicConfig {
-	if econ == nil {
-		return &setup.EconomicConfig{}
-	}
-	return econ
 }
 
 func placeValidatorOrDefault(v PlaceValidator) PlaceValidator {
@@ -204,16 +202,16 @@ func marketGateOrDefault(g MarketGate, markets MarketReader, clock Clock) Market
 	return g
 }
 
-func feeCalculatorOrDefault(c FeeCalculator, econ *setup.EconomicConfig) FeeCalculator {
+func feeCalculatorOrDefault(c FeeCalculator, config Config) FeeCalculator {
 	if c == nil {
-		return defaultFeeCalculatorStrategy(econ)
+		return defaultFeeCalculatorStrategy(config)
 	}
 	return c
 }
 
-func balanceGuardOrDefault(g BalanceGuard, econ *setup.EconomicConfig) BalanceGuard {
+func balanceGuardOrDefault(g BalanceGuard, config Config) BalanceGuard {
 	if g == nil {
-		return defaultBalanceGuardStrategy(econ)
+		return defaultBalanceGuardStrategy(config)
 	}
 	return g
 }
@@ -225,9 +223,9 @@ func betLedgerOrDefault(l BetLedger, repo BetWriter, users TransactionRecorder) 
 	return l
 }
 
-func saleCalculatorOrDefault(c SaleCalculator, econ *setup.EconomicConfig) SaleCalculator {
+func saleCalculatorOrDefault(c SaleCalculator, config Config) SaleCalculator {
 	if c == nil {
-		return defaultSaleCalculatorStrategy(econ)
+		return defaultSaleCalculatorStrategy(config)
 	}
 	return c
 }
@@ -263,7 +261,7 @@ func WithMarketGate(g MarketGate) ServiceOption {
 func WithFeeCalculator(c FeeCalculator) ServiceOption {
 	return func(s *Service) {
 		if s != nil {
-			s.fees = feeCalculatorOrDefault(c, s.econ)
+			s.fees = feeCalculatorOrDefault(c, s.config)
 		}
 	}
 }
@@ -272,7 +270,7 @@ func WithFeeCalculator(c FeeCalculator) ServiceOption {
 func WithBalanceGuard(g BalanceGuard) ServiceOption {
 	return func(s *Service) {
 		if s != nil {
-			s.balances = balanceGuardOrDefault(g, s.econ)
+			s.balances = balanceGuardOrDefault(g, s.config)
 		}
 	}
 }
@@ -290,7 +288,7 @@ func WithBetLedger(l BetLedger) ServiceOption {
 func WithSaleCalculator(c SaleCalculator) ServiceOption {
 	return func(s *Service) {
 		if s != nil {
-			s.saleCalculator = saleCalculatorOrDefault(c, s.econ)
+			s.saleCalculator = saleCalculatorOrDefault(c, s.config)
 		}
 	}
 }
@@ -305,12 +303,12 @@ func WithClock(clock Clock) ServiceOption {
 }
 
 // NewService constructs a bets service.
-func NewService(repo Repository, markets MarketService, users UserService, econ *setup.EconomicConfig, clock Clock, opts ...ServiceOption) *Service {
+func NewService(repo Repository, markets MarketService, users UserService, config Config, clock Clock, opts ...ServiceOption) *Service {
 	s := &Service{
 		repo:    repo,
 		markets: markets,
 		users:   users,
-		econ:    econOrDefault(econ),
+		config:  config,
 		clock:   clockOrDefault(clock),
 	}
 
@@ -331,8 +329,8 @@ func (s *Service) ensureDefaults() {
 	s.placeValidator = placeValidatorOrDefault(s.placeValidator)
 	s.sellValidator = sellValidatorOrDefault(s.sellValidator)
 	s.marketGate = marketGateOrDefault(s.marketGate, s.markets, s.clock)
-	s.fees = feeCalculatorOrDefault(s.fees, s.econ)
-	s.balances = balanceGuardOrDefault(s.balances, s.econ)
+	s.fees = feeCalculatorOrDefault(s.fees, s.config)
+	s.balances = balanceGuardOrDefault(s.balances, s.config)
 	s.ledger = betLedgerOrDefault(s.ledger, s.repo, s.users)
-	s.saleCalculator = saleCalculatorOrDefault(s.saleCalculator, s.econ)
+	s.saleCalculator = saleCalculatorOrDefault(s.saleCalculator, s.config)
 }

--- a/backend/internal/domain/bets/service_helpers_test.go
+++ b/backend/internal/domain/bets/service_helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"socialpredict/internal/domain/boundary"
 	dmarkets "socialpredict/internal/domain/markets"
 	dusers "socialpredict/internal/domain/users"
-	"socialpredict/setup"
 )
 
 var errUnexpectedHelperCall = errors.New("unexpected call")
@@ -164,11 +163,10 @@ func TestMarketGate_Open(t *testing.T) {
 }
 
 func TestFeeCalculator_Calculate(t *testing.T) {
-	econ := &setup.EconomicConfig{}
-	econ.Economics.Betting.BetFees.InitialBetFee = 5
-	econ.Economics.Betting.BetFees.BuySharesFee = 2
-
-	calc := feeCalculator{econ: econ}
+	calc := feeCalculator{config: Config{
+		InitialBetFee: 5,
+		BuySharesFee:  2,
+	}}
 
 	tests := []struct {
 		name   string
@@ -199,7 +197,7 @@ func TestFeeCalculator_Calculate(t *testing.T) {
 		})
 	}
 
-	if zeroFees := (feeCalculator{econ: &setup.EconomicConfig{}}).Calculate(false, 0); zeroFees.totalCost != 0 {
+	if zeroFees := (feeCalculator{config: Config{}}).Calculate(false, 0); zeroFees.totalCost != 0 {
 		t.Fatalf("expected zero-value config to remain usable, got %+v", zeroFees)
 	}
 }

--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -11,7 +11,6 @@ import (
 	dmarkets "socialpredict/internal/domain/markets"
 	dusers "socialpredict/internal/domain/users"
 	"socialpredict/models/modelstesting"
-	"socialpredict/setup"
 )
 
 var errUnexpectedServiceCall = errors.New("unexpected call")
@@ -247,7 +246,7 @@ func (c fixedClock) Now() time.Time {
 }
 
 type serviceFixture struct {
-	econ    *setup.EconomicConfig
+	config  bets.Config
 	repo    *fakeRepo
 	markets *fakeMarkets
 	users   *fakeUsers
@@ -289,14 +288,23 @@ func withFixtureUser(user *dusers.User) serviceFixtureOption {
 
 func withFixtureMaxDust(maxDust int64) serviceFixtureOption {
 	return func(f *serviceFixture) {
-		f.econ.Economics.Betting.MaxDustPerSale = maxDust
+		f.config.MaxDustPerSale = maxDust
+	}
+}
+
+func defaultBetsConfig() bets.Config {
+	econ := modelstesting.GenerateEconomicConfig()
+	return bets.Config{
+		InitialBetFee:      econ.Economics.Betting.BetFees.InitialBetFee,
+		BuySharesFee:       econ.Economics.Betting.BetFees.BuySharesFee,
+		MaxDustPerSale:     econ.Economics.Betting.MaxDustPerSale,
+		MaximumDebtAllowed: econ.Economics.User.MaximumDebtAllowed,
 	}
 }
 
 func newServiceFixture(now time.Time, opts ...serviceFixtureOption) (*serviceFixture, *bets.Service) {
-	econ := modelstesting.GenerateEconomicConfig()
 	fixture := &serviceFixture{
-		econ:    econ,
+		config:  defaultBetsConfig(),
 		repo:    newFakeRepo(),
 		markets: newFakeMarkets(),
 		users:   newFakeUsers(),
@@ -305,7 +313,7 @@ func newServiceFixture(now time.Time, opts ...serviceFixtureOption) (*serviceFix
 	for _, opt := range opts {
 		opt(fixture)
 	}
-	svc := bets.NewService(fixture.repo, fixture.markets, fixture.users, fixture.econ, fixture.clock)
+	svc := bets.NewService(fixture.repo, fixture.markets, fixture.users, fixture.config, fixture.clock)
 	return fixture, svc
 }
 
@@ -343,12 +351,12 @@ func TestServicePlace_Succeeds(t *testing.T) {
 	if len(fixture.users.calls) != 1 {
 		t.Fatalf("expected one ApplyTransaction call, got %d", len(fixture.users.calls))
 	}
-	totalCost := int64(100 + fixture.econ.Economics.Betting.BetFees.InitialBetFee + fixture.econ.Economics.Betting.BetFees.BuySharesFee)
+	totalCost := int64(100 + fixture.config.InitialBetFee + fixture.config.BuySharesFee)
 	if fixture.users.calls[0].amount != totalCost {
 		t.Fatalf("unexpected transaction amount: %d", fixture.users.calls[0].amount)
 	}
 
-	fallbackService := bets.NewService(fixture.repo, fixture.markets, fixture.users, nil, nil, bets.WithClock(nil))
+	fallbackService := bets.NewService(fixture.repo, fixture.markets, fixture.users, bets.Config{}, nil, bets.WithClock(nil))
 	if fallbackService == nil {
 		t.Fatalf("expected fallback service")
 	}

--- a/backend/internal/service/config/loader.go
+++ b/backend/internal/service/config/loader.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	ErrNilSource  = errors.New("config source is nil")
+	ErrNilDecoder = errors.New("config decoder is nil")
+)
+
+// Source returns raw configuration bytes from the current source asset.
+type Source interface {
+	Bytes() ([]byte, error)
+}
+
+type SourceFunc func() ([]byte, error)
+
+func (f SourceFunc) Bytes() ([]byte, error) {
+	return f()
+}
+
+// StaticSource wraps immutable source bytes for loader construction.
+type StaticSource []byte
+
+func (s StaticSource) Bytes() ([]byte, error) {
+	return bytes.Clone(s), nil
+}
+
+// Decoder transforms source bytes into the owned application-policy snapshot.
+type Decoder interface {
+	Decode(data []byte) (*AppConfig, error)
+}
+
+type DecoderFunc func(data []byte) (*AppConfig, error)
+
+func (f DecoderFunc) Decode(data []byte) (*AppConfig, error) {
+	return f(data)
+}
+
+// AssetLoader composes a source asset and decoder into the runtime loader seam.
+type AssetLoader struct {
+	source  Source
+	decoder Decoder
+}
+
+// NewAssetLoader creates an explicit loader from a source asset and decoder.
+func NewAssetLoader(source Source, decoder Decoder) Loader {
+	return AssetLoader{
+		source:  source,
+		decoder: decoder,
+	}
+}
+
+// NewYAMLLoader loads the owned application-policy config from YAML source bytes.
+func NewYAMLLoader(source Source) Loader {
+	return NewAssetLoader(source, DecoderFunc(decodeYAML))
+}
+
+func (l AssetLoader) Load() (*AppConfig, error) {
+	if l.source == nil {
+		return nil, ErrNilSource
+	}
+	if l.decoder == nil {
+		return nil, ErrNilDecoder
+	}
+
+	data, err := l.source.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	return l.decoder.Decode(data)
+}
+
+func decodeYAML(data []byte) (*AppConfig, error) {
+	cfg := &AppConfig{}
+	if len(data) == 0 {
+		return cfg, nil
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/backend/internal/service/config/loader_test.go
+++ b/backend/internal/service/config/loader_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAssetLoaderUsesSourceAndDecoder(t *testing.T) {
+	want := &AppConfig{
+		Economics: Economics{
+			User: User{MaximumDebtAllowed: 500},
+		},
+	}
+
+	loader := NewAssetLoader(
+		SourceFunc(func() ([]byte, error) {
+			return []byte("source-bytes"), nil
+		}),
+		DecoderFunc(func(data []byte) (*AppConfig, error) {
+			if got := string(data); got != "source-bytes" {
+				t.Fatalf("decoder received %q, want source-bytes", got)
+			}
+			return want, nil
+		}),
+	)
+
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg != want {
+		t.Fatalf("Load returned unexpected config pointer")
+	}
+}
+
+func TestAssetLoaderPropagatesSourceError(t *testing.T) {
+	wantErr := errors.New("source failed")
+
+	loader := NewAssetLoader(
+		SourceFunc(func() ([]byte, error) {
+			return nil, wantErr
+		}),
+		DecoderFunc(func([]byte) (*AppConfig, error) {
+			t.Fatal("decoder should not be called when source fails")
+			return nil, nil
+		}),
+	)
+
+	_, err := loader.Load()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Load error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestAssetLoaderPropagatesDecoderError(t *testing.T) {
+	wantErr := errors.New("decode failed")
+
+	loader := NewAssetLoader(
+		StaticSource("source-bytes"),
+		DecoderFunc(func(data []byte) (*AppConfig, error) {
+			if got := string(data); got != "source-bytes" {
+				t.Fatalf("decoder received %q, want source-bytes", got)
+			}
+			return nil, wantErr
+		}),
+	)
+
+	_, err := loader.Load()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Load error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestAssetLoaderRejectsNilSourceOrDecoder(t *testing.T) {
+	_, err := NewAssetLoader(nil, DecoderFunc(func([]byte) (*AppConfig, error) {
+		return &AppConfig{}, nil
+	})).Load()
+	if !errors.Is(err, ErrNilSource) {
+		t.Fatalf("Load error = %v, want %v", err, ErrNilSource)
+	}
+
+	_, err = NewAssetLoader(StaticSource("source-bytes"), nil).Load()
+	if !errors.Is(err, ErrNilDecoder) {
+		t.Fatalf("Load error = %v, want %v", err, ErrNilDecoder)
+	}
+}

--- a/backend/internal/service/config/service.go
+++ b/backend/internal/service/config/service.go
@@ -2,16 +2,6 @@ package config
 
 import "socialpredict/setup"
 
-const (
-	minChartSigFigs     = 2
-	maxChartSigFigs     = 9
-	defaultChartSigFigs = 4
-)
-
-type AppConfig = setup.EconomicConfig
-type Economics = setup.Economics
-type Frontend = setup.Frontend
-
 // Service exposes typed access to application configuration slices.
 type Service interface {
 	Current() *AppConfig
@@ -37,7 +27,7 @@ type RuntimeService struct {
 
 func NewService(loader Loader) (*RuntimeService, error) {
 	if loader == nil {
-		return NewStaticService(nil), nil
+		return NewStaticService((*AppConfig)(nil)), nil
 	}
 
 	cfg, err := loader.Load()
@@ -48,19 +38,16 @@ func NewService(loader Loader) (*RuntimeService, error) {
 	return NewStaticService(cfg), nil
 }
 
-func NewStaticService(cfg *AppConfig) *RuntimeService {
-	if cfg == nil {
-		cfg = &AppConfig{}
-	}
-
-	return &RuntimeService{current: cfg}
+// NewStaticService preserves a static config snapshot, including legacy setup snapshots.
+func NewStaticService(cfg any) *RuntimeService {
+	return &RuntimeService{current: normalizeConfig(cfg)}
 }
 
 func (s *RuntimeService) Current() *AppConfig {
 	if s == nil || s.current == nil {
 		return &AppConfig{}
 	}
-	return s.current
+	return s.current.Clone()
 }
 
 func (s *RuntimeService) Economics() Economics {
@@ -75,17 +62,19 @@ func (s *RuntimeService) ChartSigFigs() int {
 	return ClampChartSigFigs(s.Frontend())
 }
 
-func ClampChartSigFigs(frontend Frontend) int {
-	sigFigs := frontend.Charts.SigFigs
-	if sigFigs == 0 {
-		sigFigs = defaultChartSigFigs
+func normalizeConfig(cfg any) *AppConfig {
+	switch typed := cfg.(type) {
+	case nil:
+		return &AppConfig{}
+	case *AppConfig:
+		return typed.Clone()
+	case AppConfig:
+		return typed.Clone()
+	case *setup.EconomicConfig:
+		return FromSetup(typed)
+	case setup.EconomicConfig:
+		return FromSetup(&typed)
+	default:
+		return &AppConfig{}
 	}
-
-	if sigFigs < minChartSigFigs {
-		return minChartSigFigs
-	}
-	if sigFigs > maxChartSigFigs {
-		return maxChartSigFigs
-	}
-	return sigFigs
 }

--- a/backend/internal/service/config/service_test.go
+++ b/backend/internal/service/config/service_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestNewServiceLoadsCurrentConfig(t *testing.T) {
-	cfg := &setup.EconomicConfig{
-		Economics: setup.Economics{
-			User: setup.User{MaximumDebtAllowed: 500},
+	cfg := &AppConfig{
+		Economics: Economics{
+			User: User{MaximumDebtAllowed: 500},
 		},
-		Frontend: setup.Frontend{
-			Charts: setup.FrontendCharts{SigFigs: 7},
+		Frontend: Frontend{
+			Charts: FrontendCharts{SigFigs: 7},
 		},
 	}
 
@@ -24,14 +24,48 @@ func TestNewServiceLoadsCurrentConfig(t *testing.T) {
 		t.Fatalf("NewService returned error: %v", err)
 	}
 
-	if got := svc.Current(); got != cfg {
-		t.Fatalf("Current returned unexpected config pointer")
+	current := svc.Current()
+	if current == cfg {
+		t.Fatalf("Current should return a defensive copy")
+	}
+	if got := current.Economics.User.MaximumDebtAllowed; got != 500 {
+		t.Fatalf("Current returned wrong maximum debt: got %d", got)
 	}
 	if got := svc.Economics().User.MaximumDebtAllowed; got != 500 {
 		t.Fatalf("Economics returned wrong maximum debt: got %d", got)
 	}
 	if got := svc.ChartSigFigs(); got != 7 {
 		t.Fatalf("ChartSigFigs returned %d, want 7", got)
+	}
+}
+
+func TestNewStaticServiceClonesInputSnapshot(t *testing.T) {
+	cfg := &AppConfig{
+		Economics: Economics{
+			User: User{MaximumDebtAllowed: 500},
+		},
+	}
+
+	svc := NewStaticService(cfg)
+	cfg.Economics.User.MaximumDebtAllowed = 999
+
+	if got := svc.Economics().User.MaximumDebtAllowed; got != 500 {
+		t.Fatalf("Economics returned %d after source mutation, want frozen 500", got)
+	}
+}
+
+func TestCurrentReturnsDefensiveCopy(t *testing.T) {
+	svc := NewStaticService(&AppConfig{
+		Economics: Economics{
+			User: User{MaximumDebtAllowed: 500},
+		},
+	})
+
+	current := svc.Current()
+	current.Economics.User.MaximumDebtAllowed = 999
+
+	if got := svc.Economics().User.MaximumDebtAllowed; got != 500 {
+		t.Fatalf("Economics returned %d after Current mutation, want frozen 500", got)
 	}
 }
 
@@ -59,14 +93,14 @@ func TestClampChartSigFigs(t *testing.T) {
 		{
 			name: "clamps low",
 			frontend: Frontend{
-				Charts: setup.FrontendCharts{SigFigs: 1},
+				Charts: FrontendCharts{SigFigs: 1},
 			},
 			want: 2,
 		},
 		{
 			name: "clamps high",
 			frontend: Frontend{
-				Charts: setup.FrontendCharts{SigFigs: 99},
+				Charts: FrontendCharts{SigFigs: 99},
 			},
 			want: 9,
 		},
@@ -78,5 +112,72 @@ func TestClampChartSigFigs(t *testing.T) {
 				t.Fatalf("ClampChartSigFigs() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSetupCompatibilityTranslation(t *testing.T) {
+	legacy := &setup.EconomicConfig{
+		Economics: setup.Economics{
+			MarketCreation: setup.MarketCreation{
+				InitialMarketProbability:   0.42,
+				InitialMarketSubsidization: 250,
+				InitialMarketYes:           5,
+				InitialMarketNo:            7,
+				MinimumFutureHours:         24,
+			},
+			MarketIncentives: setup.MarketIncentives{
+				CreateMarketCost: 15,
+				TraderBonus:      20,
+			},
+			User: setup.User{
+				InitialAccountBalance: 900,
+				MaximumDebtAllowed:    300,
+			},
+			Betting: setup.Betting{
+				MinimumBet:     10,
+				MaxDustPerSale: 3,
+				BetFees: setup.BetFees{
+					InitialBetFee: 1,
+					BuySharesFee:  2,
+					SellSharesFee: 4,
+				},
+			},
+		},
+		Frontend: setup.Frontend{
+			Charts: setup.FrontendCharts{SigFigs: 6},
+		},
+	}
+
+	owned := FromSetup(legacy)
+	if owned.Economics.User.InitialAccountBalance != 900 {
+		t.Fatalf("owned initial account balance = %d, want 900", owned.Economics.User.InitialAccountBalance)
+	}
+	if owned.Frontend.Charts.SigFigs != 6 {
+		t.Fatalf("owned sig figs = %d, want 6", owned.Frontend.Charts.SigFigs)
+	}
+
+	roundTrip := owned.ToSetup()
+	if roundTrip.Economics.MarketIncentives.TraderBonus != 20 {
+		t.Fatalf("round trip trader bonus = %d, want 20", roundTrip.Economics.MarketIncentives.TraderBonus)
+	}
+	if roundTrip.Economics.Betting.BetFees.SellSharesFee != 4 {
+		t.Fatalf("round trip sell shares fee = %d, want 4", roundTrip.Economics.Betting.BetFees.SellSharesFee)
+	}
+}
+
+func TestNewStaticServiceClonesLegacySnapshot(t *testing.T) {
+	legacy := &setup.EconomicConfig{
+		Economics: setup.Economics{
+			User: setup.User{
+				MaximumDebtAllowed: 300,
+			},
+		},
+	}
+
+	svc := NewStaticService(legacy)
+	legacy.Economics.User.MaximumDebtAllowed = 700
+
+	if got := svc.Economics().User.MaximumDebtAllowed; got != 300 {
+		t.Fatalf("Economics returned %d after legacy mutation, want frozen 300", got)
 	}
 }

--- a/backend/internal/service/config/types.go
+++ b/backend/internal/service/config/types.go
@@ -1,0 +1,167 @@
+package config
+
+import "socialpredict/setup"
+
+const (
+	minChartSigFigs     = 2
+	maxChartSigFigs     = 9
+	defaultChartSigFigs = 4
+)
+
+type MarketCreation struct {
+	InitialMarketProbability   float64 `yaml:"initialMarketProbability" json:"initialMarketProbability"`
+	InitialMarketSubsidization int64   `yaml:"initialMarketSubsidization" json:"initialMarketSubsidization"`
+	InitialMarketYes           int64   `yaml:"initialMarketYes" json:"initialMarketYes"`
+	InitialMarketNo            int64   `yaml:"initialMarketNo" json:"initialMarketNo"`
+	MinimumFutureHours         float64 `yaml:"minimumFutureHours" json:"minimumFutureHours"`
+}
+
+type MarketIncentives struct {
+	CreateMarketCost int64 `yaml:"createMarketCost" json:"createMarketCost"`
+	TraderBonus      int64 `yaml:"traderBonus" json:"traderBonus"`
+}
+
+type User struct {
+	InitialAccountBalance int64 `yaml:"initialAccountBalance" json:"initialAccountBalance"`
+	MaximumDebtAllowed    int64 `yaml:"maximumDebtAllowed" json:"maximumDebtAllowed"`
+}
+
+type BetFees struct {
+	InitialBetFee int64 `yaml:"initialBetFee" json:"initialBetFee"`
+	BuySharesFee  int64 `yaml:"buySharesFee" json:"buySharesFee"`
+	SellSharesFee int64 `yaml:"sellSharesFee" json:"sellSharesFee"`
+}
+
+type Betting struct {
+	MinimumBet     int64   `yaml:"minimumBet" json:"minimumBet"`
+	MaxDustPerSale int64   `yaml:"maxDustPerSale" json:"maxDustPerSale"`
+	BetFees        BetFees `yaml:"betFees" json:"betFees"`
+}
+
+type Economics struct {
+	MarketCreation   MarketCreation   `yaml:"marketcreation" json:"marketcreation"`
+	MarketIncentives MarketIncentives `yaml:"marketincentives" json:"marketincentives"`
+	User             User             `yaml:"user" json:"user"`
+	Betting          Betting          `yaml:"betting" json:"betting"`
+}
+
+type FrontendCharts struct {
+	SigFigs int `yaml:"sigFigs" json:"sigFigs"`
+}
+
+type Frontend struct {
+	Charts FrontendCharts `yaml:"charts" json:"charts"`
+}
+
+type AppConfig struct {
+	Economics Economics `yaml:"economics" json:"economics"`
+	Frontend  Frontend  `yaml:"frontend" json:"frontend"`
+}
+
+// Clone returns a detached copy of the application policy snapshot.
+func (cfg *AppConfig) Clone() *AppConfig {
+	if cfg == nil {
+		return &AppConfig{}
+	}
+
+	cfgCopy := *cfg
+	return &cfgCopy
+}
+
+// FromSetup converts the legacy setup snapshot into the owned config service types.
+func FromSetup(cfg *setup.EconomicConfig) *AppConfig {
+	if cfg == nil {
+		return &AppConfig{}
+	}
+
+	return &AppConfig{
+		Economics: Economics{
+			MarketCreation: MarketCreation{
+				InitialMarketProbability:   cfg.Economics.MarketCreation.InitialMarketProbability,
+				InitialMarketSubsidization: cfg.Economics.MarketCreation.InitialMarketSubsidization,
+				InitialMarketYes:           cfg.Economics.MarketCreation.InitialMarketYes,
+				InitialMarketNo:            cfg.Economics.MarketCreation.InitialMarketNo,
+				MinimumFutureHours:         cfg.Economics.MarketCreation.MinimumFutureHours,
+			},
+			MarketIncentives: MarketIncentives{
+				CreateMarketCost: cfg.Economics.MarketIncentives.CreateMarketCost,
+				TraderBonus:      cfg.Economics.MarketIncentives.TraderBonus,
+			},
+			User: User{
+				InitialAccountBalance: cfg.Economics.User.InitialAccountBalance,
+				MaximumDebtAllowed:    cfg.Economics.User.MaximumDebtAllowed,
+			},
+			Betting: Betting{
+				MinimumBet:     cfg.Economics.Betting.MinimumBet,
+				MaxDustPerSale: cfg.Economics.Betting.MaxDustPerSale,
+				BetFees: BetFees{
+					InitialBetFee: cfg.Economics.Betting.BetFees.InitialBetFee,
+					BuySharesFee:  cfg.Economics.Betting.BetFees.BuySharesFee,
+					SellSharesFee: cfg.Economics.Betting.BetFees.SellSharesFee,
+				},
+			},
+		},
+		Frontend: Frontend{
+			Charts: FrontendCharts{
+				SigFigs: cfg.Frontend.Charts.SigFigs,
+			},
+		},
+	}
+}
+
+// ToSetup converts the owned snapshot into the legacy setup shape for unmigrated consumers.
+func (cfg *AppConfig) ToSetup() *setup.EconomicConfig {
+	if cfg == nil {
+		return &setup.EconomicConfig{}
+	}
+
+	return &setup.EconomicConfig{
+		Economics: setup.Economics{
+			MarketCreation: setup.MarketCreation{
+				InitialMarketProbability:   cfg.Economics.MarketCreation.InitialMarketProbability,
+				InitialMarketSubsidization: cfg.Economics.MarketCreation.InitialMarketSubsidization,
+				InitialMarketYes:           cfg.Economics.MarketCreation.InitialMarketYes,
+				InitialMarketNo:            cfg.Economics.MarketCreation.InitialMarketNo,
+				MinimumFutureHours:         cfg.Economics.MarketCreation.MinimumFutureHours,
+			},
+			MarketIncentives: setup.MarketIncentives{
+				CreateMarketCost: cfg.Economics.MarketIncentives.CreateMarketCost,
+				TraderBonus:      cfg.Economics.MarketIncentives.TraderBonus,
+			},
+			User: setup.User{
+				InitialAccountBalance: cfg.Economics.User.InitialAccountBalance,
+				MaximumDebtAllowed:    cfg.Economics.User.MaximumDebtAllowed,
+			},
+			Betting: setup.Betting{
+				MinimumBet:     cfg.Economics.Betting.MinimumBet,
+				MaxDustPerSale: cfg.Economics.Betting.MaxDustPerSale,
+				BetFees: setup.BetFees{
+					InitialBetFee: cfg.Economics.Betting.BetFees.InitialBetFee,
+					BuySharesFee:  cfg.Economics.Betting.BetFees.BuySharesFee,
+					SellSharesFee: cfg.Economics.Betting.BetFees.SellSharesFee,
+				},
+			},
+		},
+		Frontend: setup.Frontend{
+			Charts: setup.FrontendCharts{
+				SigFigs: cfg.Frontend.Charts.SigFigs,
+			},
+		},
+	}
+}
+
+// ClampChartSigFigs bounds the frontend chart precision to the supported range.
+func ClampChartSigFigs(frontend Frontend) int {
+	sigFigs := frontend.Charts.SigFigs
+	if sigFigs == 0 {
+		sigFigs = defaultChartSigFigs
+	}
+
+	if sigFigs < minChartSigFigs {
+		return minChartSigFigs
+	}
+	if sigFigs > maxChartSigFigs {
+		return maxChartSigFigs
+	}
+	return sigFigs
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -11,6 +11,7 @@ import (
 	_ "socialpredict/migration/migrations" // <-- side-effect import: registers migrations via init()
 	"socialpredict/seed"
 	"socialpredict/server"
+	"socialpredict/setup"
 )
 
 func main() {
@@ -41,7 +42,7 @@ func main() {
 		log.Printf("migration: warning: %v", err)
 	}
 
-	configService, err := appruntime.LoadConfigService()
+	configService, err := appruntime.LoadConfigService(setup.EmbeddedSource{})
 	if err != nil {
 		log.Fatalf("config init: %v", err)
 	}

--- a/backend/seed/seed.go
+++ b/backend/seed/seed.go
@@ -26,7 +26,7 @@ func SeedUsers(db *gorm.DB, configService configsvc.Service) error {
 	if configService == nil {
 		return fmt.Errorf("configuration service unavailable")
 	}
-	config := configService.Current()
+	userConfig := configService.Economics().User
 
 	adminPassword, err := getEnv("ADMIN_PASSWORD")
 	if err != nil {
@@ -45,8 +45,8 @@ func SeedUsers(db *gorm.DB, configService configsvc.Service) error {
 				Username:              "admin",
 				DisplayName:           "Administrator",
 				UserType:              "ADMIN",
-				InitialAccountBalance: config.Economics.User.InitialAccountBalance,
-				AccountBalance:        config.Economics.User.InitialAccountBalance,
+				InitialAccountBalance: userConfig.InitialAccountBalance,
+				AccountBalance:        userConfig.InitialAccountBalance,
 				PersonalEmoji:         "NONE",
 				Description:           "Administrator",
 			},

--- a/backend/seed/seed_test.go
+++ b/backend/seed/seed_test.go
@@ -17,7 +17,11 @@ func TestSeedUsersUsesConfigServiceInitialBalance(t *testing.T) {
 	config := modelstesting.GenerateEconomicConfig()
 	config.Economics.User.InitialAccountBalance = 4321
 
-	SeedUsers(db, configsvc.NewStaticService(config))
+	if err := SeedUsers(db, economicsOnlyConfigService{
+		economics: configsvc.FromSetup(config).Economics,
+	}); err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
 
 	var admin models.User
 	if err := db.Where("username = ?", "admin").First(&admin).Error; err != nil {
@@ -210,4 +214,24 @@ func TestSeedHomepage_DoesNotDuplicateExisting(t *testing.T) {
 	if content.Title != "Existing" {
 		t.Errorf("Existing content was modified: %s", content.Title)
 	}
+}
+
+type economicsOnlyConfigService struct {
+	economics configsvc.Economics
+}
+
+func (s economicsOnlyConfigService) Current() *configsvc.AppConfig {
+	panic("Current should not be called")
+}
+
+func (s economicsOnlyConfigService) Economics() configsvc.Economics {
+	return s.economics
+}
+
+func (economicsOnlyConfigService) Frontend() configsvc.Frontend {
+	panic("Frontend should not be called")
+}
+
+func (economicsOnlyConfigService) ChartSigFigs() int {
+	panic("ChartSigFigs should not be called")
 }

--- a/backend/seed/seed_users_test.go
+++ b/backend/seed/seed_users_test.go
@@ -8,6 +8,26 @@ import (
 	"socialpredict/models/modelstesting"
 )
 
+type panicOnCurrentSeedConfigService struct {
+	economics configsvc.Economics
+}
+
+func (s panicOnCurrentSeedConfigService) Current() *configsvc.AppConfig {
+	panic("Current should not be called")
+}
+
+func (s panicOnCurrentSeedConfigService) Economics() configsvc.Economics {
+	return s.economics
+}
+
+func (s panicOnCurrentSeedConfigService) Frontend() configsvc.Frontend {
+	panic("Frontend should not be called")
+}
+
+func (s panicOnCurrentSeedConfigService) ChartSigFigs() int {
+	panic("ChartSigFigs should not be called")
+}
+
 func TestSeedUsersRequiresConfigService(t *testing.T) {
 	db := modelstesting.NewFakeDB(t)
 	t.Setenv("ADMIN_PASSWORD", "secret-password")
@@ -39,5 +59,29 @@ func TestSeedUsersCreatesAdminUsingInjectedConfig(t *testing.T) {
 	}
 	if admin.AccountBalance != 321 {
 		t.Fatalf("expected injected account balance 321, got %d", admin.AccountBalance)
+	}
+}
+
+func TestSeedUsersAvoidsWholeTreeConfigAccess(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	t.Setenv("ADMIN_PASSWORD", "secret-password")
+
+	cfg := modelstesting.GenerateEconomicConfig()
+	cfg.Economics.User.InitialAccountBalance = 654
+
+	if err := SeedUsers(db, panicOnCurrentSeedConfigService{economics: configsvc.FromSetup(cfg).Economics}); err != nil {
+		t.Fatalf("SeedUsers returned error: %v", err)
+	}
+
+	var admin models.User
+	if err := db.Where("username = ?", "admin").First(&admin).Error; err != nil {
+		t.Fatalf("load admin user: %v", err)
+	}
+
+	if admin.InitialAccountBalance != 654 {
+		t.Fatalf("expected injected initial balance 654, got %d", admin.InitialAccountBalance)
+	}
+	if admin.AccountBalance != 654 {
+		t.Fatalf("expected injected account balance 654, got %d", admin.AccountBalance)
 	}
 }

--- a/backend/server/server_test.go
+++ b/backend/server/server_test.go
@@ -182,7 +182,7 @@ func TestServerBlocksProtectedProfileRoutesWhenPasswordChangeRequired(t *testing
 	}
 }
 
-func buildTestHandlerWithConfig(t *testing.T, db *gorm.DB, econConfig *configsvc.AppConfig) http.Handler {
+func buildTestHandlerWithConfig(t *testing.T, db *gorm.DB, econConfig any) http.Handler {
 	t.Helper()
 
 	handler, err := buildHandler(testOpenAPISpec, testSwaggerUIFS(), db, configsvc.NewStaticService(econConfig))

--- a/backend/setup/setup.go
+++ b/backend/setup/setup.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	_ "embed"
+	"fmt"
 	"log"
 	"sync"
 
@@ -10,6 +11,18 @@ import (
 
 //go:embed setup.yaml
 var setupYaml []byte
+
+// Source exposes setup asset bytes for explicit configuration seams.
+type Source interface {
+	Bytes() ([]byte, error)
+}
+
+// EmbeddedSource serves the embedded setup asset without exposing package globals to callers.
+type EmbeddedSource struct{}
+
+func (EmbeddedSource) Bytes() ([]byte, error) {
+	return append([]byte(nil), setupYaml...), nil
+}
 
 type MarketCreation struct {
 	InitialMarketProbability   float64 `yaml:"initialMarketProbability" json:"initialMarketProbability"`
@@ -61,6 +74,16 @@ type EconomicConfig struct {
 	Frontend  Frontend  `yaml:"frontend" json:"frontend"`
 }
 
+// Clone returns a defensive copy of the legacy startup snapshot.
+func (cfg *EconomicConfig) Clone() *EconomicConfig {
+	if cfg == nil {
+		return &EconomicConfig{}
+	}
+
+	cfgCopy := *cfg
+	return &cfgCopy
+}
+
 var economicConfig *EconomicConfig
 
 const (
@@ -69,48 +92,65 @@ const (
 	defaultChartSigFigs = 4
 )
 
-// load once as a singleton pattern
-var once sync.Once
+var legacyLoadState struct {
+	once sync.Once
+	err  error
+}
 
+// ParseEconomicConfig decodes the setup asset into the legacy config shape.
+func ParseEconomicConfig(data []byte) (*EconomicConfig, error) {
+	cfg := &EconomicConfig{}
+	if len(data) == 0 {
+		return cfg, nil
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// LoadEconomicConfigFromSource loads the legacy config explicitly from the provided asset source.
+func LoadEconomicConfigFromSource(source Source) (*EconomicConfig, error) {
+	if source == nil {
+		return nil, fmt.Errorf("setup source is nil")
+	}
+
+	data, err := source.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseEconomicConfig(data)
+}
+
+// LoadEconomicsConfig validates the embedded config once and returns a defensive copy.
 func LoadEconomicsConfig() (*EconomicConfig, error) {
-	once.Do(func() {
-		economicConfig = &EconomicConfig{}
-		err := yaml.Unmarshal(setupYaml, economicConfig)
-		if err != nil {
-			log.Println("Error parsing YAML config:", err) // Log here or just pass the error up
-			return
-		}
+	legacyLoadState.once.Do(func() {
+		economicConfig, legacyLoadState.err = LoadEconomicConfigFromSource(EmbeddedSource{})
 	})
-	return economicConfig, nil
+	if legacyLoadState.err != nil {
+		return nil, legacyLoadState.err
+	}
+	return economicConfig.Clone(), nil
 }
 
 // EconConfigLoader allows functions to use this type as a parameter to load an EconomicConfig Dependency
 type EconConfigLoader func() *EconomicConfig
 
-// EconomicsConfig returns the entire config for the applications economics
+// EconomicsConfig returns a defensive copy of the startup-loaded economics snapshot.
 func EconomicsConfig() *EconomicConfig {
-	return economicConfig
-}
-
-func mustLoadEconomicsConfig() {
-	economicConfig = &EconomicConfig{}
-	err := yaml.Unmarshal(setupYaml, economicConfig)
+	cfg, err := LoadEconomicsConfig()
 	if err != nil {
 		log.Fatal("Error parsing YAML config:", err) // If the config cannot be loaded, the application cannot recover.
 	}
-}
-
-func init() {
-	mustLoadEconomicsConfig()
+	return cfg
 }
 
 // ChartSigFigs returns a clamped significant figures value for chart formatting.
 func ChartSigFigs() int {
-	if economicConfig == nil {
-		mustLoadEconomicsConfig()
-	}
+	cfg := EconomicsConfig()
 
-	sigFigs := economicConfig.Frontend.Charts.SigFigs
+	sigFigs := cfg.Frontend.Charts.SigFigs
 	if sigFigs == 0 {
 		sigFigs = defaultChartSigFigs
 	}

--- a/backend/setup/setup_test.go
+++ b/backend/setup/setup_test.go
@@ -1,8 +1,62 @@
 package setup
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
+
+type staticSource []byte
+
+func (s staticSource) Bytes() ([]byte, error) {
+	return append([]byte(nil), s...), nil
+}
+
+func resetLegacyLoadState() {
+	economicConfig = nil
+	legacyLoadState = struct {
+		once sync.Once
+		err  error
+	}{}
+}
+
+func TestEmbeddedSourceDoesNotInitializeLegacySingleton(t *testing.T) {
+	resetLegacyLoadState()
+
+	data, err := (EmbeddedSource{}).Bytes()
+	if err != nil {
+		t.Fatalf("unexpected embedded source error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected embedded setup source bytes")
+	}
+	if economicConfig != nil {
+		t.Fatalf("expected embedded source access to avoid legacy singleton initialization")
+	}
+}
+
+func TestLoadEconomicConfigFromSource(t *testing.T) {
+	cfg, err := LoadEconomicConfigFromSource(staticSource(`
+economics:
+  user:
+    maximumDebtAllowed: 123
+frontend:
+  charts:
+    sigFigs: 5
+`))
+	if err != nil {
+		t.Fatalf("unexpected error loading explicit source: %v", err)
+	}
+	if cfg.Economics.User.MaximumDebtAllowed != 123 {
+		t.Fatalf("maximum debt = %d, want 123", cfg.Economics.User.MaximumDebtAllowed)
+	}
+	if cfg.Frontend.Charts.SigFigs != 5 {
+		t.Fatalf("sig figs = %d, want 5", cfg.Frontend.Charts.SigFigs)
+	}
+}
 
 func TestLoadEconomicsConfigSingleton(t *testing.T) {
+	resetLegacyLoadState()
+
 	cfg1, err := LoadEconomicsConfig()
 	if err != nil {
 		t.Fatalf("unexpected error loading config: %v", err)
@@ -16,42 +70,49 @@ func TestLoadEconomicsConfigSingleton(t *testing.T) {
 		t.Fatalf("unexpected error on second load: %v", err)
 	}
 
-	if cfg1 != cfg2 {
-		t.Fatalf("expected LoadEconomicsConfig to return singleton instance")
+	if economicConfig == nil {
+		t.Fatalf("expected cached startup config to be initialized")
 	}
-
+	if cfg1 == cfg2 {
+		t.Fatalf("expected LoadEconomicsConfig to return defensive copies")
+	}
+	if cfg1 == economicConfig || cfg2 == economicConfig {
+		t.Fatalf("expected callers to receive detached copies of the cached startup snapshot")
+	}
 	if cfg1.Economics.User.MaximumDebtAllowed <= 0 {
 		t.Fatalf("expected maximum debt to be populated, got %d", cfg1.Economics.User.MaximumDebtAllowed)
 	}
+	cfg1.Economics.User.MaximumDebtAllowed = 999
 
-	if EconomicsConfig() != cfg1 {
-		t.Fatalf("EconomicsConfig should return the singleton instance")
+	cfg3, err := LoadEconomicsConfig()
+	if err != nil {
+		t.Fatalf("unexpected error on third load: %v", err)
+	}
+	if cfg3.Economics.User.MaximumDebtAllowed == 999 {
+		t.Fatalf("mutating a returned config copy must not alter the cached startup snapshot")
+	}
+
+	if EconomicsConfig() == economicConfig {
+		t.Fatalf("EconomicsConfig should return a defensive copy")
 	}
 }
 
-func TestChartSigFigsClamping(t *testing.T) {
+func TestChartSigFigsUsesStartupSnapshot(t *testing.T) {
+	resetLegacyLoadState()
+
 	cfg, err := LoadEconomicsConfig()
 	if err != nil {
 		t.Fatalf("unexpected error loading config: %v", err)
 	}
-
-	original := cfg.Frontend.Charts.SigFigs
-	t.Cleanup(func() {
-		cfg.Frontend.Charts.SigFigs = original
-	})
-
-	cfg.Frontend.Charts.SigFigs = 1
-	if got := ChartSigFigs(); got != minChartSigFigs {
-		t.Fatalf("expected minChartSigFigs (%d), got %d", minChartSigFigs, got)
-	}
-
 	cfg.Frontend.Charts.SigFigs = 99
-	if got := ChartSigFigs(); got != maxChartSigFigs {
-		t.Fatalf("expected maxChartSigFigs (%d), got %d", maxChartSigFigs, got)
+	if got := ChartSigFigs(); got != 2 {
+		t.Fatalf("expected embedded startup sig figs 2, got %d", got)
 	}
-
-	cfg.Frontend.Charts.SigFigs = 6
-	if got := ChartSigFigs(); got != 6 {
-		t.Fatalf("expected unclamped value 6, got %d", got)
+	reloaded, err := LoadEconomicsConfig()
+	if err != nil {
+		t.Fatalf("unexpected error reloading config: %v", err)
+	}
+	if reloaded.Frontend.Charts.SigFigs == 99 {
+		t.Fatalf("mutating a returned config copy must not affect subsequent reads")
 	}
 }

--- a/frontend/src/components/layouts/activity/bets/BetsActivity.jsx
+++ b/frontend/src/components/layouts/activity/bets/BetsActivity.jsx
@@ -1,6 +1,7 @@
 import { API_URL } from '../../../../config';
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom'; // Import Link
+import { unwrapApiResponse } from '../../../../utils/apiResponse';
 
 const BetsActivityLayout = ({ marketId, refreshTrigger }) => {
     const [bets, setBets] = useState([]);
@@ -10,7 +11,7 @@ const BetsActivityLayout = ({ marketId, refreshTrigger }) => {
             const response = await fetch(`${API_URL}/v0/markets/bets/${marketId}`, {
             });
             if (response.ok) {
-                const data = await response.json();
+                const data = unwrapApiResponse(await response.json());
                 setBets(data.sort((a, b) => new Date(b.placedAt) - new Date(a.placedAt)));
             } else {
                 console.error('Error fetching bets:', response.statusText);

--- a/frontend/src/components/layouts/activity/leaderboard/LeaderboardActivity.jsx
+++ b/frontend/src/components/layouts/activity/leaderboard/LeaderboardActivity.jsx
@@ -2,6 +2,7 @@ import { API_URL } from '../../../../config';
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { getMarketLabels } from '../../../../utils/labelMapping';
+import { unwrapApiResponse } from '../../../../utils/apiResponse';
 
 const LeaderboardActivity = ({ marketId, market }) => {
     const [leaderboard, setLeaderboard] = useState([]);
@@ -14,7 +15,7 @@ const LeaderboardActivity = ({ marketId, market }) => {
                 setLoading(true);
                 const response = await fetch(`${API_URL}/v0/markets/${marketId}/leaderboard`);
                 if (response.ok) {
-                    const data = await response.json();
+                    const data = unwrapApiResponse(await response.json());
                     const rows = Array.isArray(data?.leaderboard) ? data.leaderboard : [];
                     setLeaderboard(rows);
                 } else {

--- a/frontend/src/pages/stats/Stats.jsx
+++ b/frontend/src/pages/stats/Stats.jsx
@@ -4,20 +4,7 @@ import { API_URL } from '../../config';
 import SiteButton from '../../components/buttons/SiteButtons';
 import LoadingSpinner from '../../components/loaders/LoadingSpinner';
 import SiteTabs from '../../components/tabs/SiteTabs';
-
-const unwrapApiResponse = (payload) => {
-  if (payload && typeof payload === 'object' && 'ok' in payload) {
-    if (payload.ok === false) {
-      throw new Error(payload.reason || 'Request failed');
-    }
-
-    if (payload.ok === true && 'result' in payload) {
-      return payload.result;
-    }
-  }
-
-  return payload;
-};
+import { unwrapApiResponse } from '../../utils/apiResponse';
 
 // MetricCard Component
 const MetricCard = ({
@@ -129,7 +116,7 @@ const Stats = () => {
       }
 
       const data = await response.json();
-      setSystemMetrics(data);
+      setSystemMetrics(unwrapApiResponse(data));
     } catch (err) {
       setMetricsError(err.message);
     } finally {
@@ -153,7 +140,7 @@ const Stats = () => {
       }
 
       const data = await response.json();
-      setGlobalLeaderboard(data);
+      setGlobalLeaderboard(unwrapApiResponse(data));
     } catch (err) {
       setLeaderboardError(err.message);
     } finally {


### PR DESCRIPTION
## Planned vs Actual

### Planned wave purpose
WAVE01 was intended to refactor backend configuration ownership and usage by:
- moving application-policy ownership into `backend/internal/service/config`
- reducing `backend/setup` toward a source-asset and translation seam
- migrating touched consumers onto narrower immutable config views
- removing raw `setup` config leakage from domain-facing code
- making startup-time immutable economics snapshot semantics more explicit and better protected

### Actual delivered scope
This PR matches that backend wave purpose by:
- adding owned config types and an explicit loader seam in `backend/internal/service/config`
- narrowing the migrated runtime path away from `setup` globals and singleton-style access
- migrating setup, stats, seed, bets, analytics, and adjacent runtime/container paths onto narrower config usage
- expanding focused backend test coverage around config loading, setup, stats, analytics, bets, seed, and runtime initialization

### Scope added during validation
While validating the backend changes in the UI, I also fixed frontend response-handling bugs caused by pages that were still reading raw API envelopes instead of unwrapping `{ ok, result }`:
- Stats page system metrics and global leaderboard loading
- market Bets tab loading
- market Leaderboard tab loading

## User-facing fixes

- the Stats page no longer crashes when calculating system metrics before any bets or markets exist
- market detail pages now show Bets and Leaderboard data again after bets have been created

## Testing

- updated backend tests across config, setup, stats, analytics, bets, and seed flows
- manually verified the affected frontend pages in the browser while reproducing the reported issues
- `npm run build` was not runnable in this workspace because the local frontend environment is missing `vite` (`sh: vite: command not found`)
