### PR TITLE
Update GitHub actions for Node 24

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -23,10 +23,10 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: build
         name: Build Go version matrix JSON
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -58,9 +58,9 @@ jobs:
       matrix:
         go-version: [ '1.25.x' ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Get Dependencies
@@ -89,19 +89,19 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ !startsWith(github.head_ref, 'doc/') }}
       # Use go-version-file when mode == file, otherwise go-version
       - name: Setup Go (from go.mod)
         if: ${{ !startsWith(github.head_ref, 'doc/') && matrix.go.mode == 'file' }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.go.value }}
           check-latest: true
           cache: true
       - name: Setup Go ${{ matrix.go.value }}
         if: ${{ !startsWith(github.head_ref, 'doc/') && matrix.go.mode == 'version' }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go.value }}
           check-latest: true

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -53,7 +53,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Wait for downstream Ansible workflow
         uses: ./.github/actions/wait-for-ansible-workflow
@@ -72,7 +72,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify public liveness and readiness
         uses: ./.github/actions/verify-public-readiness

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -51,7 +51,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Wait for downstream Ansible workflow
         uses: ./.github/actions/wait-for-ansible-workflow
@@ -70,7 +70,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify public liveness and readiness
         uses: ./.github/actions/verify-public-readiness

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,21 +23,21 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Log in to the Github Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Frontend
         id: frontend-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-frontend
           tags: |
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build and push Frontend
         id: push-frontend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/frontend/Dockerfile
@@ -68,7 +68,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Backend
         id: backend-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend
           tags: |
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build and push Backend
         id: push-backend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/backend/Dockerfile


### PR DESCRIPTION
## Summary
- update remaining official GitHub actions to Node 24-compatible majors: checkout v5, github-script v9, setup-go v6
- update Docker workflow actions to Node 24-compatible majors: docker login v4, setup-qemu v4, setup-buildx v4, metadata v6, build-push v7
- keeps deploy verification and CI workflows from emitting Node.js 20 deprecation annotations

## Validation
- actionlint for all .github/workflows/*.yml
- YAML parse for all .github/workflows/*.yml
- verified current action.yml runtimes for the updated action majors report node24 where applicable