### PR TITLE
[ 04 ] Add sell-position transaction boundary

### DIFF
--- a/README/PRODUCTION-NOTES/BACKEND/04-database-layer.md
+++ b/README/PRODUCTION-NOTES/BACKEND/04-database-layer.md
@@ -304,7 +304,9 @@ It does not require a global DAL or generic transaction wrapper for every workfl
 
 ### WAVE04-DB-005 transaction inventory
 
-The first migrated accounting-sensitive workflow is place bet.
+The first migrated accounting-sensitive workflow was place bet. On Monday,
+May 11, 2026, sell-position settlement also moved onto an explicit repository
+unit-of-work seam.
 
 For place bet, the atomic unit of work is:
 
@@ -317,9 +319,21 @@ Those steps now commit or roll back together. The transaction starts in the bets
 
 Primary-DB concurrency protection for place bet is the betting user's row. The transaction-bound user adapter applies `FOR UPDATE` when running on Postgres before computing and updating the balance. SQLite-backed tests skip that dialect-specific lock clause but still verify rollback behavior.
 
+For sell position, the atomic unit of work is:
+
+- verify the market is still open through the transaction-scoped market reader
+- derive the seller's current position from the transaction-scoped market and bet
+  snapshot
+- credit the seller's account balance for the sale value
+- insert the negative sale bet row
+
+Those steps now commit or roll back together through the bets repository
+`SellBetTransaction` adapter. On Postgres, the transaction-scoped sell reader
+locks the market row before deriving the seller's position, and the user
+balance collaborator locks the seller's account row before applying the credit.
+
 Remaining accounting-sensitive transaction surface:
 
-- Sell position still uses the older compensation-style `CreditSale` path. It needs one transaction covering position/bet-history reads, balance credit, sale bet insert, and position-sensitive concurrency protection.
 - Market resolution still needs an explicit transaction boundary for resolution state, payout/accounting writes, and prevention of overlapping resolution or betting writes.
 - Market-resolution interaction with place bet is still a surface to harden because the current place-bet transaction protects the user balance row, not the market row or a resolution gate.
 

--- a/backend/internal/domain/bets/bet_sell.go
+++ b/backend/internal/domain/bets/bet_sell.go
@@ -18,34 +18,54 @@ func (s *Service) Sell(ctx context.Context, req SellRequest) (*SellResult, error
 		return nil, ErrInvalidOutcome
 	}
 
-	if _, err := s.marketGate.Open(ctx, int64(req.MarketID)); err != nil {
-		return nil, err
+	if s.sellUnit == nil {
+		return nil, ErrSellTransactionUnavailable
 	}
 
-	sharesOwned, position, err := s.loadUserShares(ctx, req, outcome)
+	return s.sellInTransaction(ctx, req, outcome)
+}
+
+func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcome string) (*SellResult, error) {
+	var result *SellResult
+	err := s.sellUnit.SellBetTransaction(ctx, func(txCtx context.Context, repo Repository, markets MarketService, users UserService) error {
+		if _, err := (marketGate{markets: markets, clock: s.clock}).Open(txCtx, int64(req.MarketID)); err != nil {
+			return err
+		}
+
+		sharesOwned, position, err := loadUserSharesFrom(txCtx, markets, req, outcome)
+		if err != nil {
+			return err
+		}
+
+		sale, err := s.saleCalculator.Calculate(position, sharesOwned, req.Amount)
+		if err != nil {
+			return err
+		}
+		if sale.SharesToSell == 0 {
+			return ErrInsufficientShares
+		}
+
+		now := s.clock.Now()
+		bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
+		if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, sale.SaleValue); err != nil {
+			return err
+		}
+
+		result = new(SellResult).Build(req, outcome, sale, now)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	sale, err := s.saleCalculator.Calculate(position, sharesOwned, req.Amount)
-	if err != nil {
-		return nil, err
-	}
-	if sale.SharesToSell == 0 {
-		return nil, ErrInsufficientShares
-	}
-
-	now := s.clock.Now()
-	bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
-	if err := s.ledger.CreditSale(ctx, bet, sale.SaleValue); err != nil {
-		return nil, err
-	}
-
-	return new(SellResult).Build(req, outcome, sale, now), nil
+	return result, nil
 }
 
 func (s *Service) loadUserShares(ctx context.Context, req SellRequest, outcome string) (int64, *dmarkets.UserPosition, error) {
-	position, err := s.markets.GetUserPositionInMarket(ctx, int64(req.MarketID), req.Username)
+	return loadUserSharesFrom(ctx, s.markets, req, outcome)
+}
+
+func loadUserSharesFrom(ctx context.Context, markets PositionReader, req SellRequest, outcome string) (int64, *dmarkets.UserPosition, error) {
+	position, err := markets.GetUserPositionInMarket(ctx, int64(req.MarketID), req.Username)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/backend/internal/domain/bets/bet_support.go
+++ b/backend/internal/domain/bets/bet_support.go
@@ -118,9 +118,5 @@ func (l betLedger) CreditSale(ctx context.Context, bet *boundary.Bet, saleValue 
 	if err := l.users.ApplyTransaction(ctx, bet.Username, saleValue, dusers.TransactionSale); err != nil {
 		return err
 	}
-	if err := l.repo.Create(ctx, bet); err != nil {
-		_ = l.users.ApplyTransaction(ctx, bet.Username, saleValue, dusers.TransactionBuy)
-		return err
-	}
-	return nil
+	return l.repo.Create(ctx, bet)
 }

--- a/backend/internal/domain/bets/errors.go
+++ b/backend/internal/domain/bets/errors.go
@@ -42,6 +42,8 @@ var (
 	ErrInsufficientBalance BetError = newDomainError("insufficient balance for requested bet")
 	// ErrPlaceTransactionUnavailable indicates the buy flow has no explicit transaction boundary.
 	ErrPlaceTransactionUnavailable BetError = newDomainError("place bet transaction boundary unavailable")
+	// ErrSellTransactionUnavailable indicates the sell flow has no explicit transaction boundary.
+	ErrSellTransactionUnavailable BetError = newDomainError("sell transaction boundary unavailable")
 	// ErrNoPosition indicates the user has no position to sell.
 	ErrNoPosition BetError = newDomainError("no position found for the given market and outcome")
 	// ErrInsufficientShares indicates the user cannot sell the requested credits.

--- a/backend/internal/domain/bets/service.go
+++ b/backend/internal/domain/bets/service.go
@@ -27,6 +27,14 @@ type PlaceUnitOfWork interface {
 	PlaceBetTransaction(ctx context.Context, fn PlaceTransactionFunc) error
 }
 
+// SellTransactionFunc runs sale settlement against transaction-bound collaborators.
+type SellTransactionFunc func(ctx context.Context, repo Repository, markets MarketService, users UserService) error
+
+// SellUnitOfWork scopes sale credit and sale-bet writes to one database transaction.
+type SellUnitOfWork interface {
+	SellBetTransaction(ctx context.Context, fn SellTransactionFunc) error
+}
+
 // Repository exposes the persistence layer needed by the bets domain service.
 type Repository interface {
 	BetWriter
@@ -140,6 +148,7 @@ type Service struct {
 	ledger         BetLedger
 	saleCalculator SaleCalculator
 	placeUnit      PlaceUnitOfWork
+	sellUnit       SellUnitOfWork
 }
 
 var (
@@ -248,6 +257,16 @@ func placeUnitOfWorkOrDefault(u PlaceUnitOfWork, repo Repository) PlaceUnitOfWor
 	return nil
 }
 
+func sellUnitOfWorkOrDefault(u SellUnitOfWork, repo Repository) SellUnitOfWork {
+	if u != nil {
+		return u
+	}
+	if repoUnit, ok := repo.(SellUnitOfWork); ok {
+		return repoUnit
+	}
+	return nil
+}
+
 // WithPlaceValidator overrides the place validator.
 func WithPlaceValidator(v PlaceValidator) ServiceOption {
 	return func(s *Service) {
@@ -320,6 +339,15 @@ func WithPlaceUnitOfWork(u PlaceUnitOfWork) ServiceOption {
 	}
 }
 
+// WithSellUnitOfWork overrides the transaction scope used by sell-settlement writes.
+func WithSellUnitOfWork(u SellUnitOfWork) ServiceOption {
+	return func(s *Service) {
+		if s != nil {
+			s.sellUnit = sellUnitOfWorkOrDefault(u, s.repo)
+		}
+	}
+}
+
 // WithClock overrides the service clock.
 func WithClock(clock Clock) ServiceOption {
 	return func(s *Service) {
@@ -361,4 +389,5 @@ func (s *Service) ensureDefaults() {
 	s.ledger = betLedgerOrDefault(s.ledger, s.repo, s.users)
 	s.saleCalculator = saleCalculatorOrDefault(s.saleCalculator, s.config)
 	s.placeUnit = placeUnitOfWorkOrDefault(s.placeUnit, s.repo)
+	s.sellUnit = sellUnitOfWorkOrDefault(s.sellUnit, s.repo)
 }

--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -15,9 +15,9 @@ import (
 
 // Bets service tests use fakes to keep accounting rules package-local and fast.
 // They prove ordering and collaborator boundaries, not database truth. WAVE07
-// added repository-level Postgres proof for place-bet transaction behavior;
-// sell-position concurrency still needs source-of-truth verification once its
-// repository transaction scope is finalized.
+// added repository-level Postgres proof for place-bet transaction behavior.
+// Sell-position settlement now has a repository transaction seam; broader
+// market-resolution accounting remains separate.
 
 var errUnexpectedServiceCall = errors.New("unexpected call")
 
@@ -34,6 +34,16 @@ type fakePlaceUnit struct {
 
 func (f fakePlaceUnit) PlaceBetTransaction(ctx context.Context, fn bets.PlaceTransactionFunc) error {
 	return fn(ctx, f.repo, f.users)
+}
+
+type fakeSellUnit struct {
+	repo    bets.Repository
+	markets bets.MarketService
+	users   bets.UserService
+}
+
+func (f fakeSellUnit) SellBetTransaction(ctx context.Context, fn bets.SellTransactionFunc) error {
+	return fn(ctx, f.repo, f.markets, f.users)
 }
 
 func newFakeRepo(opts ...func(*fakeRepo)) *fakeRepo {
@@ -329,6 +339,7 @@ func newServiceFixture(now time.Time, opts ...serviceFixtureOption) (*serviceFix
 		opt(fixture)
 	}
 	placeUnit := fakePlaceUnit{repo: fixture.repo, users: fixture.users}
+	sellUnit := fakeSellUnit{repo: fixture.repo, markets: fixture.markets, users: fixture.users}
 	svc := bets.NewService(
 		fixture.repo,
 		fixture.markets,
@@ -336,6 +347,7 @@ func newServiceFixture(now time.Time, opts ...serviceFixtureOption) (*serviceFix
 		fixture.config,
 		fixture.clock,
 		bets.WithPlaceUnitOfWork(placeUnit),
+		bets.WithSellUnitOfWork(sellUnit),
 	)
 	return fixture, svc
 }

--- a/backend/internal/repository/bets/place_transaction_postgres_test.go
+++ b/backend/internal/repository/bets/place_transaction_postgres_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	dbets "socialpredict/internal/domain/bets"
+	"socialpredict/internal/domain/boundary"
 	dusers "socialpredict/internal/domain/users"
 	"socialpredict/models"
 	"socialpredict/models/modelstesting"
@@ -112,6 +113,53 @@ func TestGormRepositoryPlaceBetTransactionPostgres(t *testing.T) {
 
 		assertUserBalance(t, db, "bettor", 50)
 		assertBetCount(t, db, "bettor", 103, 1)
+	})
+}
+
+func TestGormRepositorySellBetTransactionPostgres(t *testing.T) {
+	dsn, ok := postgresIntegrationDSN()
+	if !ok {
+		t.Skip("set SOCIALPREDICT_POSTGRES_TEST_DSN or POSTGRES_TEST_DSN to run real-Postgres sell transaction verification")
+	}
+
+	t.Run("rollsBackCreditWhenSaleBetCreateFails", func(t *testing.T) {
+		db := openPlaceBetPostgresDB(t, dsn)
+		seedSellRows(t, db, "creator", "seller", 1000, 301)
+
+		createErr := errors.New("forced postgres sale bet create failure")
+		if err := db.Callback().Create().Before("gorm:create").Register("fail_postgres_sale_bet_create", func(tx *gorm.DB) {
+			if _, ok := tx.Statement.Dest.(*models.Bet); ok {
+				tx.AddError(createErr)
+			}
+		}); err != nil {
+			t.Fatalf("register create callback: %v", err)
+		}
+
+		repo := NewGormRepository(db)
+		err := repo.SellBetTransaction(context.Background(), func(ctx context.Context, txRepo dbets.Repository, markets dbets.MarketService, users dbets.UserService) error {
+			if _, err := markets.GetMarket(ctx, 301); err != nil {
+				return err
+			}
+			if _, err := markets.GetUserPositionInMarket(ctx, 301, "seller"); err != nil {
+				return err
+			}
+			if err := users.ApplyTransaction(ctx, "seller", 25, dusers.TransactionSale); err != nil {
+				return err
+			}
+			return txRepo.Create(ctx, &boundary.Bet{
+				Username: "seller",
+				MarketID: 301,
+				Amount:   -2,
+				Outcome:  "YES",
+				PlacedAt: time.Date(2026, time.May, 11, 22, 30, 0, 0, time.UTC),
+			})
+		})
+		if !errors.Is(err, createErr) {
+			t.Fatalf("expected forced create error, got %v", err)
+		}
+
+		assertUserBalance(t, db, "seller", 1000)
+		assertBetCount(t, db, "seller", 301, 1)
 	})
 }
 

--- a/backend/internal/repository/bets/sell_transaction.go
+++ b/backend/internal/repository/bets/sell_transaction.go
@@ -1,0 +1,150 @@
+package bets
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	dbets "socialpredict/internal/domain/bets"
+	"socialpredict/internal/domain/boundary"
+	dmarkets "socialpredict/internal/domain/markets"
+	positionsmath "socialpredict/internal/domain/math/positions"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var _ dbets.SellUnitOfWork = (*GormRepository)(nil)
+
+// SellBetTransaction commits the sale credit and sale bet as one unit of work.
+func (r *GormRepository) SellBetTransaction(ctx context.Context, fn dbets.SellTransactionFunc) error {
+	// The transaction-scoped market reader locks the market row before deriving
+	// the user's position so overlapping sell settlements serialize per market.
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(ctx, NewGormRepository(tx), sellMarketRepository{db: tx}, newPlaceUserService(tx))
+	})
+}
+
+type sellMarketRepository struct {
+	db *gorm.DB
+}
+
+func (r sellMarketRepository) GetMarket(ctx context.Context, id int64) (*dmarkets.Market, error) {
+	var market models.Market
+
+	query := r.db.WithContext(ctx)
+	if r.db.Dialector.Name() == "postgres" {
+		query = query.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	if err := query.First(&market, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, dmarkets.ErrMarketNotFound
+		}
+		return nil, err
+	}
+
+	return sellMarketModelToDomain(&market), nil
+}
+
+func (r sellMarketRepository) GetUserPositionInMarket(ctx context.Context, marketID int64, username string) (*dmarkets.UserPosition, error) {
+	snapshot, bets, err := r.loadMarketData(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+
+	position, err := positionsmath.CalculateMarketPositionForUser_WPAM_DBPM(snapshot, bets, username)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dmarkets.UserPosition{
+		Username:         username,
+		MarketID:         marketID,
+		YesSharesOwned:   position.YesSharesOwned,
+		NoSharesOwned:    position.NoSharesOwned,
+		Value:            position.Value,
+		TotalSpent:       position.TotalSpent,
+		TotalSpentInPlay: position.TotalSpentInPlay,
+		IsResolved:       position.IsResolved,
+		ResolutionResult: position.ResolutionResult,
+	}, nil
+}
+
+func (r sellMarketRepository) loadMarketData(ctx context.Context, marketID int64) (positionsmath.MarketSnapshot, []boundary.Bet, error) {
+	var market models.Market
+	marketQuery := r.db.WithContext(ctx)
+	if r.db.Dialector.Name() == "postgres" {
+		marketQuery = marketQuery.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	if err := marketQuery.First(&market, marketID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return positionsmath.MarketSnapshot{}, nil, dmarkets.ErrMarketNotFound
+		}
+		return positionsmath.MarketSnapshot{}, nil, err
+	}
+
+	var dbBets []models.Bet
+	betsQuery := r.db.WithContext(ctx).
+		Where("market_id = ?", marketID).
+		Order("placed_at ASC")
+	if r.db.Dialector.Name() == "postgres" {
+		betsQuery = betsQuery.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	if err := betsQuery.Find(&dbBets).Error; err != nil {
+		return positionsmath.MarketSnapshot{}, nil, err
+	}
+
+	snapshot := positionsmath.MarketSnapshot{
+		ID:               int64(market.ID),
+		CreatedAt:        market.CreatedAt,
+		IsResolved:       market.IsResolved,
+		ResolutionResult: market.ResolutionResult,
+	}
+
+	return snapshot, sellModelBetsToBoundary(dbBets), nil
+}
+
+func sellModelBetsToBoundary(dbBets []models.Bet) []boundary.Bet {
+	bets := make([]boundary.Bet, len(dbBets))
+	for i, bet := range dbBets {
+		bets[i] = boundary.Bet{
+			ID:        uint(bet.ID),
+			Username:  bet.Username,
+			MarketID:  bet.MarketID,
+			Amount:    bet.Amount,
+			Outcome:   bet.Outcome,
+			PlacedAt:  bet.PlacedAt,
+			CreatedAt: bet.CreatedAt,
+		}
+	}
+	return bets
+}
+
+func sellMarketModelToDomain(dbMarket *models.Market) *dmarkets.Market {
+	status := "active"
+	switch {
+	case dbMarket.IsResolved:
+		status = "resolved"
+	case !dbMarket.ResolutionDateTime.After(time.Now()):
+		status = "closed"
+	}
+
+	return &dmarkets.Market{
+		ID:                      dbMarket.ID,
+		QuestionTitle:           dbMarket.QuestionTitle,
+		Description:             dbMarket.Description,
+		OutcomeType:             dbMarket.OutcomeType,
+		ResolutionDateTime:      dbMarket.ResolutionDateTime,
+		FinalResolutionDateTime: dbMarket.FinalResolutionDateTime,
+		ResolutionResult:        dbMarket.ResolutionResult,
+		CreatorUsername:         dbMarket.CreatorUsername,
+		YesLabel:                dbMarket.YesLabel,
+		NoLabel:                 dbMarket.NoLabel,
+		Status:                  status,
+		CreatedAt:               dbMarket.CreatedAt,
+		UpdatedAt:               dbMarket.UpdatedAt,
+		InitialProbability:      dbMarket.InitialProbability,
+		UTCOffset:               dbMarket.UTCOffset,
+	}
+}

--- a/backend/internal/repository/bets/sell_transaction_test.go
+++ b/backend/internal/repository/bets/sell_transaction_test.go
@@ -1,0 +1,85 @@
+package bets
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dbets "socialpredict/internal/domain/bets"
+	"socialpredict/internal/domain/boundary"
+	dusers "socialpredict/internal/domain/users"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+
+	"gorm.io/gorm"
+)
+
+func TestGormRepositorySellBetTransactionRollsBackCreditWhenSaleBetCreateFails(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	sqlDB, _ := db.DB()
+	if sqlDB != nil {
+		t.Cleanup(func() { _ = sqlDB.Close() })
+	}
+
+	seedSellRows(t, db, "creator", "seller", 1000, 201)
+
+	createErr := errors.New("forced sale bet create failure")
+	if err := db.Callback().Create().Before("gorm:create").Register("fail_sale_bet_create", func(tx *gorm.DB) {
+		if _, ok := tx.Statement.Dest.(*models.Bet); ok {
+			tx.AddError(createErr)
+		}
+	}); err != nil {
+		t.Fatalf("register create callback: %v", err)
+	}
+
+	repo := NewGormRepository(db)
+	err := repo.SellBetTransaction(context.Background(), func(ctx context.Context, txRepo dbets.Repository, markets dbets.MarketService, users dbets.UserService) error {
+		if _, err := markets.GetMarket(ctx, 201); err != nil {
+			return err
+		}
+		if _, err := markets.GetUserPositionInMarket(ctx, 201, "seller"); err != nil {
+			return err
+		}
+		if err := users.ApplyTransaction(ctx, "seller", 25, dusers.TransactionSale); err != nil {
+			return err
+		}
+		return txRepo.Create(ctx, &boundary.Bet{
+			Username: "seller",
+			MarketID: 201,
+			Amount:   -2,
+			Outcome:  "YES",
+			PlacedAt: time.Date(2026, time.May, 11, 22, 30, 0, 0, time.UTC),
+		})
+	})
+	if !errors.Is(err, createErr) {
+		t.Fatalf("expected forced create error, got %v", err)
+	}
+
+	assertUserBalance(t, db, "seller", 1000)
+	assertBetCount(t, db, "seller", 201, 1)
+}
+
+func seedSellRows(t *testing.T, db *gorm.DB, creatorUsername string, sellerUsername string, sellerBalance int64, marketID int64) {
+	t.Helper()
+
+	creator := modelstesting.GenerateUser(creatorUsername, 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator user: %v", err)
+	}
+
+	seller := modelstesting.GenerateUser(sellerUsername, sellerBalance)
+	if err := db.Create(&seller).Error; err != nil {
+		t.Fatalf("seed seller user: %v", err)
+	}
+
+	market := modelstesting.GenerateMarket(marketID, creatorUsername)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+
+	buy := modelstesting.GenerateBet(100, "YES", sellerUsername, uint(marketID), 0)
+	if err := db.Create(&buy).Error; err != nil {
+		t.Fatalf("seed buy bet: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a `SellUnitOfWork` port for sell-position settlement
- run market open check, position derivation, sale credit, and negative sale bet insert inside a repository-owned transaction
- remove the old compensation-style sale credit rollback attempt
- add SQLite rollback coverage plus env-gated Postgres rollback coverage for sell settlement
- update the database production note to mark sell-position settlement as transaction-scoped while deferring market-resolution accounting to a later PR

## Agent review
- Used dispatcher-style routing from `spec-socialpredict-tasks-auto`.
- Architecture and verifier reviews both recommended sell-position as the smallest safe item-3 PR.
- Market-resolution was intentionally deferred because it spans market state, multiple user credits, idempotency, and concurrent resolver behavior.

## Validation
- `gofmt` on changed Go files
- `git diff --check`
- `cd backend && go test ./internal/domain/bets ./internal/repository/bets`
- `cd backend && go test ./handlers/bets/selling ./handlers/markets ./internal/domain/markets ./internal/domain/users`
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `run_boundary_checks.sh /Users/patrick/conductor/workspaces/socialpredict/stockholm`
- `run_quality_guardrails.sh /Users/patrick/conductor/workspaces/socialpredict/stockholm origin/main`

## Notes
- The new Postgres sell test is DSN-gated through the existing `SOCIALPREDICT_POSTGRES_TEST_DSN` / `POSTGRES_TEST_DSN` convention.
- Follow-up item remains: market-resolution transaction/concurrency policy.
