### PR TITLE
[ 04 ] Migrate representative frontend API calls

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'frontend/**']
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend.yml'
@@ -35,6 +35,6 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Build frontend
+      - name: Build frontend and report size
         working-directory: frontend
-        run: npm run build
+        run: npm run build:report

--- a/README/PRODUCTION-NOTES/FRONTEND/01-state-management.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/01-state-management.md
@@ -23,7 +23,7 @@ Broad state-platform ideas now live in [FUTURE/01-long-term-state-platform.md](.
 
 - `AuthContent` now uses the first API/auth adapter seam for login transport, browser persistence, and backend envelope parsing.
 - Some frontend code still reads `localStorage` directly for tokens outside that seam.
-- Components and hooks still call `fetch(API_URL...)` directly.
+- Representative create-market, change-password, homepage, and admin homepage flows now use the API/auth adapter; other components and hooks still call `fetch(API_URL...)` directly.
 - `frontend/src/utils/apiResponse.js` exists, but duplicated response-unwrapping helpers remain.
 - `AppRoutes` embeds auth/access decisions directly in route JSX.
 

--- a/README/PRODUCTION-NOTES/FRONTEND/02-performance-optimization.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/02-performance-optimization.md
@@ -21,9 +21,10 @@ Broader performance-platform ideas now live in [FUTURE/02-long-term-performance-
 
 ## Current Baseline
 
-- Vite production builds exist, but frontend PRs do not yet have a dedicated build signal.
-- Build output size is not documented as a baseline.
-- Bundle budgets are not defined.
+- Vite production builds exist and frontend PRs now have a dedicated install/build signal.
+- `npm run build:report` runs the production build and prints an informational size table from `frontend/build`.
+- The current observed production build report totals roughly `1201 kB` raw and `326 kB` gzip, with the main JavaScript chunk at roughly `1101 kB` raw and `253 kB` gzip.
+- Bundle budgets are not defined and should not be strict until this baseline is reviewed against real product goals.
 - Route-level code splitting and dependency replacement have not been justified with current measurements.
 
 ## Active Direction
@@ -31,7 +32,7 @@ Broader performance-platform ideas now live in [FUTURE/02-long-term-performance-
 The first performance pass should be low-risk:
 
 1. Run a clean frontend production build.
-2. Record the current build output and major bundle contributors.
+2. Record the current build output and major bundle contributors using `npm run build:report`.
 3. Identify obvious duplicate or heavyweight dependencies, especially charting libraries.
 4. Decide whether a permissive build-size or bundle-report artifact belongs in CI.
 5. Avoid blocking unrelated work with strict budgets until the baseline is understood.
@@ -47,6 +48,7 @@ The canonical design plan tracks this under:
 ## Active Acceptance Criteria
 
 - Current production build size is recorded.
+- Frontend CI prints the build-size report after the production build.
 - Any CI budget starts permissive and evidence-based.
 - Future performance PRs have a baseline to compare against.
 - No route-splitting or dependency-replacement program starts before measurement.

--- a/README/PRODUCTION-NOTES/FRONTEND/04-security.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/04-security.md
@@ -23,7 +23,7 @@ Broader security-platform work now lives in [FUTURE/04-long-term-security-platfo
 
 - Login state now uses the first API/auth adapter seam from `AuthContent`.
 - Some code still reads tokens directly from browser storage outside that seam.
-- Components and hooks can still construct authenticated requests directly.
+- Create-market, change-password, homepage, and admin homepage flows now use the adapter; other components and hooks can still construct authenticated requests directly.
 - `mustChangePassword` persistence was removed from localStorage in a prior security fix.
 - CSP, server-managed sessions, and advanced auth flows are not current frontend-only changes.
 

--- a/README/PRODUCTION-NOTES/FRONTEND/05-accessibility.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/05-accessibility.md
@@ -21,6 +21,8 @@ Long-term accessibility-program work lives in [FUTURE/05-long-term-accessibility
 
 ## Current Baseline
 
+Create-market, change-password, global fallback, and navigation controls now have a first pass of explicit labels, status/error announcements, and menu button names. The frontend still needs a broader workflow audit.
+
 The frontend has domain-critical workflows that must be usable without pointer-only or color-only interaction:
 
 - Browse markets.
@@ -52,6 +54,7 @@ The canonical design plan tracks this as:
 - Core forms have labels and usable focus behavior.
 - Primary navigation and domain workflows can be operated by keyboard.
 - Screen-reader users are not blocked by obvious missing semantic structure.
+- Error and success messages use status or alert semantics where they are introduced.
 - Market/trading state is not conveyed by color alone.
 - Any automated check added to CI is stable and scoped.
 

--- a/README/PRODUCTION-NOTES/FRONTEND/10-deployment-cicd.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/10-deployment-cicd.md
@@ -24,15 +24,16 @@ Long-term maintenance and deployment-platform work lives in [FUTURE/10-long-term
 - `.github/workflows/docker.yml` builds/publishes frontend images on release/manual paths.
 - [`.github/workflows/frontend.yml`](../../../.github/workflows/frontend.yml) now runs the first dedicated frontend PR install/build check.
 - Frontend test tooling is not yet declared.
-- Browser performance and bundle evidence are not yet CI artifacts.
+- Browser performance is not yet a CI artifact.
+- Bundle size evidence is now printed in the frontend workflow logs through `npm run build:report`.
 
 ## Active Direction
 
 1. Add a frontend PR job or extend an existing workflow with a frontend job.
 2. Use Node 22 unless the project deliberately chooses another supported runtime.
 3. Run `npm ci` from `frontend/`.
-4. Run `npm run build` from `frontend/`.
-5. Add tests, accessibility checks, and bundle budgets only after tooling and thresholds are explicit.
+4. Run `npm run build:report` from `frontend/` so CI shows the production build and informational size table.
+5. Add tests, accessibility checks, and enforceable bundle budgets only after tooling and thresholds are explicit.
 
 ## Design Plan Alignment
 
@@ -46,6 +47,7 @@ The canonical design plan tracks this as:
 
 - Frontend PRs have a visible GitHub Actions check.
 - Broken frontend builds fail before merge.
+- Frontend workflow logs include a non-blocking build-size report.
 - First job is small and stable.
 - Any later checks have declared dependencies and documented thresholds.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "start": "vite --host",
     "build": "vite build",
+    "build:report": "npm run build && node scripts/report-build-size.mjs",
     "serve": "vite preview"
   },
   "eslintConfig": {

--- a/frontend/scripts/report-build-size.mjs
+++ b/frontend/scripts/report-build-size.mjs
@@ -1,0 +1,60 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const buildDir = join(process.cwd(), 'build');
+
+const formatKb = (bytes) => `${(bytes / 1024).toFixed(2)} kB`;
+
+const walkFiles = (dir) => {
+  const entries = readdirSync(dir);
+
+  return entries.flatMap((entry) => {
+    const fullPath = join(dir, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      return walkFiles(fullPath);
+    }
+
+    return [fullPath];
+  });
+};
+
+if (!existsSync(buildDir)) {
+  console.error('Build directory not found. Run npm run build before reporting build size.');
+  process.exit(1);
+}
+
+const files = walkFiles(buildDir)
+  .map((filePath) => {
+    const contents = readFileSync(filePath);
+
+    return {
+      path: relative(buildDir, filePath),
+      bytes: contents.byteLength,
+      gzipBytes: gzipSync(contents).byteLength,
+    };
+  })
+  .sort((left, right) => right.bytes - left.bytes);
+
+const totals = files.reduce(
+  (memo, file) => ({
+    bytes: memo.bytes + file.bytes,
+    gzipBytes: memo.gzipBytes + file.gzipBytes,
+  }),
+  { bytes: 0, gzipBytes: 0 },
+);
+
+console.log('Frontend build size report');
+console.log('Informational only: this report does not enforce a bundle budget.');
+console.log('');
+console.log('| File | Size | Gzip |');
+console.log('| --- | ---: | ---: |');
+
+files.forEach((file) => {
+  console.log(`| ${file.path} | ${formatKb(file.bytes)} | ${formatKb(file.gzipBytes)} |`);
+});
+
+console.log('| --- | ---: | ---: |');
+console.log(`| Total | ${formatKb(totals.bytes)} | ${formatKb(totals.gzipBytes)} |`);

--- a/frontend/src/components/datetimeSelector/DatetimeSelector.jsx
+++ b/frontend/src/components/datetimeSelector/DatetimeSelector.jsx
@@ -10,7 +10,7 @@ const formatNow = () => {
     return `${year}-${formattedMonth}-${formattedDay}T23:59`;
 };
 
-const DatetimeSelector = ({ value, onChange }) => {
+const DatetimeSelector = ({ value, onChange, id = 'datetime-selector', label = 'Select Date and Time:' }) => {
     const [internalValue, setInternalValue] = useState(() => value ?? formatNow());
 
     useEffect(() => {
@@ -30,11 +30,11 @@ const DatetimeSelector = ({ value, onChange }) => {
 
     return (
         <div className="p-4 bg-custom-gray-light text-white rounded-lg shadow-md max-w-md mx-auto my-4">
-            <label htmlFor="datetime-selector" className="block mb-2 font-bold">
-                Select Date and Time:
+            <label htmlFor={id} className="block mb-2 font-bold">
+                {label}
             </label>
             <input
-                id="datetime-selector"
+                id={id}
                 type="datetime-local"
                 className="w-full p-2 rounded border-gray-300 shadow-sm bg-white text-black"
                 value={internalValue}

--- a/frontend/src/components/inputs/EmojiPicker.jsx
+++ b/frontend/src/components/inputs/EmojiPicker.jsx
@@ -134,6 +134,8 @@ const EmojiPickerInput = ({
           onClick={toggleEmojiPicker}
           className="emoji-picker-button absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-200 transition-colors p-1 rounded"
           title="Add emoji"
+          aria-label="Add emoji"
+          aria-expanded={showEmojiPicker}
         >
           😀
         </button>

--- a/frontend/src/components/inputs/InputBar.jsx
+++ b/frontend/src/components/inputs/InputBar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const RegularInput = ({ value, onChange, placeholder, type = 'text', id, name, autoComplete }) => {
+const RegularInput = ({ value, onChange, placeholder, type = 'text', id, name, autoComplete, required, ariaDescribedBy }) => {
     return (
         <input
             type={type}
@@ -10,6 +10,8 @@ const RegularInput = ({ value, onChange, placeholder, type = 'text', id, name, a
             id={id}
             name={name}
             autoComplete={autoComplete}
+            required={required}
+            aria-describedby={ariaDescribedBy}
             className="w-full px-4 py-2 border-2 border-blue-500 rounded-md text-white bg-transparent focus:outline-none"
         />
     );

--- a/frontend/src/components/layouts/changepassword/ChangePasswordLayout.jsx
+++ b/frontend/src/components/layouts/changepassword/ChangePasswordLayout.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useContext } from 'react';
-import { API_URL } from '../../../config';
 import { useHistory } from 'react-router-dom';
 import SiteButton from '../../buttons/SiteButtons';
 import { RegularInput } from '../../inputs/InputBar';
 import { AuthContext } from '../../../helpers/AuthContent';
-import { getApiErrorMessage, parseApiResponseText } from '../../../utils/apiResponse';
+import { authenticatedApiRequest } from '../../../api/httpClient';
 
 function ChangePasswordLayout() {
     const [currentPassword, setCurrentPassword] = useState('');
@@ -44,24 +43,15 @@ function ChangePasswordLayout() {
         }
 
         try {
-            const response = await fetch(`${API_URL}/v0/changepassword`, {
+            await authenticatedApiRequest('/v0/changepassword', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('token')}`,
                 },
-                body: JSON.stringify({ currentPassword, newPassword })
+                body: JSON.stringify({ currentPassword, newPassword }),
+                fallbackMessage: 'Failed to change password',
+                reasonMessages: changePasswordReasonMessages,
             });
-            if (!response.ok) {
-                const payload = parseApiResponseText(await response.text());
-                const errMsg = capitalizeFirstChar(getApiErrorMessage(
-                    response,
-                    payload,
-                    'Failed to change password',
-                    changePasswordReasonMessages,
-                ));
-                throw new Error(errMsg || 'Failed to change password');
-            }
 
             // Set success message
             setSuccess("Password changed successfully! Logging out. Please log in with your new password.");
@@ -73,7 +63,7 @@ function ChangePasswordLayout() {
             }, 2000);  // Delay of 2000 milliseconds (2 seconds)
         } catch (err) {
             console.error('Failed to change password:', err);
-            setError(err.message);
+            setError(capitalizeFirstChar(err.message || 'Failed to change password'));
         }
     };
 

--- a/frontend/src/components/layouts/changepassword/ChangePasswordLayout.jsx
+++ b/frontend/src/components/layouts/changepassword/ChangePasswordLayout.jsx
@@ -72,33 +72,55 @@ function ChangePasswordLayout() {
             <h1 className="text-2xl font-bold mb-4">Change Password</h1>
             <p>Password change required. You will be automatically logged out after password has been changed.</p>
             <form onSubmit={handleSubmit} className="space-y-8">
+                <label htmlFor="current-password" className="block text-sm font-medium text-gray-300">
+                    Current Password
+                </label>
                 <RegularInput
+                    id="current-password"
+                    name="current-password"
                     type="password"
                     value={currentPassword}
                     onChange={handleCurrentPasswordChange}
                     placeholder="Current Password"
+                    autoComplete="current-password"
                     required
                 />
+                <label htmlFor="new-password" className="block text-sm font-medium text-gray-300">
+                    New Password
+                </label>
                 <RegularInput
+                    id="new-password"
+                    name="new-password"
                     type="password"
                     value={newPassword}
                     onChange={handleNewPasswordChange}
                     placeholder="New Password"
+                    autoComplete="new-password"
+                    ariaDescribedBy="new-password-requirements"
                     required
                 />
+                <p id="new-password-requirements" className="text-sm text-gray-300">
+                    Use 8-128 characters with uppercase, lowercase, and a digit.
+                </p>
+                <label htmlFor="confirm-new-password" className="block text-sm font-medium text-gray-300">
+                    Confirm New Password
+                </label>
                 <RegularInput
+                    id="confirm-new-password"
+                    name="confirm-new-password"
                     type="password"
                     value={confirmPassword}
                     onChange={handleConfirmPasswordChange}
                     placeholder="Confirm New Password"
+                    autoComplete="new-password"
                     required
                 />
                 <SiteButton type="submit">
                     Save New Password
                 </SiteButton>
             </form>
-            {success && <p className="text-green-500">{success}</p>}
-            {error && <p className="error">{error}</p>}
+            {success && <p className="text-green-500" role="status">{success}</p>}
+            {error && <p className="error" role="alert">{error}</p>}
         </div>
     );
 }

--- a/frontend/src/components/sidebar/Sidebar.jsx
+++ b/frontend/src/components/sidebar/Sidebar.jsx
@@ -176,7 +176,12 @@ const Sidebar = () => {
       >
         <div className='flex items-center justify-between p-3 border-b border-gray-700'>
           <h2 className='text-lg font-bold'>SocialPredict</h2>
-          <button onClick={toggleSidebar} className='md:hidden'>
+          <button
+            onClick={toggleSidebar}
+            className='md:hidden'
+            aria-label={isSidebarOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={isSidebarOpen}
+          >
             {isSidebarOpen ? (
               <MenuShrinkSVG className='w-5 h-5' />
             ) : (
@@ -184,7 +189,7 @@ const Sidebar = () => {
             )}
           </button>
         </div>
-        <nav className='flex-grow overflow-y-auto px-2 py-3'>
+        <nav className='flex-grow overflow-y-auto px-2 py-3' aria-label='Primary navigation'>
           <ul className='space-y-1'>{renderLinks()}</ul>
         </nav>
         <footer className='border-t border-gray-700 p-2'>
@@ -203,27 +208,29 @@ const Sidebar = () => {
       </aside>
       {!isSidebarOpen && (
         <div className='fixed bottom-0 left-0 right-0 z-50 bg-gray-800 text-white flex justify-around items-center p-2 md:hidden'>
-          <Link to='/' className='text-gray-300 hover:text-white'>
+          <Link to='/' className='text-gray-300 hover:text-white' aria-label='Home'>
             <HomeSVG className='w-5 h-5' />
           </Link>
-          <Link to='/markets' className='text-gray-300 hover:text-white'>
+          <Link to='/markets' className='text-gray-300 hover:text-white' aria-label='Markets'>
             <MarketsSVG className='w-5 h-5' />
           </Link>
           {isLoggedIn ? (
-            <Link to='/create' className='text-gray-300 hover:text-white'>
+            <Link to='/create' className='text-gray-300 hover:text-white' aria-label='Create market'>
               <CreateSVG className='w-5 h-5' />
             </Link>
           ) : (
             <LoginModalButton iconOnly={true} />
           )}
           {isLoggedIn && (
-            <Link to='/profile' className='text-gray-300 hover:text-white'>
+            <Link to='/profile' className='text-gray-300 hover:text-white' aria-label='Profile'>
               <ProfileSVG className='w-5 h-5' />
             </Link>
           )}
           <button
             onClick={toggleSidebar}
             className='text-gray-300 hover:text-white'
+            aria-label='Open navigation menu'
+            aria-expanded={isSidebarOpen}
           >
             <MenuGrowSVG className='w-5 h-5' />
           </button>

--- a/frontend/src/pages/admin/HomeEditor.jsx
+++ b/frontend/src/pages/admin/HomeEditor.jsx
@@ -1,19 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {API_URL} from "../../config";
-
-const unwrapApiResponse = (payload) => {
-  if (payload && typeof payload === 'object' && 'ok' in payload) {
-    if (payload.ok === false) {
-      throw new Error(payload.reason || 'Request failed');
-    }
-
-    if (payload.ok === true && 'result' in payload) {
-      return payload.result;
-    }
-  }
-
-  return payload;
-};
+import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
 
 function HomeEditor() {
   const [content, setContent] = useState({
@@ -32,20 +18,16 @@ function HomeEditor() {
 
   const fetchContent = async () => {
     try {
-      const response = await fetch(`${API_URL}/v0/content/home`);
-      if (response.ok) {
-        const data = await response.json();
-        const homeContent = unwrapApiResponse(data);
-        setContent({
-          title: homeContent.title || '',
-          html: homeContent.html || '',
-          version: homeContent.version || 0
-        });
-      } else {
-        setError('Failed to load content');
-      }
+      const homeContent = await apiRequest('/v0/content/home', {
+        fallbackMessage: 'Failed to load content',
+      });
+      setContent({
+        title: homeContent.title || '',
+        html: homeContent.html || '',
+        version: homeContent.version || 0
+      });
     } catch (err) {
-      setError('Error loading content: ' + err.message);
+      setError(err.message || 'Error loading content');
     } finally {
       setLoading(false);
     }
@@ -57,36 +39,28 @@ function HomeEditor() {
     setError('');
 
     try {
-      const token = localStorage.getItem('token'); // Use correct token key from localStorage
-      const response = await fetch(`${API_URL}/v0/admin/content/home`, {
+      const homeContent = await authenticatedApiRequest('/v0/admin/content/home', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
         },
         body: JSON.stringify({
           title: content.title,
           format: 'html',
           html: content.html,
           version: content.version
-        })
+        }),
+        fallbackMessage: 'Failed to save content',
       });
 
-      if (response.ok) {
-        const data = await response.json();
-        const homeContent = unwrapApiResponse(data);
-        setContent(prev => ({
-          ...prev,
-          version: homeContent.version,
-          html: homeContent.html
-        }));
-        setMessage('Content saved successfully!');
-      } else {
-        const errorText = await response.text();
-        setError('Failed to save: ' + errorText);
-      }
+      setContent(prev => ({
+        ...prev,
+        version: homeContent.version,
+        html: homeContent.html
+      }));
+      setMessage('Content saved successfully!');
     } catch (err) {
-      setError('Error saving content: ' + err.message);
+      setError(err.message || 'Error saving content');
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/create/Create.jsx
+++ b/frontend/src/pages/create/Create.jsx
@@ -7,7 +7,7 @@ import { RegularInput } from '../../components/inputs/InputBar';
 import RegularInputBox from '../../components/inputs/InputBox';
 import EmojiPickerInput from '../../components/inputs/EmojiPicker';
 import SiteButton from '../../components/buttons/SiteButtons';
-import { API_URL } from '../../config';
+import { authenticatedApiRequest } from '../../api/httpClient';
 
 function Create() {
   const [questionTitle, setQuestionTitle] = useState('');
@@ -52,12 +52,6 @@ function Create() {
       }
     }
 
-    const token = localStorage.getItem('token');
-    if (!token) {
-      setError('Authentication token not found. Please log in again.');
-      return;
-    }
-
     try {
       const marketData = {
         questionTitle,
@@ -72,26 +66,19 @@ function Create() {
         noLabel: trimmedNoLabel || 'NO',
       };
 
-      const response = await fetch(`${API_URL}/v0/markets`, {
+      const responseData = await authenticatedApiRequest('/v0/markets', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(marketData),
+        fallbackMessage: 'Market creation failed. Please try again.',
       });
 
-      if (response.ok) {
-        const responseData = await response.json();
-        history.push(`/markets/${responseData.id}`);
-      } else {
-        const errorText = await response.text();
-        console.error('Market creation failed:', errorText);
-        setError(`Market creation failed: ${errorText}`);
-      }
+      history.push(`/markets/${responseData.id}`);
     } catch (error) {
       console.error('Error during market creation:', error);
-      setError(`Error during market creation: ${error.message}`);
+      setError(error.message || 'Market creation failed. Please try again.');
     }
   };
 

--- a/frontend/src/pages/create/Create.jsx
+++ b/frontend/src/pages/create/Create.jsx
@@ -90,10 +90,11 @@ function Create() {
 
       <form onSubmit={handleSubmit} className='space-y-4 sm:space-y-6'>
         <div>
-          <label className='block text-sm font-medium text-gray-300 mb-1'>
+          <label htmlFor='market-question-title' className='block text-sm font-medium text-gray-300 mb-1'>
             Question Title
           </label>
           <EmojiPickerInput
+            id='market-question-title'
             type='text'
             value={questionTitle}
             onChange={(e) => setQuestionTitle(e.target.value)}
@@ -103,10 +104,11 @@ function Create() {
         </div>
 
         <div>
-          <label className='block text-sm font-medium text-gray-300 mb-1'>
+          <label htmlFor='market-description' className='block text-sm font-medium text-gray-300 mb-1'>
             Description
           </label>
           <EmojiPickerInput
+            id='market-description'
             type='textarea'
             value={description}
             onChange={(e) => setDescription(e.target.value)}
@@ -117,42 +119,46 @@ function Create() {
 
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
           <div>
-            <label className='block text-sm font-medium text-gray-300 mb-1'>
+            <label htmlFor='market-yes-label' className='block text-sm font-medium text-gray-300 mb-1'>
               Yes Label (Optional)
             </label>
             <EmojiPickerInput
+              id='market-yes-label'
               type='text'
               value={yesLabel}
               onChange={(e) => setYesLabel(e.target.value)}
               placeholder='e.g., BULL 🚀, WIN, PASS'
               maxLength={20}
+              aria-describedby='market-yes-label-hint'
               className='w-full bg-gray-700 border border-gray-600 text-white px-3 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500'
             />
-            <p className='text-xs text-gray-400 mt-1'>
+            <p id='market-yes-label-hint' className='text-xs text-gray-400 mt-1'>
               Custom label for positive outcome (defaults to "YES")
             </p>
           </div>
           
           <div>
-            <label className='block text-sm font-medium text-gray-300 mb-1'>
+            <label htmlFor='market-no-label' className='block text-sm font-medium text-gray-300 mb-1'>
               No Label (Optional)
             </label>
             <EmojiPickerInput
+              id='market-no-label'
               type='text'
               value={noLabel}
               onChange={(e) => setNoLabel(e.target.value)}
               placeholder='e.g., BEAR 📉, LOSE, FAIL'
               maxLength={20}
+              aria-describedby='market-no-label-hint'
               className='w-full bg-gray-700 border border-gray-600 text-white px-3 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500'
             />
-            <p className='text-xs text-gray-400 mt-1'>
+            <p id='market-no-label-hint' className='text-xs text-gray-400 mt-1'>
               Custom label for negative outcome (defaults to "NO")
             </p>
           </div>
         </div>
 
         {(yesLabel.trim() || noLabel.trim()) && (
-          <div className='bg-gray-700 p-3 rounded-md'>
+          <div className='bg-gray-700 p-3 rounded-md' aria-label='Outcome label preview'>
             <p className='text-sm font-medium text-gray-300 mb-2'>Preview:</p>
             <div className='flex space-x-2'>
               <span className='px-3 py-1 bg-green-600 text-white text-sm rounded'>
@@ -167,10 +173,9 @@ function Create() {
         )}
 
         <div>
-          <label className='block text-sm font-medium text-gray-300 mb-1'>
-            Resolution Date Time
-          </label>
           <DatetimeSelector
+            id='market-resolution-date-time'
+            label='Resolution Date Time'
             value={resolutionDateTime}
             onChange={(e) => setResolutionDateTime(e.target.value)}
             className='w-full'
@@ -178,7 +183,7 @@ function Create() {
         </div>
 
         {error && (
-          <div className='bg-red-600 text-white p-3 rounded-md text-sm'>
+          <div className='bg-red-600 text-white p-3 rounded-md text-sm' role='alert'>
             {error}
           </div>
         )}

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -1,35 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import {API_URL} from "../../config";
-
-const unwrapApiResponse = (payload) => {
-  if (payload && typeof payload === 'object' && 'ok' in payload) {
-    if (payload.ok === false) {
-      throw new Error(payload.reason || 'Request failed');
-    }
-
-    if (payload.ok === true && 'result' in payload) {
-      return payload.result;
-    }
-  }
-
-  return payload;
-};
+import { apiRequest } from '../../api/httpClient';
 
 function Home() {
   const [content, setContent] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`${API_URL}/v0/content/home`)
-      .then(response => {
-        if (!response.ok) {
-          throw new Error(`Failed to load homepage content: ${response.status}`);
-        }
-
-        return response.json();
-      })
-      .then(data => {
-        const homeContent = unwrapApiResponse(data);
+    apiRequest('/v0/content/home', {
+      fallbackMessage: 'Failed to load homepage content.',
+    })
+      .then(homeContent => {
         setContent({
           title: homeContent.title,
           html: homeContent.html,


### PR DESCRIPTION
## Summary
- Migrates create-market and change-password flows to the API/auth adapter.
- Migrates public homepage and admin homepage content flows to the API adapter.
- Removes duplicated local response-envelope unwrapping from the homepage flows.
- Updates frontend state/security notes with the migrated representative flows and remaining direct call-site work.

## Scope
This is a representative migration, not a full repo-wide sweep. Other direct fetch/API_URL/localStorage call sites remain for later incremental PRs.

## Validation
- npm run build
- git diff --check

## Stack
Base: #701 / frontend/api-auth-adapter-seam
Next: [ 05 ] accessibility baseline stacks on this branch.