### PR TITLE
[ 06 ] Add frontend build-size baseline

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'frontend/**']
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend.yml'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,6 +35,6 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Build frontend
+      - name: Build frontend and report size
         working-directory: frontend
-        run: npm run build
+        run: npm run build:report

--- a/README/PRODUCTION-NOTES/FRONTEND/02-performance-optimization.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/02-performance-optimization.md
@@ -21,9 +21,10 @@ Broader performance-platform ideas now live in [FUTURE/02-long-term-performance-
 
 ## Current Baseline
 
-- Vite production builds exist, but frontend PRs do not yet have a dedicated build signal.
-- Build output size is not documented as a baseline.
-- Bundle budgets are not defined.
+- Vite production builds exist and frontend PRs now have a dedicated install/build signal.
+- `npm run build:report` runs the production build and prints an informational size table from `frontend/build`.
+- The current observed production build report totals roughly `1201 kB` raw and `326 kB` gzip, with the main JavaScript chunk at roughly `1101 kB` raw and `253 kB` gzip.
+- Bundle budgets are not defined and should not be strict until this baseline is reviewed against real product goals.
 - Route-level code splitting and dependency replacement have not been justified with current measurements.
 
 ## Active Direction
@@ -31,7 +32,7 @@ Broader performance-platform ideas now live in [FUTURE/02-long-term-performance-
 The first performance pass should be low-risk:
 
 1. Run a clean frontend production build.
-2. Record the current build output and major bundle contributors.
+2. Record the current build output and major bundle contributors using `npm run build:report`.
 3. Identify obvious duplicate or heavyweight dependencies, especially charting libraries.
 4. Decide whether a permissive build-size or bundle-report artifact belongs in CI.
 5. Avoid blocking unrelated work with strict budgets until the baseline is understood.
@@ -47,6 +48,7 @@ The canonical design plan tracks this under:
 ## Active Acceptance Criteria
 
 - Current production build size is recorded.
+- Frontend CI prints the build-size report after the production build.
 - Any CI budget starts permissive and evidence-based.
 - Future performance PRs have a baseline to compare against.
 - No route-splitting or dependency-replacement program starts before measurement.

--- a/README/PRODUCTION-NOTES/FRONTEND/10-deployment-cicd.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/10-deployment-cicd.md
@@ -24,15 +24,16 @@ Long-term maintenance and deployment-platform work lives in [FUTURE/10-long-term
 - `.github/workflows/docker.yml` builds/publishes frontend images on release/manual paths.
 - [`.github/workflows/frontend.yml`](../../../.github/workflows/frontend.yml) now runs the first dedicated frontend PR install/build check.
 - Frontend test tooling is not yet declared.
-- Browser performance and bundle evidence are not yet CI artifacts.
+- Browser performance is not yet a CI artifact.
+- Bundle size evidence is now printed in the frontend workflow logs through `npm run build:report`.
 
 ## Active Direction
 
 1. Add a frontend PR job or extend an existing workflow with a frontend job.
 2. Use Node 22 unless the project deliberately chooses another supported runtime.
 3. Run `npm ci` from `frontend/`.
-4. Run `npm run build` from `frontend/`.
-5. Add tests, accessibility checks, and bundle budgets only after tooling and thresholds are explicit.
+4. Run `npm run build:report` from `frontend/` so CI shows the production build and informational size table.
+5. Add tests, accessibility checks, and enforceable bundle budgets only after tooling and thresholds are explicit.
 
 ## Design Plan Alignment
 
@@ -46,6 +47,7 @@ The canonical design plan tracks this as:
 
 - Frontend PRs have a visible GitHub Actions check.
 - Broken frontend builds fail before merge.
+- Frontend workflow logs include a non-blocking build-size report.
 - First job is small and stable.
 - Any later checks have declared dependencies and documented thresholds.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "start": "vite --host",
     "build": "vite build",
+    "build:report": "npm run build && node scripts/report-build-size.mjs",
     "serve": "vite preview"
   },
   "eslintConfig": {

--- a/frontend/scripts/report-build-size.mjs
+++ b/frontend/scripts/report-build-size.mjs
@@ -1,0 +1,60 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const buildDir = join(process.cwd(), 'build');
+
+const formatKb = (bytes) => `${(bytes / 1024).toFixed(2)} kB`;
+
+const walkFiles = (dir) => {
+  const entries = readdirSync(dir);
+
+  return entries.flatMap((entry) => {
+    const fullPath = join(dir, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      return walkFiles(fullPath);
+    }
+
+    return [fullPath];
+  });
+};
+
+if (!existsSync(buildDir)) {
+  console.error('Build directory not found. Run npm run build before reporting build size.');
+  process.exit(1);
+}
+
+const files = walkFiles(buildDir)
+  .map((filePath) => {
+    const contents = readFileSync(filePath);
+
+    return {
+      path: relative(buildDir, filePath),
+      bytes: contents.byteLength,
+      gzipBytes: gzipSync(contents).byteLength,
+    };
+  })
+  .sort((left, right) => right.bytes - left.bytes);
+
+const totals = files.reduce(
+  (memo, file) => ({
+    bytes: memo.bytes + file.bytes,
+    gzipBytes: memo.gzipBytes + file.gzipBytes,
+  }),
+  { bytes: 0, gzipBytes: 0 },
+);
+
+console.log('Frontend build size report');
+console.log('Informational only: this report does not enforce a bundle budget.');
+console.log('');
+console.log('| File | Size | Gzip |');
+console.log('| --- | ---: | ---: |');
+
+files.forEach((file) => {
+  console.log(`| ${file.path} | ${formatKb(file.bytes)} | ${formatKb(file.gzipBytes)} |`);
+});
+
+console.log('| --- | ---: | ---: |');
+console.log(`| Total | ${formatKb(totals.bytes)} | ${formatKb(totals.gzipBytes)} |`);


### PR DESCRIPTION
## Summary
- Add npm run build:report for a production Vite build followed by a raw/gzip build-size table from frontend/build.
- Update the frontend GitHub Actions workflow to print the informational size report after install/build.
- Document the current observed build-size baseline and keep bundle budgets explicitly non-enforcing for now.

## Stack
- Base: #703 [ 05 ] Add frontend accessibility baseline
- Completes the current six-item frontend triage stack.

## Validation
- npm run build:report
- git diff --check
