### PR TITLE
[ 02 ] Document release-to-readiness deploy feedback

### DIFF
--- a/.github/actions/verify-public-readiness/action.yml
+++ b/.github/actions/verify-public-readiness/action.yml
@@ -25,19 +25,76 @@ runs:
       run: |
         set -euo pipefail
 
+        BASE_URL="${BASE_URL%/}"
+        started_at="${SECONDS}"
+        attempt=1
+        attempts_completed=0
+        health_body="not checked"
+        ready_body="not checked"
+
+        summary_body() {
+          local value="$1"
+
+          value="${value//$'\r'/ }"
+          value="${value//$'\n'/ }"
+          if (( ${#value} > 160 )); then
+            value="${value:0:160}..."
+          fi
+          value="${value//|/\\|}"
+
+          printf '%s' "${value}"
+        }
+
+        write_summary() {
+          local result="$1"
+          local details="$2"
+          local elapsed_seconds=$((SECONDS - started_at))
+          local health_summary=""
+          local ready_summary=""
+
+          if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+            return 0
+          fi
+
+          health_summary="$(summary_body "${health_body}")"
+          ready_summary="$(summary_body "${ready_body}")"
+
+          {
+            echo "## Public Readiness Verification"
+            echo
+            echo "- Result: ${result}"
+            echo "- Base URL: ${BASE_URL}"
+            echo "- Attempts completed: ${attempts_completed}"
+            echo "- Elapsed time: ${elapsed_seconds}s"
+            echo "- Timeout: ${TIMEOUT_SECONDS}s"
+            echo "- Interval: ${INTERVAL_SECONDS}s"
+            echo
+            echo "| Probe | URL | Expected body | Last observed body |"
+            echo "| --- | --- | --- | --- |"
+            echo "| Liveness | ${BASE_URL}/health | \`live\` | ${health_summary} |"
+            echo "| Readiness | ${BASE_URL}/readyz | \`ready\` | ${ready_summary} |"
+            echo
+            echo "${details}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+        }
+
         check_endpoint() {
           local path="$1"
           local expected_body="$2"
+          local body_var="$3"
           local url="${BASE_URL}${path}"
           local response=""
           local body=""
 
           if ! response="$(curl -fsS --max-time 15 "${url}")"; then
+            printf -v "${body_var}" '%s' "request failed"
             echo "${url} did not return a successful response."
             return 1
           fi
 
           body="$(printf '%s' "${response}" | tr -d '\r\n')"
+          printf -v "${body_var}" '%s' "${body}"
+
           if [[ "${body}" != "${expected_body}" ]]; then
             echo "${url} returned unexpected body. Expected '${expected_body}', got '${body:0:160}'."
             return 1
@@ -48,15 +105,28 @@ runs:
         }
 
         deadline=$((SECONDS + TIMEOUT_SECONDS))
-        attempt=1
 
         echo "Polling ${BASE_URL}/health and ${BASE_URL}/readyz for up to ${TIMEOUT_SECONDS} seconds."
 
         while (( SECONDS < deadline )); do
           echo "Public readiness attempt ${attempt}."
+          attempts_completed="${attempt}"
+          health_body="not checked"
+          ready_body="not checked"
+          health_ok=0
+          ready_ok=0
 
-          if check_endpoint /health live && check_endpoint /readyz ready; then
+          if check_endpoint /health live health_body; then
+            health_ok=1
+          fi
+
+          if check_endpoint /readyz ready ready_body; then
+            ready_ok=1
+          fi
+
+          if (( health_ok == 1 && ready_ok == 1 )); then
             echo "Public deployment is live and ready."
+            write_summary "passed" "Public deployment became live and ready from GitHub Actions."
             exit 0
           fi
 
@@ -65,4 +135,5 @@ runs:
         done
 
         echo "Timed out waiting for ${BASE_URL} to become live and ready."
+        write_summary "failed" "Timed out waiting for the public deployment to become live and ready from GitHub Actions."
         exit 1

--- a/README/INFRA/README-INFRA-PRODUCTION.md
+++ b/README/INFRA/README-INFRA-PRODUCTION.md
@@ -128,7 +128,10 @@ curl -sS https://brierfoxforecast.com/readyz
 The GitHub production deploy workflow now performs the `/health` and `/readyz`
 checks externally from GitHub Actions after the Ansible workflow completes. It
 polls every 30 seconds for up to 10 minutes and expects `/health` to return
-`live` and `/readyz` to return `ready`.
+`live` and `/readyz` to return `ready`. The verification job writes a GitHub
+Actions job summary with the checked URLs, expected and last observed bodies,
+attempt count, timeout, interval, and final result. `/ops/status` remains an
+operator status endpoint and is not currently used as a production deploy gate.
 
 ## Notes
 

--- a/README/INFRA/README-INFRA-STAGING.md
+++ b/README/INFRA/README-INFRA-STAGING.md
@@ -284,7 +284,10 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://kconfs.com/readyz
 The GitHub staging workflow now performs the `/health` and `/readyz` checks
 externally from GitHub Actions after the Ansible workflow completes. It polls
 every 30 seconds for up to 10 minutes and expects `/health` to return `live`
-and `/readyz` to return `ready`.
+and `/readyz` to return `ready`. The verification job writes a GitHub Actions
+job summary with the checked URLs, expected and last observed bodies, attempt
+count, timeout, interval, and final result. `/ops/status` remains an operator
+status endpoint and is not currently used as a staging deploy gate.
 
 A deploy is not zero-downtime today. Brief 404s or failed probes can occur
 while containers are stopped and restarted.

--- a/README/PRODUCTION-NOTES/BACKEND/08-deployment-infrastructure.md
+++ b/README/PRODUCTION-NOTES/BACKEND/08-deployment-infrastructure.md
@@ -33,6 +33,11 @@ This note was updated on Monday, April 27, 2026 to replace an older Kubernetes-h
 
 On Thursday, April 30, 2026, the first deployment-facing health problem was finished for the backend serving path: `/health` now reports liveness, `/readyz` checks readiness and database availability, and Docker black-box checks confirmed both endpoints on `http://localhost:8080`. On Saturday, May 02, 2026, the backend image and production compose topology were wired to that contract: the image-level Docker `HEALTHCHECK` consumes `/health` as a process liveness probe, while production compose overrides backend service healthchecks to consume `/readyz` before starting dependents. The nginx production template also publishes backend-owned infra probes, Swagger UI, and the OpenAPI document explicitly at `/health`, `/readyz`, `/swagger/`, and `/openapi.yaml`. As of upstream `main` at `051aac6b2fefa5634b8c98cc38caf52acf0043a9`, startup mutation mode is explicit: the `backend-startup-writer` compose service runs the same backend image with `STARTUP_WRITER=true` for migrations and startup-owned seeds, while the request-serving `backend` service sets `STARTUP_WRITER=false` and verifies applied migrations before serving. The backend now closes readiness, waits `BACKEND_READINESS_DRAIN_SECONDS`, and then lets HTTP shutdown drain in-flight requests for `BACKEND_SHUTDOWN_TIMEOUT_SECONDS`.
 
+On Monday, May 11, 2026, release-to-readiness feedback was split into its own
+note in [14-release-readiness-feedback.md](/workspace/socialpredict/README/PRODUCTION-NOTES/BACKEND/14-release-readiness-feedback.md). That note owns the
+GitHub Actions external verification policy and the decision that `/health` and
+`/readyz` are deploy gates while `/ops/status` remains operator status.
+
 | Topic | Prior to April 27, 2026 | After April 27, 2026 |
 | --- | --- | --- |
 | Core framing | Treated deployment infrastructure as a large new platform buildout | Treats deployment infrastructure as hardening the runtime and publish path the repo already uses |

--- a/README/PRODUCTION-NOTES/BACKEND/14-release-readiness-feedback.md
+++ b/README/PRODUCTION-NOTES/BACKEND/14-release-readiness-feedback.md
@@ -1,0 +1,116 @@
+---
+title: Release-To-Readiness Feedback
+document_type: production-notes
+domain: backend
+author: Patrick Delaney
+updated_at: 2026-05-11T21:45:00Z
+updated_at_display: "Monday, May 11, 2026 at 09:45 PM UTC"
+update_reason: "Document release-to-readiness feedback policy for GitHub deploy verification and backend probe semantics."
+status: active
+---
+
+# Release-To-Readiness Feedback
+
+## TL;DR
+
+SocialPredict deployment feedback is split across two ownership boundaries:
+
+- Ansible owns host-level deployment and reports whether the deployment job
+  completed.
+- The `socialpredict` GitHub Actions workflows own external public verification
+  and report whether the deployed domain became live and ready from outside the
+  host.
+
+For the current OpenPredictionMarkets deployment, the public gate is intentionally
+small: `GET /health` must return `live`, and `GET /readyz` must return `ready`.
+The richer `GET /ops/status` endpoint is operator status, not a deploy gate yet.
+
+## Current Release Contract
+
+OpenPredictionMarkets uses this release-to-environment mapping:
+
+| Event | Environment | Domain |
+| --- | --- | --- |
+| Pull request merged into `main` | Staging | `https://kconfs.com` |
+| GitHub release published | Model office / production | `https://brierfoxforecast.com` |
+
+The `openpredictionmarkets/socialpredict` repository dispatches deployment work
+to `openpredictionmarkets/ansible_playbooks`. The Ansible repository connects to
+the VPS, updates the checkout, runs `./SocialPredict install`, starts the app,
+and performs host-level deployment steps. After that downstream Ansible workflow
+finishes successfully, the `socialpredict` workflow polls the public domain from
+GitHub Actions.
+
+This gives reviewers one visible path in the application repository:
+
+1. image build or deployment trigger starts in `socialpredict`
+2. Ansible workflow is dispatched in `ansible_playbooks`
+3. `socialpredict` waits for the matching Ansible workflow result
+4. `socialpredict` performs external public readiness verification
+5. GitHub Actions shows a final success or failure in the application repo
+
+## Probe Semantics
+
+| Endpoint | Expected success body | What it proves | What it does not prove |
+| --- | --- | --- | --- |
+| `GET /health` | `live` | The public route reaches a serving backend HTTP process. | Database readiness, business correctness, latency, or request success rate. |
+| `GET /readyz` | `ready` | The public route reaches a backend instance whose readiness gate is open and whose primary database ping succeeds. | Background job health, third-party dependency health, or full user journey success. |
+| `GET /ops/status` | JSON status object | Operator-visible process status including liveness, readiness, request failure count, and DB pool stats. | A stable deploy gate, fleet-wide monitoring signal, or early startup progress before the backend is listening. |
+
+`/health` and `/readyz` are deliberately plain-text and exact-body probes so
+Docker, compose, GitHub Actions, and black-box checks can use them without
+parsing a larger operator payload.
+
+`/ops/status` is intentionally not part of the deployment gate in this wave. It
+is richer and process-local. It is useful for operator investigation after a
+deploy, but making it a release gate should be a separate design decision that
+defines which JSON fields are stable enough to enforce from CI.
+
+## GitHub Actions Feedback
+
+The shared `.github/actions/verify-public-readiness` action polls the configured
+public origin every 30 seconds for up to 10 minutes by default. It now writes a
+GitHub Actions job summary containing:
+
+- the verified base URL
+- the number of completed attempts
+- elapsed time, timeout, and interval
+- the checked `/health` and `/readyz` URLs
+- the expected and last observed probe bodies
+- the final pass or timeout result
+
+This summary is meant to answer the operator question: "Did the public site
+become live and ready after the deployment job finished?"
+
+## Design Review Triggers
+
+Review the active design plan before changing any of these release-facing
+contracts:
+
+- changing `/health` or `/readyz` status code or response-body semantics
+- adding or removing an endpoint from the GitHub deployment gate
+- changing whether `/ops/status` is operator-only or deploy-gating
+- changing staging or production workflow trigger conditions
+- changing the Ansible dispatch/wait boundary between `socialpredict` and
+  `ansible_playbooks`
+- changing startup writer, readiness gate, database TLS, or production compose
+  behavior that affects when `/readyz` should become true
+
+Timeout and polling interval changes are smaller operational changes, but they
+should still be reflected in the infra docs because they affect what deployers
+see in GitHub Actions.
+
+## Non-Goals
+
+This note does not introduce:
+
+- Kubernetes, blue-green deployment, or a new orchestration platform
+- Prometheus, Grafana, alert rules, or a monitoring stack
+- host-internal Ansible health checks as a replacement for external public
+  verification
+- a full browser/user journey smoke test
+- `/ops/status` JSON conformance as a required release gate
+
+Those may be valid later, but the current baseline is intentionally a narrow
+release-to-readiness feedback loop around the deployed public domain.
+

--- a/README/PRODUCTION-NOTES/BACKEND/plan.md
+++ b/README/PRODUCTION-NOTES/BACKEND/plan.md
@@ -3,9 +3,9 @@ title: Backend Production Notes Plan
 document_type: production-notes-index
 domain: backend
 author: Patrick Delaney
-updated_at: 2026-04-30T11:55:00Z
-updated_at_display: "Thursday, April 30, 2026 at 11:55 AM UTC"
-update_reason: "Record the April 30 runtime-boundary and security-hardening completion while keeping the remaining production-note order intact."
+updated_at: 2026-05-11T21:45:00Z
+updated_at_display: "Monday, May 11, 2026 at 09:45 PM UTC"
+update_reason: "Add release-to-readiness feedback as an active deployment verification note."
 status: active
 ---
 
@@ -36,6 +36,7 @@ The current production-note priority is:
 11. [11-runtime-performance-tuning.md](/workspace/socialpredict/README/PRODUCTION-NOTES/BACKEND/11-runtime-performance-tuning.md)
 12. [12-database-caching.md](/workspace/socialpredict/README/PRODUCTION-NOTES/BACKEND/12-database-caching.md)
 13. [13-background-jobs.md](/workspace/socialpredict/README/PRODUCTION-NOTES/BACKEND/13-background-jobs.md)
+14. [14-release-readiness-feedback.md](/workspace/socialpredict/README/PRODUCTION-NOTES/BACKEND/14-release-readiness-feedback.md)
 
 From `08` onward, the numbering now matches the reprioritized execution order instead of preserving the older sequence.
 
@@ -52,6 +53,8 @@ The live backend still has earlier operational concerns, though the first livene
 That means:
 
 - deployment runtime hardening should come before optimization
+- release-to-readiness feedback should stay visible in the application repo, not
+  only in the downstream Ansible repo
 - operational monitoring contract should come before dashboards or alert platforms
 - validation consolidation should come before caching or worker systems
 - caching and background jobs should remain later and more explicitly deferred
@@ -64,6 +67,8 @@ The active notes are the ones that should drive near-term design-plan and task-p
 
 - `01` through `11`, with the re-ranked order above
 - `08`, but only as a lower-priority evidence-driven optimization note
+- `14`, as the active note for GitHub Actions external deploy verification and
+  release-to-readiness feedback policy
 
 ### Deferred or draft notes
 

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -29,7 +29,7 @@ SocialPredict is currently in a functional development state but requires signif
 ### 🔧 Backend Production Readiness
 **Location**: [`BACKEND/plan.md`](./BACKEND/plan.md)
 
-The backend implementation covers 12 critical areas for production deployment:
+The backend implementation covers 14 critical areas for production deployment:
 
 1. **Configuration Management** - Environment-based config, secrets management
 2. **Logging & Observability** - Structured logging, metrics, tracing
@@ -38,11 +38,13 @@ The backend implementation covers 12 critical areas for production deployment:
 5. **Security Hardening** - Authentication, authorization, rate limiting
 6. **API Design** - RESTful APIs, validation, documentation
 7. **Testing Strategy** - Unit, integration, and load testing
-8. **Performance Optimization** - Caching, database tuning, profiling
-9. **Deployment Infrastructure** - CI/CD, containerization, orchestration
-10. **Monitoring & Alerting** - Health checks, metrics, incident response
-11. **Data Validation** - Input validation, sanitization, schema validation
-12. **Background Jobs** - Async processing, job queues, scheduling
+8. **Deployment Infrastructure** - CI/CD, containerization, orchestration
+9. **Monitoring & Alerting** - Health checks, metrics, incident response
+10. **Data Validation** - Input validation, sanitization, schema validation
+11. **Runtime Performance Tuning** - DB pool defaults and runtime measurement
+12. **Database Caching** - Deferred cache policy and cache-boundary decisions
+13. **Background Jobs** - Async processing, job queues, scheduling
+14. **Release-To-Readiness Feedback** - External deploy verification policy
 
 **Key Technologies**: Go 1.23.1, Gorilla Mux, GORM, PostgreSQL, JWT, Docker, Prometheus, Grafana
 


### PR DESCRIPTION
## Summary
- add a backend production note for release-to-readiness feedback and probe semantics
- write public readiness verification results to the GitHub Actions job summary
- document that `/health` and `/readyz` are deploy gates while `/ops/status` remains operator status
- update infra and production-notes navigation so the policy is discoverable

## Agent review
- Used dispatcher-style routing from `spec-socialpredict-tasks-auto`.
- Architecture review recommended keeping the gate narrow: Ansible completion plus public `/health == live` and `/readyz == ready`.
- Verifier review flagged summary hardening; the final action now trims trailing slashes, checks both probes each attempt, truncates summary bodies, and escapes table separators.

## Validation
- `ruby -ryaml -e 'puts YAML.load_file(".github/actions/verify-public-readiness/action.yml").fetch("runs").fetch("steps").first.fetch("run")' > .context/verify-public-readiness.sh`
- `bash -n .context/verify-public-readiness.sh`
- `git diff --check`

## Not run
- `actionlint` is not installed locally in this workspace.
