### PR TITLE
Fix production deploy runtime defaults

### DIFF
--- a/README/INFRA/README-INFRA-PRODUCTION.md
+++ b/README/INFRA/README-INFRA-PRODUCTION.md
@@ -82,6 +82,13 @@ The Ansible secrets let GitHub Actions connect to the VPS and invoke
 then consume the generated `.env` and config files on the host. By contrast,
 HostOps variables live only on an operator laptop and are for human access.
 
+The packaged production compose topology uses a local Docker Postgres service.
+For that topology, `./SocialPredict install -e production` writes
+`DB_REQUIRE_TLS=false` so the backend does not reject the in-container
+`sslmode=disable` connection. Operators who replace the local Docker database
+with an external production database should review `DB_REQUIRE_TLS` and
+`DB_SSLMODE` explicitly.
+
 The `ansible_playbooks` repository may also contain an `ADMIN_PASSWORD` secret,
 but the current production workflow does not pass it into the Ansible command.
 It is only relevant if the workflow or a manual Ansible run supplies an

--- a/scripts/docker-compose-prod.yaml
+++ b/scripts/docker-compose-prod.yaml
@@ -104,7 +104,7 @@ services:
 
   traefik:
     container_name: "${TRAEFIK_CONTAINER_NAME}"
-    image: traefik:v3.5
+    image: traefik:v3.6.1
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -289,6 +289,15 @@ build_production() {
   echo "Setting EMAIL to: $email_answer"
 
   # Update Database User Password:
+  # The packaged production compose topology uses local Docker Postgres.
+  # Keep TLS disabled for that in-container DB connection unless an operator
+  # replaces the DB topology and opts into TLS explicitly.
+  if grep -q '^DB_REQUIRE_TLS=' "${SCRIPT_DIR}/.env"; then
+    "${SED_INPLACE[@]}" "s|^DB_REQUIRE_TLS=.*|DB_REQUIRE_TLS=false|" "${SCRIPT_DIR}/.env"
+  else
+    printf "\nDB_REQUIRE_TLS=false\n" >> "${SCRIPT_DIR}/.env"
+  fi
+
   local db_pass
   db_pass=$(generate_password)
   "${SED_INPLACE[@]}" "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD='${db_pass}'|" "${SCRIPT_DIR}/.env"
@@ -333,6 +342,15 @@ build_production_args() {
   echo "Setting EMAIL to: $2"
 
   # Update Database User Password:
+  # The packaged production compose topology uses local Docker Postgres.
+  # Keep TLS disabled for that in-container DB connection unless an operator
+  # replaces the DB topology and opts into TLS explicitly.
+  if grep -q '^DB_REQUIRE_TLS=' "${SCRIPT_DIR}/.env"; then
+    "${SED_INPLACE[@]}" "s|^DB_REQUIRE_TLS=.*|DB_REQUIRE_TLS=false|" "${SCRIPT_DIR}/.env"
+  else
+    printf "\nDB_REQUIRE_TLS=false\n" >> "${SCRIPT_DIR}/.env"
+  fi
+
   local db_pass
   db_pass=$(generate_password)
   "${SED_INPLACE[@]}" "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD='${db_pass}'|" "${SCRIPT_DIR}/.env"


### PR DESCRIPTION
## Summary
- update production Traefik image to v3.6.1 for Docker Engine 29 compatibility
- write DB_REQUIRE_TLS=false during production install for the packaged local Docker Postgres topology
- document the local-production DB TLS override and when operators should review it

## Production Recovery Context
The v3.0.0 production deploy failed because startup-writer rejected sslmode=disable while DB_REQUIRE_TLS defaulted true. After setting DB_REQUIRE_TLS=false manually, the app containers became healthy. Public traffic still returned Traefik 404 because Docker Engine 29 rejected Traefik v3.5's Docker provider API negotiation; manually moving the host to traefik:v3.6.1 restored /health and /readyz.

## Validation
- bash -n scripts/install.sh SocialPredict scripts/docker-commands.sh
- git diff --check
- verified https://brierfoxforecast.com/health returns live
- verified https://brierfoxforecast.com/readyz returns ready