### PR TITLE
[ 12 ] Restore SocialPredict logs command

### DIFF
--- a/SocialPredict
+++ b/SocialPredict
@@ -75,6 +75,7 @@ Commands:
   up          Start SocialPredict containers
   down        Stop SocialPredict containers
   exec        Execute command on SocialPredict containers
+  logs        View logs from SocialPredict containers
   backup      Backup operations on SocialPredict
   cleanup     Cleanup unused Docker artifacts
 
@@ -110,6 +111,13 @@ case "$COMMAND" in
     export CALLED_FROM_SOCIALPREDICT=yes
     shift
     source "${SCRIPT_DIR}/scripts/docker-commands.sh" exec "$@"
+    unset CALLED_FROM_SOCIALPREDICT
+    ;;
+  logs)
+    init
+    export CALLED_FROM_SOCIALPREDICT=yes
+    shift
+    source "${SCRIPT_DIR}/scripts/docker-commands.sh" logs "$@"
     unset CALLED_FROM_SOCIALPREDICT
     ;;
   backup)

--- a/scripts/docker-commands.sh
+++ b/scripts/docker-commands.sh
@@ -234,8 +234,154 @@ sp_exec() {
   esac
 }
 
+compose_cmd() {
+  docker compose --env-file "${SCRIPT_DIR}/.env" "${COMPOSE_FILES[@]}" "$@"
+}
+
+compose_services() {
+  compose_cmd config --services
+}
+
+compose_container_name() {
+  local target_service="${1:-}"
+
+  compose_cmd config | awk -v target="${target_service}" '
+    /^services:/ { in_services=1; next }
+    in_services && /^[^[:space:]]/ { in_services=0 }
+    in_services {
+      if ($0 ~ /^  [^[:space:]][^:]*:$/) {
+        current=$0
+        sub(/^  /, "", current)
+        sub(/:$/, "", current)
+        next
+      }
+
+      if (current == target && $0 ~ /^    container_name:/) {
+        sub(/^    container_name:[[:space:]]*/, "", $0)
+        gsub(/^"/, "", $0)
+        gsub(/"$/, "", $0)
+        print $0
+        exit
+      }
+    }
+  '
+}
+
+print_logs_options() {
+  local service
+  local container_name
+
+  echo "Available log targets:"
+  while IFS= read -r service; do
+    [ -z "${service}" ] && continue
+    container_name="$(compose_container_name "${service}")"
+    if [ -n "${container_name}" ]; then
+      printf "  %-22s %s\n" "${service}" "${container_name}"
+    else
+      printf "  %-22s %s\n" "${service}" "(container name managed by docker compose)"
+    fi
+  done < <(compose_services)
+  printf "  %-22s %s\n" "all" "docker compose aggregated logs"
+  echo
+  echo "Use './SocialPredict logs help' or './SocialPredict logs --help' for examples."
+}
+
+resolve_log_service() {
+  local target="${1:-}"
+  local service
+  local container_name
+
+  while IFS= read -r service; do
+    [ -z "${service}" ] && continue
+
+    if [ "${target}" = "${service}" ]; then
+      echo "${service}"
+      return 0
+    fi
+
+    container_name="$(compose_container_name "${service}")"
+    if [ -n "${container_name}" ] && [ "${target}" = "${container_name}" ]; then
+      echo "${service}"
+      return 0
+    fi
+  done < <(compose_services)
+
+  return 1
+}
+
+sp_logs() {
+  local target="${1:-}"
+  local resolved_service
+  shift || true
+
+  if [ -z "${target}" ]; then
+    print_logs_options
+    return 0
+  fi
+
+  case "${target}" in
+    options|list)
+      print_logs_options
+      return 0
+      ;;
+    -h|--help|help)
+      cat <<EOF
+Usage: ./SocialPredict logs <service> [-f|--follow]
+       ./SocialPredict logs all [-f|--follow]
+
+Examples:
+  ./SocialPredict logs
+  ./SocialPredict logs options
+  ./SocialPredict logs help
+  ./SocialPredict logs <service>
+  ./SocialPredict logs <service> -f
+  ./SocialPredict logs all
+
+Services and current container names from the active compose file:
+EOF
+      print_logs_options
+      return 0
+      ;;
+  esac
+
+  local follow_args=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -f|--follow)
+        follow_args+=("-f")
+        ;;
+      *)
+        echo "Unknown logs option '$1'. Use -f or --follow."
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  if [ "${target}" = "all" ]; then
+    if [ "${#follow_args[@]}" -gt 0 ]; then
+      compose_cmd logs "${follow_args[@]}"
+    else
+      compose_cmd logs
+    fi
+    return 0
+  fi
+
+  resolved_service="$(resolve_log_service "${target}")" || {
+    echo "Unknown log target '${target}'."
+    print_logs_options
+    exit 1
+  }
+
+  if [ "${#follow_args[@]}" -gt 0 ]; then
+    compose_cmd logs "${follow_args[@]}" "${resolved_service}"
+  else
+    compose_cmd logs "${resolved_service}"
+  fi
+}
+
 # --------------------------------------------------------------------------------------
-# Entry points (up / down / exec / cleanup)
+# Entry points (up / down / exec / logs / cleanup)
 # --------------------------------------------------------------------------------------
 case "${1:-}" in
   up)
@@ -248,12 +394,16 @@ case "${1:-}" in
     shift
     sp_exec "$@"
     ;;
+  logs)
+    shift
+    sp_logs "$@"
+    ;;
   cleanup)
     shift
     sp_cleanup "$@"
     ;;
   *)
-    echo "Usage: $0 {up|down|exec <service> [command]|cleanup docker [options]}"
+    echo "Usage: $0 {up|down|exec <service> [command]|logs <service|container-name|all> [-f|--follow]|cleanup docker [options]}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- restore `./SocialPredict logs` in the top-level wrapper
- restore compose-aware log target discovery in `scripts/docker-commands.sh`
- support service names, container names, `all`, and `-f/--follow`

## Validation
- `./SocialPredict --help`
- `./SocialPredict logs help`
- `./SocialPredict logs options`
- `./SocialPredict logs backend 2>&1 | sed -n '1,25p'`
- `./SocialPredict logs socialpredict-backend-container 2>&1 | sed -n '1,8p'`
- `./SocialPredict logs all 2>&1 | sed -n '1,8p'`
- `git diff --check`
