### PR TITLE
[ 11 ] Clarify request-boundary observability ownership

### DIFF
--- a/README/PRODUCTION-NOTES/BACKEND/02-logging-observability.md
+++ b/README/PRODUCTION-NOTES/BACKEND/02-logging-observability.md
@@ -3,9 +3,9 @@ title: Logging and Observability
 document_type: production-notes
 domain: backend
 author: Patrick Delaney
-updated_at: 2026-04-30T11:55:00Z
-updated_at_display: "Thursday, April 30, 2026 at 11:55 AM UTC"
-update_reason: "Record the April 30 liveness/readiness completion while keeping backend/logger as the owned runtime adapter."
+updated_at: 2026-05-12T00:00:00Z
+updated_at_display: "Tuesday, May 12, 2026"
+update_reason: "Clarify the canonical production request-boundary observability chain."
 status: active
 ---
 
@@ -16,6 +16,8 @@ status: active
 This note was updated on Saturday, April 25, 2026 to replace an older greenfield observability-platform plan with guidance that matches the current SocialPredict backend, the active design-plan posture, and the package-ownership decision to standardize on `backend/logger`.
 
 On Thursday, April 30, 2026, the health/readiness split called out by this note was finished for the serving path: `/health` now reports liveness, and `/readyz` reports readiness plus database availability.
+
+On Tuesday, May 12, 2026, the production request-boundary ownership was clarified: server wiring uses `security.RequestBoundaryMiddlewareWithProxyTrust` for request IDs, trace correlation, panic recovery, and completion logs, then wraps it with `OperationalMetrics.Middleware` for the first app-owned request-failure counter. The older `logger.RequestLoggingMiddleware` remains compatibility/test support and should not be reintroduced into production server wiring.
 
 | Topic | Prior to April 25, 2026 | After April 25, 2026 |
 | --- | --- | --- |
@@ -129,12 +131,30 @@ Current limitations include:
 
 - string-oriented convenience APIs rather than structured event shapes
 - per-call convenience construction in [simplelogging.go](/workspace/socialpredict/backend/logger/simplelogging.go)
-- incomplete request-correlation and middleware-level logging
+- request-boundary logging is now centralized in [requestboundary.go](/workspace/socialpredict/backend/security/requestboundary.go), but richer route, latency, and failure classification remains intentionally narrow
 - no unified redaction policy documented here yet
-- no explicit readiness/liveness split yet
+- readiness/liveness now exist, but early-startup status before the HTTP listener is reachable remains deferred
 - no tracing boundary yet
 
 That is acceptable for the current note because the first task is not to build everything. The first task is to unify ownership and make future hardening coherent.
+
+### Canonical production request boundary
+
+The production HTTP chain in [server.go](/workspace/socialpredict/backend/server/server.go) receives requests in this order:
+
+```text
+OperationalMetrics.Middleware
+RequestBoundaryMiddlewareWithProxyTrust
+SecurityHeadersMiddleware
+CORS, when enabled
+router
+```
+
+That ownership matters:
+
+- `security.RequestBoundaryMiddlewareWithProxyTrust` owns request ID propagation, logger correlation context, traceparent field extraction, sanitized path logging, panic recovery, and one completion log per request.
+- `OperationalMetrics.Middleware` owns the process-local `/ops/status.requestFailuresTotal` counter for non-probe server-side `5xx` responses.
+- `logger.RequestLoggingMiddleware` is a legacy compatibility helper for package-level tests only. It should not be added to `server.go`, because that would create duplicate completion logs and competing request-boundary behavior.
 
 ## OpenTelemetry Posture
 

--- a/README/PRODUCTION-NOTES/BACKEND/09-monitoring-alerting.md
+++ b/README/PRODUCTION-NOTES/BACKEND/09-monitoring-alerting.md
@@ -23,6 +23,8 @@ On Sunday, May 3, 2026, the production nginx template was updated to publish `/o
 
 On Tuesday, May 12, 2026, `/ops/status` was tightened as a stable cache-disabled JSON operator contract. Server tests assert the top-level fields `live`, `ready`, `requestFailuresTotal`, and `dbPool`, plus the current SQL pool counter field names. The staging checklist and OpenAPI response headers now call out `Cache-Control: no-store`.
 
+Also on Tuesday, May 12, 2026, the request-boundary observability chain was made explicit. `security.RequestBoundaryMiddlewareWithProxyTrust` is the production owner for request IDs, trace correlation, completion logs, and panic recovery; `OperationalMetrics.Middleware` is the production owner for the first app-owned request-failure counter exposed through `/ops/status`.
+
 The staging verification checklist for this wave lives in [STAGETEST/09-monitoring-alerting.md](/workspace/socialpredict/README/PRODUCTION-NOTES/BACKEND/STAGETEST/09-monitoring-alerting.md).
 
 The WAVE09 stop-and-review point is that the backend can now support a first alert set for backend down, backend unready, fatal startup failure before readiness opens, and severe server-side request-failure spikes. Broader dashboards or external monitoring platforms should not start until the next app-owned signal seam is chosen and landed.
@@ -116,6 +118,8 @@ The current backend signal contract is intentionally small:
 
 This inventory reflects the live server wiring in [server.go](/workspace/socialpredict/backend/server/server.go), startup order in [main.go](/workspace/socialpredict/backend/main.go), and runtime failure helpers in [security/failures.go](/workspace/socialpredict/backend/security/failures.go) and [security/requestboundary.go](/workspace/socialpredict/backend/security/requestboundary.go).
 
+The production request-boundary chain is intentionally singular: do not add `logger.RequestLoggingMiddleware` to `server.go`. Request completion logging belongs to `security.RequestBoundaryMiddlewareWithProxyTrust`, while the process-local failure counter belongs to `OperationalMetrics.Middleware`. Keeping those responsibilities separate avoids duplicate completion logs and keeps `/ops/status.requestFailuresTotal` tied to the same public response status an operator sees.
+
 ### First supported alert set
 
 The current backend can support only this first alert set:
@@ -208,7 +212,7 @@ The design-plan-aligned monitoring direction is:
 
 The remaining gaps should stay narrow and tied to runtime signals the backend can own:
 
-- Add request-boundary latency and duration fields before promising latency dashboards.
+- Add richer request-boundary latency and duration aggregation before promising latency dashboards.
 - Decide whether the next app-owned counter should classify failures by route family, stable reason, or status class before adding more counters.
 - Add process identity or start-time metadata if operators need to distinguish counter resets from real recovery.
 - Decide which traffic-volume and edge-failure signals belong in the backend versus nginx or Traefik before moving proxy observations into app docs.

--- a/backend/logger/middleware.go
+++ b/backend/logger/middleware.go
@@ -70,6 +70,9 @@ func ContextWithRequestCorrelation(ctx context.Context, requestID, traceparent s
 
 // RequestLoggingMiddleware logs one completion line per request and propagates
 // stable request/correlation identifiers at the runtime boundary.
+//
+// Deprecated: production HTTP wiring uses security.RequestBoundaryMiddleware.
+// Keep this helper for compatibility tests only; do not add it to server wiring.
 func RequestLoggingMiddleware(next http.Handler) http.Handler {
 	if next == nil {
 		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -70,6 +70,9 @@ func buildHandler(openAPISpec []byte, swaggerUIFS fs.FS, db *gorm.DB, configServ
 		handler = c.Handler(handler)
 	}
 	handler = security.SecurityHeadersMiddleware(securityConfig.Headers)(handler)
+	// Canonical production request boundary: request IDs, panic recovery, and
+	// completion logging live here. Keep logger.RequestLoggingMiddleware out of
+	// server wiring to avoid duplicate request IDs and completion logs.
 	handler = security.RequestBoundaryMiddlewareWithProxyTrust(securityConfig.TrustProxyHeaders)(handler)
 	handler = operationalMetrics.Middleware(handler)
 

--- a/backend/server/server_test.go
+++ b/backend/server/server_test.go
@@ -662,24 +662,6 @@ func TestServerPreservesIncomingRequestIDHeader(t *testing.T) {
 	}
 }
 
-func TestRequestLoggingMiddlewareTreatsCanceledRequestsAsClientClosed(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/v0/markets", nil)
-	ctx, cancel := context.WithCancel(req.Context())
-	cancel()
-	req = req.WithContext(ctx)
-
-	rec := httptest.NewRecorder()
-	handler := logger.RequestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-	}))
-
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected recorder to remain unwritten with default 200, got %d", rec.Code)
-	}
-}
-
 func buildTestHandlerWithConfig(t *testing.T, db *gorm.DB, econConfig any, readiness ...*appruntime.Readiness) http.Handler {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- clarify that production request-boundary observability is owned by `security.RequestBoundaryMiddlewareWithProxyTrust`
- keep `OperationalMetrics.Middleware` scoped to `/ops/status.requestFailuresTotal`
- mark legacy `logger.RequestLoggingMiddleware` as compatibility/test-only and remove server-package coverage of that legacy helper
- update backend production notes 02 and 09 with the current canonical chain and remaining signal seams

## Validation
- `cd backend && go test -count=1 ./logger ./security ./server ./internal/app/runtime`
- `cd backend && go test -count=1 ./...`
- `git diff --check`
