### PR TITLE
Docs: refresh frontend production notes baseline

### DIFF
--- a/README/PRODUCTION-NOTES/FRONTEND/00-TRIAGE.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/00-TRIAGE.md
@@ -3,9 +3,9 @@ title: Frontend Baseline Triage
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Ground frontend production-note sequencing with Evans/Fowler/Martin design-agent review and current frontend code evidence."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the landed frontend baseline stack and reset the next work around remaining call-site migration, tests, and broader workflow audits."
 status: draft
 ---
 
@@ -81,17 +81,33 @@ Recommended design-plan direction:
 
 The canonical design plan now includes frontend extraction tags, a `Frontend Experience Context`, a `Frontend Visual System Boundary`, active frontend workstreams `W08` and `W09`, and ADR guardrails for deferring browser platform capabilities until baseline seams are stable.
 
+## May 24 Baseline Update
+
+The first stacked frontend baseline has now landed on `frontend/baseline-ci-auth-error` for review into `main`.
+
+That stack includes:
+
+- a dedicated frontend PR workflow using Node 22, `npm ci`, and `npm run build:report`
+- a user-safe global error fallback with development-only diagnostic details
+- a first `authStorage` and `httpClient` API/auth adapter seam
+- representative migrations for login, create market, change password, homepage content, and admin homepage content
+- a first accessibility pass for create-market, change-password, navigation controls, status/error regions, and the datetime selector
+- an informational production build-size report
+
+This update does not mean the frontend platform work is complete. It means the baseline now has enough CI and adapter structure to continue smaller, lower-risk follow-up slices.
+
 ## Current Code Snapshot
 
 As of this triage pass, the frontend is a Vite React app under `frontend/` with:
 
 - React 18, Vite, Tailwind, React Router v5, charting libraries, and `react-error-boundary` in [package.json](../../../frontend/package.json).
 - App-level routing and auth context in [App.jsx](../../../frontend/src/App.jsx), [AppRoutes.jsx](../../../frontend/src/helpers/AppRoutes.jsx), and [AuthContent.jsx](../../../frontend/src/helpers/AuthContent.jsx).
-- A global error boundary in [App.jsx](../../../frontend/src/App.jsx), but the fallback currently renders `error.message` directly to the user.
-- Persistent auth state in `localStorage` from [AuthContent.jsx](../../../frontend/src/helpers/AuthContent.jsx), plus several direct `localStorage.getItem('token')` call sites across pages/components.
-- API transport and envelope handling spread across pages, hooks, and components; [axios.js](../../../frontend/src/api/axios.js) is a placeholder, while direct `fetch(API_URL...)` call sites and duplicated `unwrapApiResponse` functions remain.
+- A global error boundary in [App.jsx](../../../frontend/src/App.jsx) with user-safe production copy and development-only diagnostic details.
+- Persistent auth state still uses browser storage, but login/logout and stored auth state now go through [authStorage.js](../../../frontend/src/api/authStorage.js).
+- API transport and envelope handling now have a first preferred path in [httpClient.js](../../../frontend/src/api/httpClient.js), while direct `fetch(API_URL...)` call sites and duplicated `unwrapApiResponse` functions remain in several market, profile, stats, and trading surfaces.
 - One visible frontend test file, [useDocumentMeta.test.jsx](../../../frontend/src/test/useDocumentMeta.test.jsx), but [package.json](../../../frontend/package.json) has no `test` script and does not declare `vitest` or `jsdom`.
-- Backend and Docker workflows in `.github/workflows`, but no dedicated frontend PR CI workflow that runs install, build, lint, or tests for frontend-only changes. Release/manual Docker builds do build the frontend image through [docker.yml](../../../.github/workflows/docker.yml), but that is not the same as PR feedback.
+- Backend and Docker workflows exist, and [frontend.yml](../../../.github/workflows/frontend.yml) now adds a dedicated frontend PR install/build check with a non-blocking build-size report.
+- The current production build report is roughly `1201 kB` raw and `326 kB` gzip, with the main JavaScript chunk roughly `1101 kB` raw and `254 kB` gzip.
 - No current service worker, i18n runtime, product analytics runtime, browser APM client, or PWA installation surface in `frontend/src`.
 
 This means the immediate work should not start with Redux, PWA, analytics, Grafana, or a full design-system rewrite. The immediate work should make the existing app safer to change, easier to validate, and more consistent with canonical SocialPredict domain language.
@@ -153,17 +169,19 @@ Primary sources:
 
 Why this is first for code:
 
-The current frontend can be built locally, but the repo does not yet have a dedicated frontend CI signal comparable to the backend workflow. Before making larger UI, auth, accessibility, or performance changes, the branch should have a reliable GitHub check that proves the frontend still installs and builds.
+The current frontend now has a dedicated CI signal comparable to the backend smoke signal. This should remain small and reliable while later slices decide whether to add test, accessibility, or bundle-budget gates.
 
-Recommended first slice:
+Completed first slice:
 
-- Add a frontend PR workflow or extend an existing workflow with a frontend job.
 - Use Node 22 unless the project deliberately chooses another supported runtime.
 - Run `npm ci` from `frontend/`.
-- Run `npm run build` from `frontend/`.
+- Run `npm run build:report` from `frontend/`.
+
+Remaining verification work:
+
 - Do not claim test coverage until test tooling is declared. The current test imports Vitest, but `vitest`, `jsdom`, and a `test` script are not declared in [package.json](../../../frontend/package.json).
-- If tests are added in this slice, add an explicit `vitest --environment jsdom` script and the required dev dependencies.
-- Keep the first workflow intentionally small; do not introduce Playwright, Lighthouse, visual regression, or bundle budgets in the same slice.
+- If tests are added in the next verification slice, add an explicit `vitest --environment jsdom` script and the required dev dependencies.
+- Keep the workflow intentionally small; do not introduce Playwright, Lighthouse, visual regression, or strict bundle budgets without separate thresholds.
 
 Acceptance criteria:
 
@@ -182,19 +200,22 @@ Primary sources:
 
 Why this is second:
 
-The frontend still treats the browser as the auth state source of truth and stores bearer tokens in `localStorage`. A previous CodeQL finding already pushed one smaller fix around `mustChangePassword`; the broader risk remains that security-relevant auth state, transport, headers, backend envelope parsing, and user-facing error display are spread across helper, page, hook, and component call sites.
+The frontend still uses browser storage for bearer-token compatibility, but token access now has a first `authStorage` boundary and request/envelope handling now has a first `httpClient` boundary. The broader risk remains that several market, profile, stats, and trading surfaces still construct transport, headers, backend envelope parsing, and user-facing errors directly.
 
 This is not only a storage issue. It is a frontend boundary issue.
 
-Recommended first slice:
+Completed first slice:
+
+- Define a small API client port/adapter for authenticated requests.
+- Centralize auth header injection for migrated callers.
+- Centralize backend envelope parsing for migrated callers.
+- Preserve login/logout/runtime behavior while introducing the seam.
+
+Remaining cleanup:
 
 - Inventory every frontend token read/write call site.
 - Inventory direct `fetch(API_URL...)` call sites and duplicated `unwrapApiResponse` helpers.
-- Define a small API client port/adapter for authenticated requests.
-- Centralize auth header injection.
-- Centralize backend envelope parsing.
 - Keep React components dependent on use-case functions/hooks, not directly on `API_URL`, `fetch`, or `localStorage`.
-- Preserve current runtime behavior while reducing direct storage and transport coupling.
 - Document that server-managed sessions or memory-only token handling would require backend/session design, not just frontend refactoring.
 - Split implementation PRs if a branch changes more than the seam plus one or two representative call sites.
 
@@ -216,15 +237,18 @@ Primary sources:
 
 Why this is third:
 
-The app has an error boundary, which is a good start, but the fallback renders `error.message` to the user. That is useful during development and risky as a production default. Many components also render or alert raw `err.message` values. API error parsing exists, but user-facing error behavior is not yet a clearly owned contract.
+The app has an error boundary with safe production fallback copy and development-only diagnostics. Many components can still render or alert raw `err.message` values, and API reason mapping is still uneven across non-migrated call sites.
 
 Fowler sequencing note: the tiny global fallback leak can be fixed before broad auth/API migration because it is small, reversible, and low-risk.
 
-Recommended first slice:
+Completed first slice:
 
 - Make the global error fallback user-safe by default.
 - Split diagnostic errors from safe user-facing recovery messages.
-- Keep detailed errors in development-only console output, not production UI.
+- Keep detailed errors in development-only fallback details, not production UI.
+
+Remaining cleanup:
+
 - Map backend envelopes/reasons into user-safe copy without exposing raw runtime details.
 - Standardize API error display around backend response envelopes where practical.
 - Add at least one focused test for the safe fallback or API error formatter once frontend test tooling is available.
@@ -248,16 +272,22 @@ Why this is fourth:
 
 Accessibility improvements should start with the current UI, not with a new component library. The app has forms, navigation, tables, cards, tabs, charts, and domain-critical trading flows; those are enough to define a useful first accessibility baseline.
 
-Recommended first slice:
+Completed first slice:
 
-- Check browse markets, create market, buy exposure, sell exposure, resolve market, view profile/account, and view position flows.
-- Fix obvious label, focus, keyboard, and semantic structure issues.
-- Add lightweight accessibility checks only after the frontend CI baseline exists.
+- Add explicit labels and announcements in create-market and change-password flows.
+- Add accessible names and expanded-state semantics to navigation/menu controls.
+- Add datetime selector `id`/`label` support.
+
+Remaining cleanup:
+
+- Check browse markets, buy exposure, sell exposure, resolve market, view profile/account, admin content editing, and view position flows.
+- Fix remaining obvious label, focus, keyboard, and semantic structure issues.
+- Add lightweight accessibility checks only after frontend test tooling is declared.
 - Avoid broad visual redesign in the first accessibility slice.
 
 Acceptance criteria:
 
-- Core forms have labels and usable focus behavior.
+- Create-market and change-password forms have labels and usable focus behavior.
 - Navigation can be operated with a keyboard in the primary flows.
 - Market/trading workflows are not blocked for keyboard or screen-reader users by obvious structural issues.
 - Any automated accessibility check added to CI is narrow enough to be stable.
@@ -272,12 +302,15 @@ Primary sources:
 
 Why this is fifth:
 
-The frontend uses multiple charting libraries and a Vite build, but there is no visible performance baseline or PR build artifact check. Performance work should start by measuring the existing bundle before introducing code splitting or replacing libraries.
+The frontend uses multiple charting libraries and a Vite build. A first build-size baseline is now visible through `npm run build:report`; performance work should use that evidence before introducing code splitting or replacing libraries.
 
-Recommended first slice:
+Completed first slice:
 
 - Capture current production build output size.
-- Decide whether a simple bundle-size budget belongs in CI.
+- Print the build-size report in frontend CI as non-blocking evidence.
+
+Remaining cleanup:
+
 - Identify obvious duplicate/heavy dependencies, especially charting libraries.
 - Defer route-based code splitting until after the baseline is measured.
 - Keep any budget permissive at first. Do not let a new budget block unrelated work unexpectedly.
@@ -296,10 +329,10 @@ These are not all defects to fix in one PR. They are seams that should guide sma
 | --- | --- | --- |
 | `AuthContent` | Mixes React context, browser persistence, JWT decoding, login HTTP transport, backend envelope parsing, and auth state policy | Split storage, transport, and auth-state policy behind explicit helpers/adapters. |
 | `AppRoutes` | Embeds access-policy decisions directly in route JSX | Keep short-term, then move route guards toward auth/access decision helpers. |
-| Page/component fetches | Many components import `API_URL` and call `fetch` directly | Move authenticated and envelope-aware requests through an API client boundary. |
+| Page/component fetches | Representative flows use `httpClient`, but many market, profile, stats, and trading components still import `API_URL` and call `fetch` directly | Move authenticated and envelope-aware requests through the API client boundary. |
 | Duplicated `unwrapApiResponse` | Central helper exists, but local copies remain | Use one frontend API response helper unless a route has a documented exception. |
 | Route-coupled hooks | Hooks such as market details mix router detail, auth detail, transport, DTO normalization, and view calculation | Extract transport and normalization seams before broad state-library migration. |
-| Raw error display | Global boundary and component alerts can show raw exception/backend text | Split diagnostic details from public recovery messages. |
+| Raw error display | Global boundary is safe, but component alerts can still show raw exception/backend text | Split diagnostic details from public recovery messages. |
 
 ## Deferred Until Baselines Are Stable
 
@@ -308,23 +341,33 @@ These ideas may be valuable, but they should not be first moves:
 | Deferred area | Source documents | Reason to defer |
 | --- | --- | --- |
 | Full Redux or global state rewrite | [FUTURE/01-long-term-state-platform.md](./FUTURE/01-long-term-state-platform.md) | Auth/API boundaries can be cleaned up first without a large state migration. |
-| Playwright E2E suite | [FUTURE/03-long-term-test-infrastructure.md](./FUTURE/03-long-term-test-infrastructure.md) | Needs basic frontend CI and stable selectors first. |
+| Playwright E2E suite | [FUTURE/03-long-term-test-infrastructure.md](./FUTURE/03-long-term-test-infrastructure.md) | Needs declared unit/component test tooling and stable selectors first. |
 | Full CSP/security-header program | [FUTURE/04-long-term-security-platform.md](./FUTURE/04-long-term-security-platform.md) | CSP is partly deployment/proxy owned and should be coordinated with backend/infra. |
 | i18n and RTL support | [FUTURE/06-long-term-i18n-localization.md](./FUTURE/06-long-term-i18n-localization.md) | Useful product work, but not a current production-risk blocker without localization requirements. |
 | PWA/offline/push | [FUTURE/07-long-term-pwa-offline-platform.md](./FUTURE/07-long-term-pwa-offline-platform.md) | Adds caching and state complexity before test/CI/auth seams are stable. |
 | Product analytics and A/B testing | [FUTURE/08-long-term-analytics-experimentation.md](./FUTURE/08-long-term-analytics-experimentation.md) | Needs a privacy/product decision and stable event taxonomy. |
-| Browser APM dashboards and log shipping | [FUTURE/09-long-term-browser-observability.md](./FUTURE/09-long-term-browser-observability.md) | Should follow backend signal and frontend error-boundary cleanup. |
+| Browser APM dashboards and log shipping | [FUTURE/09-long-term-browser-observability.md](./FUTURE/09-long-term-browser-observability.md) | Safe fallback exists; telemetry vocabulary, privacy, sampling, and ownership still need design. |
 | Automated backup/recovery from frontend docs | [FUTURE/10-long-term-maintenance-automation.md](./FUTURE/10-long-term-maintenance-automation.md) | Mostly backend/infra/data-ops owned, not a frontend baseline concern. |
 
-## Suggested First Five PRs
+## Completed Baseline PR Stack
 
-A practical sequence would be:
+The first frontend baseline stack has now been executed as small stacked PRs:
 
 1. Document frontend published-language and API-contract alignment.
 2. Add frontend CI build check with Node 22, `npm ci`, and `npm run build`.
 3. Sanitize the global error-boundary fallback and define safe public failure copy.
 4. Add auth/API boundary discovery plus a small API client/auth-header seam.
-5. Migrate token/API call sites incrementally, starting with one or two representative flows, then run an accessibility pass on core workflows.
+5. Migrate representative token/API call sites, add build-size reporting, and run an accessibility pass on current core workflows.
+
+## Next Follow-Up Queue
+
+The next frontend work should stay incremental:
+
+1. Finish inventorying direct `API_URL`, `fetch`, `localStorage`, and local `unwrapApiResponse` call sites.
+2. Migrate the highest-risk remaining authenticated calls: profile editing, admin user creation, buy/sell, and resolve.
+3. Add declared frontend test tooling before requiring `npm test` in CI.
+4. Decide whether the build-size report should become an artifact or remain log-only.
+5. Continue accessibility review on buy, sell, resolve, profile/account, and market-detail workflows.
 
 If frontend tests are added before or during this sequence, make that an explicit tooling slice: add `vitest`, `jsdom`, and a reproducible `npm test` script before requiring test execution in CI.
 
@@ -334,6 +377,6 @@ Stop and re-triage if any of these are discovered:
 
 - The frontend cannot build reproducibly on a clean install.
 - The current auth model cannot be made safer without backend session changes.
-- A proposed dependency introduces significant bundle growth before a performance baseline exists.
+- A proposed dependency introduces significant bundle growth without checking the build-size baseline.
 - Accessibility fixes require a design-system decision rather than local component cleanup.
 - Deployment behavior differs materially between local, staging, and production frontend builds.

--- a/README/PRODUCTION-NOTES/FRONTEND/01-state-management.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/01-state-management.md
@@ -3,9 +3,9 @@ title: Frontend State Management and API/Auth Boundary
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Keep active state-management work focused on auth/API adapter seams before any broad Redux or RTK Query platform migration."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the first auth/API adapter seam and representative call-site migrations while keeping broad state platforms deferred."
 status: draft
 ---
 
@@ -13,28 +13,29 @@ status: draft
 
 ## Purpose
 
-This active note covers the near-term frontend state-management work that is actually next for SocialPredict.
+This active note covers the near-term frontend state-management work that is actually next for SocialPredict after the first auth/API adapter seam.
 
-Start with [00-TRIAGE.md](./00-TRIAGE.md). The immediate problem is not the absence of Redux. The immediate problem is that auth state, browser storage, API transport, backend envelope parsing, and route access decisions are mixed across React context, routes, hooks, pages, and components.
+Start with [00-TRIAGE.md](./00-TRIAGE.md). The immediate problem is not the absence of Redux. The first seam now exists, but route access decisions and many non-migrated transport/envelope call sites are still mixed across React context, routes, hooks, pages, and components.
 
 Broad state-platform ideas now live in [FUTURE/01-long-term-state-platform.md](./FUTURE/01-long-term-state-platform.md).
 
 ## Current Baseline
 
 - `AuthContent` now uses the first API/auth adapter seam for login transport, browser persistence, and backend envelope parsing.
-- Some frontend code still reads `localStorage` directly for tokens outside that seam.
+- Browser token compatibility still uses `localStorage`, but token reads/writes should go through `frontend/src/api/authStorage.js` where migrated.
 - Representative create-market, change-password, homepage, and admin homepage flows now use the API/auth adapter; other components and hooks still call `fetch(API_URL...)` directly.
-- `frontend/src/utils/apiResponse.js` exists, but duplicated response-unwrapping helpers remain.
+- `frontend/src/api/httpClient.js` now wraps API URL construction, auth header injection, response parsing, and envelope unwrapping for migrated callers.
+- `frontend/src/utils/apiResponse.js` remains the shared response helper, but duplicated response-unwrapping helpers remain.
 - `AppRoutes` embeds auth/access decisions directly in route JSX.
 
 ## Active Direction
 
-Create small seams before considering a global state library:
+Continue small seam migration before considering a global state library:
 
-1. Inventory token reads/writes and direct `fetch(API_URL...)` call sites.
-2. Define a frontend API/auth adapter for authenticated requests.
-3. Centralize auth header construction.
-4. Centralize backend envelope parsing.
+1. Inventory remaining token reads/writes and direct `fetch(API_URL...)` call sites.
+2. Prefer `apiRequest` or `authenticatedApiRequest` for new or migrated call sites.
+3. Move remaining authenticated profile, trade, resolve, and admin calls behind the adapter in small slices.
+4. Centralize backend envelope parsing by removing local `unwrapApiResponse` copies where practical.
 5. Keep pages and presentational components dependent on hooks/use-case helpers, not raw transport or storage details.
 6. Preserve current runtime behavior while reducing coupling.
 
@@ -49,9 +50,9 @@ The canonical design plan tracks this as:
 
 ## Active Acceptance Criteria
 
-- Token reads are isolated behind an auth storage/API adapter boundary, except documented temporary compatibility call sites.
-- Direct authenticated `fetch` calls are reduced or inventoried for incremental migration.
-- Backend envelope parsing has one preferred helper path.
+- Login/logout token reads are isolated behind an auth storage/API adapter boundary.
+- Remaining direct token reads and direct authenticated `fetch` calls are inventoried for incremental migration.
+- Backend envelope parsing has one preferred helper path for migrated callers.
 - Login, logout, and must-change-password behavior remain unchanged from the user's perspective.
 - Server-managed sessions or memory-only token handling are treated as separate backend/session design work, not slipped into this slice.
 

--- a/README/PRODUCTION-NOTES/FRONTEND/02-performance-optimization.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/02-performance-optimization.md
@@ -3,9 +3,9 @@ title: Frontend Performance Baseline
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Keep active performance work measurement-first and move broader optimization platform ideas into FUTURE."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the first CI-visible build-size report and keep optimization work evidence-led."
 status: draft
 ---
 
@@ -13,28 +13,29 @@ status: draft
 
 ## Purpose
 
-This active note covers the first performance slice: establish evidence before optimizing.
+This active note covers the first performance slice: preserve evidence before optimizing.
 
-Start with [00-TRIAGE.md](./00-TRIAGE.md). The frontend uses Vite and several charting/rendering dependencies, but there is not yet a recorded production build-size baseline or CI-visible bundle evidence.
+Start with [00-TRIAGE.md](./00-TRIAGE.md). The frontend uses Vite and several charting/rendering dependencies. A first build-size baseline is now recorded, but there is not yet a bundle budget, artifact comparison, or dependency-replacement plan.
 
 Broader performance-platform ideas now live in [FUTURE/02-long-term-performance-platform.md](./FUTURE/02-long-term-performance-platform.md).
 
 ## Current Baseline
 
-- Vite production builds exist and frontend PRs now have a dedicated install/build signal.
+- Vite production builds exist and frontend PRs now have a dedicated install/build signal through [frontend.yml](../../../.github/workflows/frontend.yml).
 - `npm run build:report` runs the production build and prints an informational size table from `frontend/build`.
-- The current observed production build report totals roughly `1201 kB` raw and `326 kB` gzip, with the main JavaScript chunk at roughly `1101 kB` raw and `253 kB` gzip.
+- The current observed production build report totals roughly `1201 kB` raw and `326 kB` gzip, with the main JavaScript chunk at roughly `1101 kB` raw and `254 kB` gzip.
+- Vite warns that the main JavaScript chunk is larger than `1000 kB` after minification. This is informational for now, not a merge blocker.
 - Bundle budgets are not defined and should not be strict until this baseline is reviewed against real product goals.
 - Route-level code splitting and dependency replacement have not been justified with current measurements.
 
 ## Active Direction
 
-The first performance pass should be low-risk:
+The next performance pass should be low-risk:
 
-1. Run a clean frontend production build.
-2. Record the current build output and major bundle contributors using `npm run build:report`.
+1. Keep `npm run build:report` green in CI.
+2. Track build-size totals when frontend dependency or charting changes land.
 3. Identify obvious duplicate or heavyweight dependencies, especially charting libraries.
-4. Decide whether a permissive build-size or bundle-report artifact belongs in CI.
+4. Decide whether a permissive build-size artifact or trend comparison belongs in CI.
 5. Avoid blocking unrelated work with strict budgets until the baseline is understood.
 
 ## Design Plan Alignment
@@ -49,6 +50,7 @@ The canonical design plan tracks this under:
 
 - Current production build size is recorded.
 - Frontend CI prints the build-size report after the production build.
+- The current large-chunk warning is acknowledged as informational.
 - Any CI budget starts permissive and evidence-based.
 - Future performance PRs have a baseline to compare against.
 - No route-splitting or dependency-replacement program starts before measurement.

--- a/README/PRODUCTION-NOTES/FRONTEND/03-testing-strategy.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/03-testing-strategy.md
@@ -3,9 +3,9 @@ title: Frontend Verification Baseline
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Focus active testing work on reproducible frontend build feedback before broader test infrastructure."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the dedicated frontend install/build workflow and reset active verification work around declared test tooling."
 status: draft
 ---
 
@@ -13,9 +13,9 @@ status: draft
 
 ## Purpose
 
-This active note defines the first frontend verification target.
+This active note defines the next frontend verification target after the first frontend build workflow.
 
-Start with [00-TRIAGE.md](./00-TRIAGE.md). The repo needs a visible frontend PR signal before larger auth, API, accessibility, or performance changes. Do not claim test coverage until test tooling is declared and reproducible.
+Start with [00-TRIAGE.md](./00-TRIAGE.md). The repo now has a visible frontend PR signal. Do not claim test coverage until test tooling is declared and reproducible.
 
 Long-term testing infrastructure ideas live in [FUTURE/03-long-term-test-infrastructure.md](./FUTURE/03-long-term-test-infrastructure.md).
 
@@ -24,17 +24,18 @@ Long-term testing infrastructure ideas live in [FUTURE/03-long-term-test-infrast
 - One visible Vitest-style test file exists.
 - `frontend/package.json` does not declare a `test` script.
 - `vitest` and `jsdom` are not declared as frontend dependencies.
-- [`.github/workflows/frontend.yml`](../../../.github/workflows/frontend.yml) now provides the first dedicated frontend PR build check.
+- [`.github/workflows/frontend.yml`](../../../.github/workflows/frontend.yml) now provides the first dedicated frontend PR build check and runs `npm run build:report`.
+- GitHub PR checks now fail broken frontend production builds before merge.
 
 ## Active Direction
 
-The first verification slice should add a small, reliable CI signal:
+The next verification slice should add declared test tooling only if it is kept small and reproducible:
 
-1. Use Node 22 unless the project deliberately chooses another supported runtime.
-2. Run `npm ci` from `frontend/`.
-3. Run `npm run build` from `frontend/`.
-4. Add tests to CI only after adding the required test dependencies and an explicit script.
-5. Keep Playwright, coverage gates, visual regression, and accessibility automation out of the first slice.
+1. Keep the Node 22 `npm ci` and `npm run build:report` workflow stable.
+2. Add `vitest`, `jsdom`, and a `test` script before running tests in CI.
+3. Start with a small component/hook test that proves the tooling path.
+4. Add tests to CI only after the command is reproducible from a clean install.
+5. Keep Playwright, coverage gates, visual regression, and broad accessibility automation out of the next slice unless separately justified.
 
 ## Design Plan Alignment
 
@@ -48,6 +49,7 @@ The canonical design plan tracks this as:
 
 - Frontend PRs produce a visible GitHub Actions status.
 - A broken Vite build fails before merge.
+- The frontend build-size report runs as part of the same verification path.
 - Any test command run by CI is declared in `frontend/package.json` and reproducible from a clean install.
 - The CI job stays narrow enough to be stable.
 

--- a/README/PRODUCTION-NOTES/FRONTEND/04-security.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/04-security.md
@@ -3,9 +3,9 @@ title: Frontend Security Baseline
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Keep active frontend security focused on auth/API/session-adjacent seams and move broader platform security into FUTURE."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the first auth/API storage and transport seam while keeping broader session and CSP work deferred."
 status: draft
 ---
 
@@ -13,27 +13,29 @@ status: draft
 
 ## Purpose
 
-This active note covers the near-term frontend security work.
+This active note covers the near-term frontend security work after the first auth/API adapter seam.
 
-Start with [00-TRIAGE.md](./00-TRIAGE.md). The immediate issue is not only that tokens have used browser storage. The broader issue is the scattered auth/API boundary: token reads, authenticated headers, transport, backend envelope parsing, route access checks, and public failure copy are split across frontend layers.
+Start with [00-TRIAGE.md](./00-TRIAGE.md). The immediate issue is not only that tokens use browser storage. The first adapter seam now reduces scattered login/auth transport behavior, but several authenticated calls still construct token headers and failure handling directly.
 
 Broader security-platform work now lives in [FUTURE/04-long-term-security-platform.md](./FUTURE/04-long-term-security-platform.md).
 
 ## Current Baseline
 
 - Login state now uses the first API/auth adapter seam from `AuthContent`.
-- Some code still reads tokens directly from browser storage outside that seam.
+- `authStorage.js` owns login/logout token storage for migrated flows.
+- Some profile, admin, market-detail, and trading code still reads tokens directly from browser storage outside that seam.
 - Create-market, change-password, homepage, and admin homepage flows now use the adapter; other components and hooks can still construct authenticated requests directly.
 - `mustChangePassword` persistence was removed from localStorage in a prior security fix.
+- The global error fallback now avoids raw runtime detail in production UI.
 - CSP, server-managed sessions, and advanced auth flows are not current frontend-only changes.
 
 ## Active Direction
 
-1. Inventory browser token reads/writes.
-2. Inventory authenticated request construction.
-3. Introduce or document the auth/API adapter seam.
+1. Inventory remaining browser token reads/writes.
+2. Inventory remaining authenticated request construction.
+3. Move additional authenticated requests through `authenticatedApiRequest` in small slices.
 4. Keep route access behavior equivalent while extracting helper decisions.
-5. Separate user-safe failure copy from raw diagnostic detail.
+5. Continue separating user-safe failure copy from raw diagnostic detail.
 6. Coordinate server-managed session ideas with backend/API design instead of treating them as a frontend-only refactor.
 
 ## Design Plan Alignment
@@ -47,8 +49,9 @@ The canonical design plan tracks this under:
 
 ## Active Acceptance Criteria
 
-- Token/storage access is isolated or inventoried.
-- Auth header construction has one preferred path.
+- Login/logout token storage access is isolated behind `authStorage`.
+- Remaining token/storage access is inventoried before migration.
+- Auth header construction has one preferred path for migrated callers.
 - Login/logout/must-change-password behavior remains stable.
 - Production UI does not expose raw runtime errors as user-facing security copy.
 - Future server-managed session work is explicitly marked backend/API coordinated.

--- a/README/PRODUCTION-NOTES/FRONTEND/05-accessibility.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/05-accessibility.md
@@ -3,9 +3,9 @@ title: Frontend Accessibility Baseline
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Keep active accessibility work focused on current core workflows and move program-level accessibility into FUTURE."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the first accessibility pass and identify the remaining market, trade, profile, and admin workflow audit."
 status: draft
 ---
 
@@ -13,7 +13,7 @@ status: draft
 
 ## Purpose
 
-This active note covers the first accessibility pass for the current UI.
+This active note covers accessibility work for the current UI after the first baseline pass.
 
 Start with [00-TRIAGE.md](./00-TRIAGE.md). Accessibility is a participant-access contract, not visual polish and not a reason to begin a full component-library rewrite.
 
@@ -21,7 +21,9 @@ Long-term accessibility-program work lives in [FUTURE/05-long-term-accessibility
 
 ## Current Baseline
 
-Create-market, change-password, global fallback, and navigation controls now have a first pass of explicit labels, status/error announcements, and menu button names. The frontend still needs a broader workflow audit.
+Create-market, change-password, global fallback, and navigation controls now have a first pass of explicit labels, status/error announcements, menu button names, and datetime field labeling. Manual review confirmed create-market submission, route guard behavior, change-password layout, and datetime label behavior.
+
+The frontend still needs a broader workflow audit.
 
 The frontend has domain-critical workflows that must be usable without pointer-only or color-only interaction:
 
@@ -35,11 +37,11 @@ The frontend has domain-critical workflows that must be usable without pointer-o
 
 ## Active Direction
 
-1. Audit the core workflows above.
+1. Audit the remaining core workflows above, especially buy, sell, resolve, profile/account, market details, and admin content editing.
 2. Fix obvious missing labels, focus behavior, keyboard traps, semantic structure, and error announcements.
 3. Ensure outcome/state display does not rely on color alone.
-4. Add automated checks only after the frontend CI baseline exists.
-5. Keep the first pass local to existing screens and components.
+4. Add automated checks only after frontend test tooling is declared.
+5. Keep the next pass local to existing screens and components.
 
 ## Design Plan Alignment
 
@@ -51,7 +53,7 @@ The canonical design plan tracks this as:
 
 ## Active Acceptance Criteria
 
-- Core forms have labels and usable focus behavior.
+- Create-market and change-password forms have labels and usable focus behavior.
 - Primary navigation and domain workflows can be operated by keyboard.
 - Screen-reader users are not blocked by obvious missing semantic structure.
 - Error and success messages use status or alert semantics where they are introduced.

--- a/README/PRODUCTION-NOTES/FRONTEND/06-error-handling.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/06-error-handling.md
@@ -3,9 +3,9 @@ title: Frontend Failure Presentation Baseline
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Focus active error-handling work on safe public failure language before reporting or monitoring platform rollout."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the safe global fallback and keep component-level failure translation as the next active work."
 status: draft
 ---
 
@@ -13,26 +13,27 @@ status: draft
 
 ## Purpose
 
-This active note covers the first frontend error-handling slice.
+This active note covers frontend error-handling work after the first global fallback slice.
 
-Start with [00-TRIAGE.md](./00-TRIAGE.md). The app has a global error boundary, but production UI should not render raw exception messages or arbitrary backend/runtime text to participants.
+Start with [00-TRIAGE.md](./00-TRIAGE.md). The app now has a safe global error boundary fallback. Production UI should continue to avoid raw exception messages or arbitrary backend/runtime text to participants.
 
 Browser observability and reporting platform ideas now live in [FUTURE/09-long-term-browser-observability.md](./FUTURE/09-long-term-browser-observability.md).
 
 ## Current Baseline
 
-- `App.jsx` has a global error boundary fallback.
-- The fallback now uses a user-safe production recovery message and limits raw `error.message` detail to development builds.
+- `App.jsx` has a global error boundary fallback with `role="alert"` and a user-safe recovery message.
+- Raw `error.message` detail is limited to development builds inside a collapsed details region.
 - Some components still render or alert raw `err.message` values.
 - Backend envelopes and public reasons are not consistently mapped into frontend recovery copy.
 
 ## Active Direction
 
-1. Make global fallback copy user-safe by default.
+1. Keep global fallback copy user-safe by default.
 2. Keep detailed diagnostics available for development, not production UI.
 3. Distinguish public failure reasons from telemetry/error details.
 4. Map backend envelopes/reasons into stable recovery messages where practical.
-5. Add focused tests after frontend test tooling is declared.
+5. Remove or translate raw component-level `err.message` presentation where it reaches users.
+6. Add focused tests after frontend test tooling is declared.
 
 ## Design Plan Alignment
 
@@ -49,6 +50,7 @@ The canonical design plan tracks this as:
 - Expected business rejections do not read like runtime crashes.
 - Users receive a stable recovery path for unexpected failures.
 - Developers can still diagnose errors locally through development-only details.
+- Remaining raw component-level errors are inventoried before broader failure-translation work.
 
 ## Explicitly Deferred
 

--- a/README/PRODUCTION-NOTES/FRONTEND/10-deployment-cicd.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/10-deployment-cicd.md
@@ -3,9 +3,9 @@ title: Frontend Deployment and CI Baseline
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Keep active deployment guidance focused on frontend PR feedback and move broader platform deployment ideas into FUTURE."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Record the first frontend PR workflow and non-blocking build-size report."
 status: draft
 ---
 
@@ -13,9 +13,9 @@ status: draft
 
 ## Purpose
 
-This active note covers the frontend CI/deployment baseline.
+This active note covers the frontend CI/deployment baseline after the first frontend PR workflow.
 
-Start with [00-TRIAGE.md](./00-TRIAGE.md). The repository already has release/manual Docker image publishing that builds the frontend image. The missing near-term feedback loop is a dedicated frontend PR check.
+Start with [00-TRIAGE.md](./00-TRIAGE.md). The repository already has release/manual Docker image publishing that builds the frontend image. The missing near-term feedback loop was a dedicated frontend PR check; that baseline now exists.
 
 Long-term maintenance and deployment-platform work lives in [FUTURE/10-long-term-maintenance-automation.md](./FUTURE/10-long-term-maintenance-automation.md).
 
@@ -29,11 +29,12 @@ Long-term maintenance and deployment-platform work lives in [FUTURE/10-long-term
 
 ## Active Direction
 
-1. Add a frontend PR job or extend an existing workflow with a frontend job.
+1. Keep the frontend PR job small and stable.
 2. Use Node 22 unless the project deliberately chooses another supported runtime.
 3. Run `npm ci` from `frontend/`.
 4. Run `npm run build:report` from `frontend/` so CI shows the production build and informational size table.
 5. Add tests, accessibility checks, and enforceable bundle budgets only after tooling and thresholds are explicit.
+6. Decide later whether build-size output should become a stored artifact or remain workflow-log evidence.
 
 ## Design Plan Alignment
 
@@ -45,7 +46,7 @@ The canonical design plan tracks this as:
 
 ## Active Acceptance Criteria
 
-- Frontend PRs have a visible GitHub Actions check.
+- Frontend PRs have a visible GitHub Actions check on `main` and stacked `frontend/**` PRs.
 - Broken frontend builds fail before merge.
 - Frontend workflow logs include a non-blocking build-size report.
 - First job is small and stable.

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/00-baseline-triage.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/00-baseline-triage.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Separate deferred frontend platform programs from the active W08/W09 baseline sequence."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Refresh future re-entry criteria after the first frontend CI, API/auth, failure, accessibility, and build-size baseline stack."
 status: draft
 ---
 
@@ -16,7 +16,7 @@ status: draft
 
 This note indexes frontend work that is intentionally not first.
 
-The active frontend sequence lives one directory up in [../00-TRIAGE.md](../00-TRIAGE.md). That triage keeps the immediate queue focused on frontend published language, CI/build feedback, API/auth boundaries, safe failure presentation, accessibility on current workflows, and a measured performance baseline.
+The active frontend sequence lives one directory up in [../00-TRIAGE.md](../00-TRIAGE.md). The first baseline now exists for frontend CI/build feedback, API/auth boundaries, safe failure presentation, accessibility on current workflows, and measured build-size evidence. The immediate queue should now focus on finishing incremental migrations and adding declared test tooling before promoting larger platform programs.
 
 ## Current Active Workstreams
 
@@ -34,16 +34,16 @@ The design plan also records guardrails in:
 
 | Note | Topic | Why future |
 | --- | --- | --- |
-| [01-long-term-state-platform.md](./01-long-term-state-platform.md) | Redux, RTK Query, global store, offline sync | API/auth seams should come first. |
-| [02-long-term-performance-platform.md](./02-long-term-performance-platform.md) | Code splitting, Web Vitals, strict budgets, caching platform | Needs current build/bundle evidence first. |
-| [03-long-term-test-infrastructure.md](./03-long-term-test-infrastructure.md) | Playwright, coverage, visual regression, full accessibility automation | Needs reliable frontend CI and declared test tooling first. |
+| [01-long-term-state-platform.md](./01-long-term-state-platform.md) | Redux, RTK Query, global store, offline sync | First API/auth seam exists, but remaining call-site migration should come first. |
+| [02-long-term-performance-platform.md](./02-long-term-performance-platform.md) | Code splitting, Web Vitals, strict budgets, caching platform | Build-size evidence exists; strict budgets still need product thresholds. |
+| [03-long-term-test-infrastructure.md](./03-long-term-test-infrastructure.md) | Playwright, coverage, visual regression, full accessibility automation | Frontend CI exists, but declared unit/component test tooling should come first. |
 | [04-long-term-security-platform.md](./04-long-term-security-platform.md) | CSP, server-managed sessions, MFA, security monitoring | Requires backend/infra/API coordination. |
-| [05-long-term-accessibility-program.md](./05-long-term-accessibility-program.md) | Full WCAG program and assistive-tech matrix | First pass should fix current core workflows. |
+| [05-long-term-accessibility-program.md](./05-long-term-accessibility-program.md) | Full WCAG program and assistive-tech matrix | First pass has started; broader market/trade/profile workflow audit should come next. |
 | [06-long-term-i18n-localization.md](./06-long-term-i18n-localization.md) | i18n, locale formatting, RTL | Needs product/localization requirements and canonical-language decisions. |
 | [07-long-term-pwa-offline-platform.md](./07-long-term-pwa-offline-platform.md) | Service workers, offline, push, installability | Needs freshness and stale/read-only semantics. |
 | [08-long-term-analytics-experimentation.md](./08-long-term-analytics-experimentation.md) | Product analytics, funnels, A/B tests | Needs event taxonomy and privacy posture. |
-| [09-long-term-browser-observability.md](./09-long-term-browser-observability.md) | Browser APM, replay, dashboards, log shipping | Should follow safe failure presentation and telemetry vocabulary. |
-| [10-long-term-maintenance-automation.md](./10-long-term-maintenance-automation.md) | Dependency automation, regression platform, frontend recovery | Baseline should be package-manager and CI evidence first. |
+| [09-long-term-browser-observability.md](./09-long-term-browser-observability.md) | Browser APM, replay, dashboards, log shipping | Safe fallback exists; telemetry vocabulary and privacy posture still need design. |
+| [10-long-term-maintenance-automation.md](./10-long-term-maintenance-automation.md) | Dependency automation, regression platform, frontend recovery | CI/build-size evidence exists; custom automation needs repeated maintenance pain first. |
 
 ## Decision Framework
 

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/01-long-term-state-platform.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/01-long-term-state-platform.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Move full Redux, RTK Query, persisted store, and offline sync ideas behind the active API/auth adapter baseline."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Keep global state platforms deferred after the first API/auth adapter seam until remaining transport and state orchestration evidence accumulates."
 status: future
 ---
 
@@ -29,13 +29,13 @@ The active state note is [../01-state-management.md](../01-state-management.md).
 
 ## Why Deferred
 
-The current design problem is dependency direction, not store selection. `AuthContent`, direct token reads, direct `fetch(API_URL...)` calls, and duplicated envelope parsing should be cleaned up behind API/auth adapter seams before introducing a global state platform.
+The current design problem is still dependency direction, not store selection. The first `authStorage` and `httpClient` seams exist, but remaining direct token reads, direct `fetch(API_URL...)` calls, and duplicated envelope parsing should be reduced before introducing a global state platform.
 
 ## Entry Criteria
 
 Reconsider this when:
 
-- The API/auth adapter seam is stable.
+- The API/auth adapter seam has covered more than representative flows.
 - Direct transport and token-storage dependencies are reduced or documented.
 - Multiple workflows show repeated state orchestration that local hooks/adapters cannot handle cleanly.
 - Server freshness, auth/session behavior, and failure mapping are stable enough for caching decisions.

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/02-long-term-performance-platform.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/02-long-term-performance-platform.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Move broad performance optimization programs behind the active measurement baseline."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Keep broad performance programs deferred after recording the first build-size baseline."
 status: future
 ---
 
@@ -30,14 +30,14 @@ The active performance note is [../02-performance-optimization.md](../02-perform
 
 ## Why Deferred
 
-The current frontend needs a reproducible build signal and build-size baseline first. Without current measurements, code splitting or dependency replacement is speculative and risks adding complexity without a clear target.
+The current frontend now has a reproducible build signal and first build-size baseline. Code splitting or dependency replacement should still wait for repeated evidence, dependency analysis, or a product threshold rather than reacting to one informational large-chunk warning.
 
 ## Entry Criteria
 
 Reconsider this when:
 
-- Frontend PR build feedback exists.
-- Current production build size is recorded.
+- Frontend PR build feedback remains stable.
+- Current production build size is recorded and tracked across dependency-heavy changes.
 - A repeated performance issue appears in user or deploy evidence.
 - Heavy dependencies are identified with actual bundle data.
 - A permissive budget can be introduced without blocking unrelated work.

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/03-long-term-test-infrastructure.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/03-long-term-test-infrastructure.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Move broad frontend test-platform ideas behind the active install/build verification baseline."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Keep broad test infrastructure deferred after frontend CI until declared unit/component test tooling exists."
 status: future
 ---
 
@@ -14,7 +14,7 @@ status: future
 
 ## Purpose
 
-This note holds frontend test-platform ideas that should follow the first CI/build baseline.
+This note holds frontend test-platform ideas that should follow declared unit/component test tooling, not merely the first CI/build baseline.
 
 The active verification note is [../03-testing-strategy.md](../03-testing-strategy.md).
 
@@ -30,7 +30,7 @@ The active verification note is [../03-testing-strategy.md](../03-testing-strate
 
 ## Why Deferred
 
-The frontend currently lacks a declared `npm test` script and the dependencies needed by the visible Vitest-style test. A stable install/build check should land before broader testing infrastructure.
+The frontend now has a stable install/build check. It still lacks a declared `npm test` script and the dependencies needed by the visible Vitest-style test, so broad testing infrastructure remains premature.
 
 ## Entry Criteria
 

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/04-long-term-security-platform.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/04-long-term-security-platform.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Move broad CSP, session, and security-monitoring work behind the active auth/API boundary cleanup."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Keep CSP, server sessions, and security monitoring deferred after the first frontend auth/API seam."
 status: future
 ---
 
@@ -30,13 +30,13 @@ The active security note is [../04-security.md](../04-security.md).
 
 ## Why Deferred
 
-The immediate frontend security issue is scattered auth/API behavior. CSP, server-managed sessions, and stronger auth cannot be solved correctly by the frontend alone.
+The first frontend auth/API seam now exists, but scattered authenticated call sites remain. CSP, server-managed sessions, and stronger auth still cannot be solved correctly by the frontend alone.
 
 ## Entry Criteria
 
 Reconsider this when:
 
-- The frontend API/auth adapter seam is stable.
+- The frontend API/auth adapter seam is stable across the main authenticated workflows, not only representative flows.
 - Backend session/auth direction is explicit.
 - Deployment/proxy ownership for headers is clarified.
 - Security monitoring has a privacy/redaction and telemetry vocabulary.

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/05-long-term-accessibility-program.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/05-long-term-accessibility-program.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Move program-level accessibility work behind the active core-workflow accessibility baseline."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Keep program-level accessibility deferred after the first form/navigation pass until broader workflow findings are known."
 status: future
 ---
 
@@ -14,7 +14,7 @@ status: future
 
 ## Purpose
 
-This note holds accessibility-program work that should follow fixes to current core workflows.
+This note holds accessibility-program work that should follow the broader current-workflow accessibility audit.
 
 The active accessibility note is [../05-accessibility.md](../05-accessibility.md).
 
@@ -29,14 +29,14 @@ The active accessibility note is [../05-accessibility.md](../05-accessibility.md
 
 ## Why Deferred
 
-The first accessibility pass should make existing core market/account/auth workflows usable. A program-level rollout needs stable components, CI, and the visual-system baseline.
+The first accessibility pass improved create-market, change-password, navigation controls, and status/error announcements. A program-level rollout needs the remaining market, trade, resolve, profile/account, and admin workflows to be audited first.
 
 ## Entry Criteria
 
 Reconsider this when:
 
-- Frontend CI exists.
-- Core workflow accessibility issues have been fixed or documented.
+- Frontend CI and declared frontend test tooling are stable enough to host accessibility checks.
+- Core workflow accessibility issues have been fixed or documented beyond the first form/navigation pass.
 - Shared component contracts exist for common controls.
 - Automated checks can be scoped narrowly enough to avoid noisy failures.
 

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/09-long-term-browser-observability.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/09-long-term-browser-observability.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Move browser APM, replay, and log-shipping work behind safe failure presentation and telemetry vocabulary."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Keep browser APM, replay, and log shipping deferred after safe fallback copy until telemetry vocabulary and privacy policy exist."
 status: future
 ---
 
@@ -14,7 +14,7 @@ status: future
 
 ## Purpose
 
-This note holds browser observability work that should follow safe failure presentation and event vocabulary design.
+This note holds browser observability work that should follow safe failure presentation, event vocabulary design, and privacy/redaction policy.
 
 The active failure-presentation note is [../06-error-handling.md](../06-error-handling.md).
 
@@ -29,13 +29,13 @@ The active failure-presentation note is [../06-error-handling.md](../06-error-ha
 
 ## Why Deferred
 
-Browser observability affects privacy, bundle size, user/session identifiers, sampling, incident workflow, and vendor lock-in. The frontend should first stop exposing raw errors to users and define what telemetry is safe to collect.
+Browser observability affects privacy, bundle size, user/session identifiers, sampling, incident workflow, and vendor lock-in. The frontend now has a safe global fallback, but it still needs a telemetry vocabulary and redaction policy before collecting browser error data.
 
 ## Entry Criteria
 
 Reconsider this when:
 
-- User-safe recovery messages are implemented.
+- User-safe global recovery messages are implemented.
 - The browser telemetry event vocabulary exists.
 - Redaction and forbidden fields are explicit.
 - Operators know what incidents browser telemetry should detect.

--- a/README/PRODUCTION-NOTES/FRONTEND/FUTURE/10-long-term-maintenance-automation.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/FUTURE/10-long-term-maintenance-automation.md
@@ -4,9 +4,9 @@ document_type: production-notes
 domain: frontend
 future: true
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Move custom dependency, regression, and recovery automation behind CI/build/bundle evidence."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Keep custom maintenance automation deferred after CI/build-size evidence until repeated maintenance pain appears."
 status: future
 ---
 
@@ -14,7 +14,7 @@ status: future
 
 ## Purpose
 
-This note holds frontend maintenance automation ideas that should not replace basic CI evidence.
+This note holds frontend maintenance automation ideas that should not replace ordinary CI and package-manager evidence.
 
 The active deployment/CI note is [../10-deployment-cicd.md](../10-deployment-cicd.md).
 
@@ -29,13 +29,13 @@ The active deployment/CI note is [../10-deployment-cicd.md](../10-deployment-cic
 
 ## Why Deferred
 
-The first maintenance baseline should be ordinary package-manager audit/update behavior plus frontend CI/build/bundle evidence. Backup and data recovery are mostly backend, infrastructure, and data-ops concerns unless a concrete static-asset or client-state recovery issue appears.
+The first maintenance baseline now has frontend CI/build/bundle evidence. Backup and data recovery are mostly backend, infrastructure, and data-ops concerns unless a concrete static-asset or client-state recovery issue appears.
 
 ## Entry Criteria
 
 Reconsider this when:
 
-- Frontend install/build CI exists.
+- Frontend install/build CI remains stable over several frontend PRs.
 - Dependency update pain appears repeatedly.
 - Bundle/performance baselines exist.
 - A concrete frontend-owned recovery problem is identified.

--- a/README/PRODUCTION-NOTES/FRONTEND/plan.md
+++ b/README/PRODUCTION-NOTES/FRONTEND/plan.md
@@ -3,9 +3,9 @@ title: Frontend Production Readiness Notes Index
 document_type: production-notes
 domain: frontend
 author: Patrick Delaney
-updated_at: 2026-05-23T00:00:00Z
-updated_at_display: "Saturday, May 23, 2026"
-update_reason: "Replace the broad greenfield plan with an index that separates active frontend baseline notes from FUTURE platform notes."
+updated_at: 2026-05-24T00:00:00Z
+updated_at_display: "Sunday, May 24, 2026"
+update_reason: "Update the index after the first frontend baseline stack landed into the main integration PR."
 status: draft
 ---
 
@@ -16,6 +16,8 @@ status: draft
 Use [00-TRIAGE.md](./00-TRIAGE.md) for the current frontend execution sequence.
 
 The active frontend queue is intentionally narrow. It follows the canonical design plan's `W08 Frontend Experience Boundary and CI Baseline` and `W09 Frontend Visual System Baseline` workstreams. Larger frontend platform programs are preserved under [FUTURE/](./FUTURE/).
+
+As of Sunday, May 24, 2026, the first frontend baseline stack has landed on the integration branch for PR #699: frontend CI, safe global fallback copy, an API/auth adapter seam, representative API migrations, accessibility fixes, and build-size reporting.
 
 ## Active Baseline Notes
 
@@ -46,13 +48,20 @@ The active frontend queue is intentionally narrow. It follows the canonical desi
 | [FUTURE/09-long-term-browser-observability.md](./FUTURE/09-long-term-browser-observability.md) | Browser APM, replay, dashboards, log shipping |
 | [FUTURE/10-long-term-maintenance-automation.md](./FUTURE/10-long-term-maintenance-automation.md) | Dependency automation, regression platform, frontend recovery |
 
-## Current First Five PRs
+## Completed Baseline Stack
 
 1. Document frontend published-language and API-contract alignment.
-2. Add frontend CI build check with Node 22, `npm ci`, and `npm run build`.
+2. Add frontend CI build check with Node 22, `npm ci`, and frontend build execution.
 3. Sanitize the global error-boundary fallback and define safe public failure copy.
 4. Add auth/API boundary discovery plus a small API client/auth-header seam.
-5. Migrate token/API call sites incrementally, then run an accessibility pass on core workflows.
+5. Migrate representative token/API call sites, add build-size reporting, and run an accessibility pass on current core workflows.
+
+## Next Active Work
+
+1. Inventory and migrate remaining direct `API_URL`, `fetch`, `localStorage`, and local `unwrapApiResponse` call sites.
+2. Add declared frontend test tooling before requiring `npm test` in CI.
+3. Continue accessibility review on buy, sell, resolve, profile/account, market-detail, and admin workflows.
+4. Review the build-size report for heavy dependencies before adding budgets or code splitting.
 
 ## Guardrail
 


### PR DESCRIPTION
## Summary

- Refreshes frontend production notes after the PR #699 frontend baseline stack landed.
- Updates active notes `00` through `06`, plus the frontend index and CI/deployment note.
- Updates relevant `FUTURE/` notes so deferred platform work now references the completed CI, API/auth, safe-fallback, accessibility, and build-size baselines.
- Reframes next work around remaining direct `API_URL`/`fetch`/`localStorage` call-site migration, declared test tooling, broader accessibility audits, and evidence-based performance follow-up.

## Validation

- `git diff --check origin/main...HEAD`

## Notes

Documentation only. This follows PR #699, which merged before the docs refresh commit could land on `main`.
