### PR TITLE
Filter deploy workflow badges by event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Deploy To Production](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-production.yml/badge.svg)](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-production.yml)
+[![Deploy To Production](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-production.yml/badge.svg?event=workflow_run)](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-production.yml)
 
-[![Deploy To Staging](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-staging.yml/badge.svg)](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-staging.yml)
+[![Deploy To Staging](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-staging.yml/badge.svg?event=pull_request)](https://github.com/openpredictionmarkets/socialpredict/actions/workflows/deploy-to-staging.yml)
 
 # SocialPredict
 


### PR DESCRIPTION
## Summary
- filter the production deploy badge to the workflow_run event
- filter the staging deploy badge to the pull_request event
- avoids stale/unfiltered badge state showing red when the relevant deployment event stream is green

## Validation
- confirmed staging filtered badge returns: Deploy To Staging - passing
- confirmed production filtered badge returns: Deploy To Production - passing
- git diff --check