### PR TITLE
Align moderator feature with design-plan boundaries

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/01/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/01/DESIGN.md
@@ -165,7 +165,7 @@ Contract rules:
 Accounting rules:
 
 - Moderator self-trade restrictions must be enforced on buy and sell paths, not only UI controls.
-- Rejected moderator proposals refund the market proposal creation cost to the creator.
+- Rejected moderator proposals refund the market proposal creation cost recorded on that market to the creator.
 - Admin cancellation refunds net unrecovered exposure, not simply gross buys.
 - Cancellation state update and refund ledger entries must commit atomically.
 - Cancellation math that depends on buy/sell history requires Postgres-backed tests.

--- a/README/PRODUCTION-NOTES/FEATURES/01/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/01/PLAN.md
@@ -5,7 +5,7 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-05-24T00:00:00Z
 updated_at_display: "Sunday, May 24, 2026"
-update_reason: "Clarify backend-first sequencing, API contract validation, service ownership, and migration expectations."
+update_reason: "Clarify backend-first sequencing, API contract validation, service ownership, migration expectations, and the proposal-cost persistence alignment fix."
 status: draft
 ---
 
@@ -28,6 +28,7 @@ Agents implementing this feature should mark checklist items as they complete th
 - Touch the bets domain only for trade eligibility guards and cancellation/refund accounting that actually crosses buy/sell paths.
 - Add explicit seams before broad migrations.
 - Keep accounting-sensitive behavior behind transaction-scoped use cases.
+- Persist proposal-cost values on the market so rejection refunds use the recorded proposal accounting value rather than the current runtime config value.
 - Add Postgres-backed tests only where SQLite cannot prove the behavior.
 - Keep every PR independently buildable and reviewable.
 

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -3280,6 +3280,10 @@ components:
           format: date-time
         rejectionReason:
           type: string
+        proposalCost:
+          type: integer
+          format: int64
+          description: Creation cost recorded on the market for proposal refund accounting.
         isResolved:
           type: boolean
         resolutionResult:
@@ -3866,6 +3870,10 @@ components:
           format: date-time
         rejectionReason:
           type: string
+        proposalCost:
+          type: integer
+          format: int64
+          description: Creation cost recorded on the market for proposal refund accounting.
         createdAt:
           type: string
           format: date-time

--- a/backend/handlers/admin/market_review.go
+++ b/backend/handlers/admin/market_review.go
@@ -46,6 +46,7 @@ type marketReviewResponse struct {
 	RejectedBy         string     `json:"rejectedBy,omitempty"`
 	RejectedAt         *time.Time `json:"rejectedAt,omitempty"`
 	RejectionReason    string     `json:"rejectionReason,omitempty"`
+	ProposalCost       int64      `json:"proposalCost,omitempty"`
 	CreatedAt          time.Time  `json:"createdAt,omitempty"`
 	UpdatedAt          time.Time  `json:"updatedAt,omitempty"`
 	ResolutionDateTime time.Time  `json:"resolutionDateTime,omitempty"`
@@ -210,6 +211,7 @@ func marketReviewResponseFromMarket(market *dmarkets.Market) marketReviewRespons
 		RejectedBy:         market.RejectedBy,
 		RejectedAt:         market.RejectedAt,
 		RejectionReason:    market.RejectionReason,
+		ProposalCost:       market.ProposalCost,
 		CreatedAt:          market.CreatedAt,
 		UpdatedAt:          market.UpdatedAt,
 		ResolutionDateTime: market.ResolutionDateTime,

--- a/backend/handlers/markets/createmarket.go
+++ b/backend/handlers/markets/createmarket.go
@@ -221,6 +221,8 @@ func toCreateMarketResponse(market *dmarkets.Market) dto.CreateMarketResponse {
 		YesLabel:           market.YesLabel,
 		NoLabel:            market.NoLabel,
 		Status:             market.Status,
+		LifecycleStatus:    market.LifecycleStatus,
+		ProposalCost:       market.ProposalCost,
 		CreatedAt:          market.CreatedAt,
 	}
 }

--- a/backend/handlers/markets/dto/responses.go
+++ b/backend/handlers/markets/dto/responses.go
@@ -21,6 +21,7 @@ type MarketResponse struct {
 	RejectedBy         string     `json:"rejectedBy,omitempty"`
 	RejectedAt         *time.Time `json:"rejectedAt,omitempty"`
 	RejectionReason    string     `json:"rejectionReason,omitempty"`
+	ProposalCost       int64      `json:"proposalCost,omitempty"`
 	IsResolved         bool       `json:"isResolved"`
 	ResolutionResult   string     `json:"resolutionResult"`
 	CreatedAt          time.Time  `json:"createdAt"`
@@ -38,6 +39,8 @@ type CreateMarketResponse struct {
 	YesLabel           string    `json:"yesLabel"`
 	NoLabel            string    `json:"noLabel"`
 	Status             string    `json:"status"`
+	LifecycleStatus    string    `json:"lifecycleStatus,omitempty"`
+	ProposalCost       int64     `json:"proposalCost,omitempty"`
 	CreatedAt          time.Time `json:"createdAt"`
 }
 

--- a/backend/handlers/markets/overview_helpers.go
+++ b/backend/handlers/markets/overview_helpers.go
@@ -65,6 +65,7 @@ func marketToResponse(market *dmarkets.Market) *dto.MarketResponse {
 		RejectedBy:         market.RejectedBy,
 		RejectedAt:         market.RejectedAt,
 		RejectionReason:    market.RejectionReason,
+		ProposalCost:       market.ProposalCost,
 		IsResolved:         strings.EqualFold(market.Status, "resolved"),
 		ResolutionResult:   market.ResolutionResult,
 		CreatedAt:          market.CreatedAt,

--- a/backend/internal/domain/markets/market_approval.go
+++ b/backend/internal/domain/markets/market_approval.go
@@ -72,8 +72,12 @@ func (s *Service) RejectProposedMarket(ctx context.Context, marketID int64, acto
 	if err := repo.RejectMarket(ctx, marketID, actorUsername, now, market.RejectionReason); err != nil {
 		return nil, err
 	}
-	if s.config.CreateMarketCost > 0 && s.userService != nil {
-		if err := s.userService.ApplyTransaction(ctx, market.CreatorUsername, s.config.CreateMarketCost, users.TransactionRefund); err != nil {
+	refundAmount := market.ProposalCost
+	if refundAmount == 0 {
+		refundAmount = s.config.CreateMarketCost
+	}
+	if refundAmount > 0 && s.userService != nil {
+		if err := s.userService.ApplyTransaction(ctx, market.CreatorUsername, refundAmount, users.TransactionRefund); err != nil {
 			return nil, err
 		}
 	}

--- a/backend/internal/domain/markets/models.go
+++ b/backend/internal/domain/markets/models.go
@@ -26,6 +26,7 @@ type Market struct {
 	RejectedBy              string
 	RejectedAt              *time.Time
 	RejectionReason         string
+	ProposalCost            int64
 	CreatedAt               time.Time
 	UpdatedAt               time.Time
 	InitialProbability      float64

--- a/backend/internal/domain/markets/service_approval_test.go
+++ b/backend/internal/domain/markets/service_approval_test.go
@@ -79,6 +79,7 @@ func TestRejectProposedMarketRefundsCreationCost(t *testing.T) {
 	now := marketsTestTime()
 	market := proposedMarket(80, now)
 	market.CreatorUsername = "moderator"
+	market.ProposalCost = 7
 	repo := newProjectionRepo(withProjectionRepoMarket(market), func(repo *projectionRepo) {
 		repo.rejectMarketFunc = func(context.Context, int64, string, time.Time, string) error {
 			return nil
@@ -100,8 +101,34 @@ func TestRejectProposedMarketRefundsCreationCost(t *testing.T) {
 	if _, err := service.RejectProposedMarket(context.Background(), market.ID, "admin", "duplicate"); err != nil {
 		t.Fatalf("RejectProposedMarket returned error: %v", err)
 	}
-	if refundedUsername != "moderator" || refundedAmount != 10 || refundType != dusers.TransactionRefund {
+	if refundedUsername != "moderator" || refundedAmount != 7 || refundType != dusers.TransactionRefund {
 		t.Fatalf("refund mismatch: username=%q amount=%d type=%q", refundedUsername, refundedAmount, refundType)
+	}
+}
+
+func TestRejectProposedMarketFallsBackToConfigCostForLegacyProposals(t *testing.T) {
+	now := marketsTestTime()
+	market := proposedMarket(81, now)
+	market.CreatorUsername = "moderator"
+	repo := newProjectionRepo(withProjectionRepoMarket(market), func(repo *projectionRepo) {
+		repo.rejectMarketFunc = func(context.Context, int64, string, time.Time, string) error {
+			return nil
+		}
+	})
+	var refundedAmount int64
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.applyTransactionFunc = func(_ context.Context, _ string, amount int64, _ string) error {
+			refundedAmount = amount
+			return nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{CreateMarketCost: 10})
+
+	if _, err := service.RejectProposedMarket(context.Background(), market.ID, "admin", "duplicate"); err != nil {
+		t.Fatalf("RejectProposedMarket returned error: %v", err)
+	}
+	if refundedAmount != 10 {
+		t.Fatalf("fallback refund amount = %d, want 10", refundedAmount)
 	}
 }
 

--- a/backend/internal/domain/markets/service_creation_lifecycle_test.go
+++ b/backend/internal/domain/markets/service_creation_lifecycle_test.go
@@ -60,6 +60,7 @@ func TestCreateMarketModeratorModeCreatesProposedMarketForActiveModerator(t *tes
 	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{
 		GameMode:               "moderator",
 		MarketApprovalRequired: true,
+		CreateMarketCost:       10,
 	})
 
 	market, err := service.CreateMarket(context.Background(), validCreateRequest(now), "moderator")
@@ -68,6 +69,9 @@ func TestCreateMarketModeratorModeCreatesProposedMarketForActiveModerator(t *tes
 	}
 	if market.Status != markets.MarketLifecycleProposed || market.LifecycleStatus != markets.MarketLifecycleProposed {
 		t.Fatalf("expected proposed lifecycle in moderator mode, got %+v", market)
+	}
+	if market.ProposalCost != 10 {
+		t.Fatalf("proposal cost = %d, want 10", market.ProposalCost)
 	}
 	if market.IsTradableAt(now) {
 		t.Fatalf("proposed market must not be tradable")

--- a/backend/internal/domain/markets/service_policies.go
+++ b/backend/internal/domain/markets/service_policies.go
@@ -85,6 +85,7 @@ func (p defaultCreationPolicy) BuildMarketEntity(now time.Time, req MarketCreate
 		NoLabel:            labels.no,
 		Status:             MarketStatusActive,
 		LifecycleStatus:    MarketLifecyclePublished,
+		ProposalCost:       p.config.CreateMarketCost,
 		CreatedAt:          now,
 		UpdatedAt:          now,
 	}

--- a/backend/internal/repository/markets/repository.go
+++ b/backend/internal/repository/markets/repository.go
@@ -497,6 +497,7 @@ func (r *GormRepository) domainToModel(market *dmarkets.Market) models.Market {
 		RejectedBy:              market.RejectedBy,
 		RejectedAt:              market.RejectedAt,
 		RejectionReason:         market.RejectionReason,
+		ProposalCost:            market.ProposalCost,
 		IsResolved:              market.Status == dmarkets.MarketStatusResolved || lifecycle == dmarkets.MarketLifecycleResolved,
 		InitialProbability:      market.InitialProbability,
 	}
@@ -525,6 +526,7 @@ func (r *GormRepository) modelToDomain(dbMarket *models.Market) *dmarkets.Market
 		RejectedBy:              dbMarket.RejectedBy,
 		RejectedAt:              cloneTimePtr(dbMarket.RejectedAt),
 		RejectionReason:         dbMarket.RejectionReason,
+		ProposalCost:            dbMarket.ProposalCost,
 		CreatedAt:               dbMarket.CreatedAt,
 		UpdatedAt:               dbMarket.UpdatedAt,
 		InitialProbability:      dbMarket.InitialProbability,

--- a/backend/internal/repository/markets/repository_test.go
+++ b/backend/internal/repository/markets/repository_test.go
@@ -382,6 +382,7 @@ func TestGormRepositoryApproveAndRejectMarketPersistReviewMetadata(t *testing.T)
 	approveTarget.LifecycleStatus = dmarkets.MarketLifecycleProposed
 	rejectTarget := modelstesting.GenerateMarket(602, creator.Username)
 	rejectTarget.LifecycleStatus = dmarkets.MarketLifecycleProposed
+	rejectTarget.ProposalCost = 7
 	published := modelstesting.GenerateMarket(603, creator.Username)
 	published.LifecycleStatus = dmarkets.MarketLifecyclePublished
 	for _, market := range []*models.Market{&approveTarget, &rejectTarget, &published} {
@@ -410,7 +411,7 @@ func TestGormRepositoryApproveAndRejectMarketPersistReviewMetadata(t *testing.T)
 	if err != nil {
 		t.Fatalf("load rejected market: %v", err)
 	}
-	if rejected.LifecycleStatus != dmarkets.MarketLifecycleRejected || rejected.RejectedBy != "admin" || rejected.RejectionReason != "duplicate" || rejected.RejectedAt == nil || !rejected.RejectedAt.Equal(rejectedAt) {
+	if rejected.LifecycleStatus != dmarkets.MarketLifecycleRejected || rejected.RejectedBy != "admin" || rejected.RejectionReason != "duplicate" || rejected.ProposalCost != 7 || rejected.RejectedAt == nil || !rejected.RejectedAt.Equal(rejectedAt) {
 		t.Fatalf("unexpected rejected market: %+v", rejected)
 	}
 

--- a/backend/migration/migrations/20251117_090000_add_market_proposal_cost.go
+++ b/backend/migration/migrations/20251117_090000_add_market_proposal_cost.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+func MigrateAddMarketProposalCost(db *gorm.DB) error {
+	m := db.Migrator()
+	if !m.HasColumn(&models.Market{}, "ProposalCost") {
+		if err := m.AddColumn(&models.Market{}, "ProposalCost"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	migration.Register("20251117090000", func(db *gorm.DB) error {
+		return MigrateAddMarketProposalCost(db)
+	})
+}

--- a/backend/migration/migrations/20251117_090000_add_market_proposal_cost_test.go
+++ b/backend/migration/migrations/20251117_090000_add_market_proposal_cost_test.go
@@ -1,0 +1,22 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateAddMarketProposalCostAddsProposalCostColumn(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	_ = db.Migrator().DropColumn(&models.Market{}, "ProposalCost")
+
+	if err := migrations.MigrateAddMarketProposalCost(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	if !db.Migrator().HasColumn(&models.Market{}, "ProposalCost") {
+		t.Fatalf("expected ProposalCost column after migration")
+	}
+}

--- a/backend/models/market.go
+++ b/backend/models/market.go
@@ -26,6 +26,7 @@ type Market struct {
 	RejectedBy              string     `json:"rejectedBy,omitempty" gorm:"index"`
 	RejectedAt              *time.Time `json:"rejectedAt,omitempty"`
 	RejectionReason         string     `json:"rejectionReason,omitempty" gorm:"type:text"`
+	ProposalCost            int64      `json:"proposalCost" gorm:"not null;default:0"`
 	CreatorUsername         string     `json:"creatorUsername" gorm:"not null"`
 	Creator                 User       `gorm:"foreignKey:CreatorUsername;references:Username"`
 }

--- a/frontend/src/api/adminUsersApi.js
+++ b/frontend/src/api/adminUsersApi.js
@@ -1,9 +1,4 @@
-import { API_URL } from '../config';
-import {
-  getApiErrorMessage,
-  parseApiResponseText,
-  unwrapApiResponse,
-} from '../utils/apiResponse';
+import { authenticatedApiRequest } from './httpClient';
 
 const adminUserReasonMessages = {
   AUTHORIZATION_DENIED: 'Only admins can manage users.',
@@ -19,28 +14,16 @@ const adminRequest = async ({ path, token, method = 'GET', body }) => {
     throw new Error('Admin authentication token is missing. Please log in again.');
   }
 
-  const response = await fetch(`${API_URL}${path}`, {
+  return authenticatedApiRequest(path, {
     method,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: body ? JSON.stringify(body) : undefined,
+    authToken: token,
+    reasonMessages: adminUserReasonMessages,
+    fallbackMessage: 'Admin user request failed. Please try again.',
   });
-
-  const text = await response.text();
-  const payload = parseApiResponseText(text);
-
-  if (!response.ok) {
-    throw new Error(getApiErrorMessage(
-      response,
-      payload,
-      `Admin user request failed with status ${response.status}.`,
-      adminUserReasonMessages,
-    ));
-  }
-
-  return unwrapApiResponse(payload);
 };
 
 export const listAdminUsers = ({ token, limit = 100, offset = 0 }) => {

--- a/frontend/src/api/httpClient.js
+++ b/frontend/src/api/httpClient.js
@@ -30,10 +30,11 @@ export const apiRequest = async (
     fallbackMessage,
     unwrap = true,
     authenticated = false,
+    authToken,
     ...options
   } = {},
 ) => {
-  const token = authenticated ? authStorage.getToken() : null;
+  const token = authenticated ? (authToken || authStorage.getToken()) : null;
   const response = await fetch(buildUrl(path), {
     ...options,
     headers: mergeHeaders(headers, token),

--- a/frontend/src/api/lifecycleMarketsApi.js
+++ b/frontend/src/api/lifecycleMarketsApi.js
@@ -1,9 +1,4 @@
-import { API_URL } from '../config';
-import {
-  getApiErrorMessage,
-  parseApiResponseText,
-  unwrapApiResponse,
-} from '../utils/apiResponse';
+import { authenticatedApiRequest } from './httpClient';
 
 const lifecycleReasonMessages = {
   AUTHORIZATION_DENIED: 'You are not allowed to view this market queue.',
@@ -16,26 +11,14 @@ const lifecycleRequest = async ({ path, token }) => {
     throw new Error('Authentication token is missing. Please log in again.');
   }
 
-  const response = await fetch(`${API_URL}${path}`, {
+  return authenticatedApiRequest(path, {
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
+    authToken: token,
+    reasonMessages: lifecycleReasonMessages,
+    fallbackMessage: 'Market queue request failed. Please try again.',
   });
-
-  const text = await response.text();
-  const payload = parseApiResponseText(text);
-
-  if (!response.ok) {
-    throw new Error(getApiErrorMessage(
-      response,
-      payload,
-      `Market queue request failed with status ${response.status}.`,
-      lifecycleReasonMessages,
-    ));
-  }
-
-  return unwrapApiResponse(payload);
 };
 
 const buildLifecycleQuery = ({ status, limit = 50, offset = 0 }) => {

--- a/frontend/src/api/moderationApi.js
+++ b/frontend/src/api/moderationApi.js
@@ -1,9 +1,4 @@
-import { API_URL } from '../config';
-import {
-  getApiErrorMessage,
-  parseApiResponseText,
-  unwrapApiResponse,
-} from '../utils/apiResponse';
+import { authenticatedApiRequest } from './httpClient';
 
 const marketReviewReasonMessages = {
   AUTHORIZATION_DENIED: 'Only admins can review proposed markets.',
@@ -22,28 +17,16 @@ const reviewMarket = async ({ marketId, token, action, body }) => {
     throw new Error('Admin authentication token is missing. Please log in again.');
   }
 
-  const response = await fetch(`${API_URL}/v0/admin/markets/${normalizedMarketId}/${action}`, {
+  return authenticatedApiRequest(`/v0/admin/markets/${normalizedMarketId}/${action}`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(body),
+    authToken: token,
+    reasonMessages: marketReviewReasonMessages,
+    fallbackMessage: 'Market review failed. Please try again.',
   });
-
-  const text = await response.text();
-  const payload = parseApiResponseText(text);
-
-  if (!response.ok) {
-    throw new Error(getApiErrorMessage(
-      response,
-      payload,
-      `Market review failed with status ${response.status}.`,
-      marketReviewReasonMessages,
-    ));
-  }
-
-  return unwrapApiResponse(payload);
 };
 
 export const approveProposedMarket = ({ marketId, token }) => reviewMarket({

--- a/frontend/src/components/layouts/profile/MarketLifecycleTable.jsx
+++ b/frontend/src/components/layouts/profile/MarketLifecycleTable.jsx
@@ -57,6 +57,7 @@ const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false,
               </td>
               <td className="px-4 py-4 text-gray-300">{formatDate(market.createdAt)}</td>
               <td className="px-4 py-4 text-xs text-gray-300">
+                {market.proposalCost > 0 && <div>Proposal cost: {market.proposalCost} credits</div>}
                 {market.approvedBy && <div>Approved by {market.approvedBy} at {formatDate(market.approvedAt)}</div>}
                 {market.rejectedBy && <div>Rejected by {market.rejectedBy} at {formatDate(market.rejectedAt)}</div>}
                 {market.rejectionReason && <div className="mt-1 text-rose-200">Reason: {market.rejectionReason}</div>}

--- a/frontend/src/hooks/useFrontendConfig.js
+++ b/frontend/src/hooks/useFrontendConfig.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { API_URL } from '../config';
+import { apiRequest } from '../api/httpClient';
 
 const defaultFrontendConfig = {
   charts: { sigFigs: 2 },
@@ -18,11 +18,9 @@ const useFrontendConfig = () => {
       setLoading(true);
       setError('');
       try {
-        const response = await fetch(`${API_URL}/v0/setup/frontend`);
-        if (!response.ok) {
-          throw new Error(`Frontend config failed with status ${response.status}`);
-        }
-        const data = await response.json();
+        const data = await apiRequest('/v0/setup/frontend', {
+          fallbackMessage: 'Unable to load frontend config.',
+        });
         if (!ignore) {
           setFrontendConfig({
             ...defaultFrontendConfig,

--- a/frontend/src/pages/create/Create.jsx
+++ b/frontend/src/pages/create/Create.jsx
@@ -111,10 +111,11 @@ function Create() {
 
       window.dispatchEvent(new Event(USER_CREDIT_REFRESH_EVENT));
       if (String(responseData.status || '').toLowerCase() === 'proposed') {
+        const proposalCost = responseData.proposalCost ?? marketCreationCost;
         setCreatedMarket(responseData);
         history.push('/profile?tab=Proposed%20Markets', {
           proposedMarket: responseData,
-          marketCreationCost,
+          marketCreationCost: proposalCost,
         });
         return;
       }

--- a/frontend/src/utils/apiResponse.js
+++ b/frontend/src/utils/apiResponse.js
@@ -30,16 +30,16 @@ export const getApiErrorMessage = (
   fallbackMessage,
   reasonMessages = {},
 ) => {
+  if (payload?.reason && reasonMessages[payload.reason]) {
+    return reasonMessages[payload.reason];
+  }
+
   if (payload?.message) {
     return payload.message;
   }
 
   if (payload?.error) {
     return payload.error;
-  }
-
-  if (payload?.reason && reasonMessages[payload.reason]) {
-    return reasonMessages[payload.reason];
   }
 
   if (typeof payload === 'string' && payload.trim()) {


### PR DESCRIPTION
## Summary

Audits the merged moderator-mode stack (#708 through #712, landed through #705) against the canonical design plan at `/Users/patrick/Projects/spec-socialpredict-tasks-auto/lib/design/design-plan.json` and the Evans/Fowler/Martin designer-agent posture in `/Users/patrick/Projects/spec-socialpredict-tasks-auto/.codex/agents`.

Most of the stack aligned with the plan:

- Configuration Service Slice owns the moderator game-mode policy.
- Participant Account Context owns moderator role/status/suspension state.
- Prediction Market Context owns proposal, publication, rejection, and lifecycle terminology.
- API and Auth Contract Boundary exposes stable public `reason` values for moderator-mode rejections.
- Frontend Experience Context presents route guards and review queues without being the authority for backend policy.

This PR fixes the concrete alignment drift found during the audit.

## Changes

- Centralizes new moderator frontend API adapters on `apiRequest` / `authenticatedApiRequest` instead of duplicating API base URL selection, auth header construction, envelope parsing, and reason mapping.
- Makes frontend error mapping prefer known backend public `reason` values over arbitrary backend message text when a caller supplies `reasonMessages`.
- Persists `proposalCost` on markets at creation time so moderator proposal rejection refunds use the recorded market accounting value instead of the current runtime config value.
- Adds a migration and migration test for `markets.proposal_cost`.
- Surfaces `proposalCost` in market/admin review API responses and OpenAPI docs.
- Keeps a compatibility fallback to configured create-market cost for legacy proposed markets that predate the new column.
- Updates the moderator feature design/plan notes to clarify recorded proposal-cost refund behavior.

## Validation

- `cd backend && go test ./...`
- `cd frontend && npm run build`
- `git diff --check`
- Conflict-marker scan over README/backend/frontend/.github excluding vendored Swagger UI assets
