### PR TITLE
Add guarded load testing harness and release dossier plan

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
@@ -87,6 +87,8 @@ Load testing must be opt-in and environment-scoped.
 Required safety posture:
 
 - Load-test seed/reset commands must refuse to run unless an environment flag such as `LOAD_TEST_ENABLED=true` is present.
+- `./SocialPredict load seed` is the current seed/reset entrypoint; it writes generated credentials and market IDs under `loadtest/fixtures/`.
+- A representative staging seed command is `LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 50000 --moderators 100 --markets 1000 --hot-markets 10 --reset`.
 - The default production path must not expose test seeding or reset endpoints.
 - Fictional users should authenticate through the normal login path unless a short-lived staging-only fixture export is explicitly implemented.
 - Any admin or bootstrap token should be used only for seed/reset orchestration, not for placing bets.

--- a/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
@@ -1,0 +1,229 @@
+---
+title: Load Testing And Release Dossier Evidence
+document_type: production-notes
+domain: features
+author: Patrick Delaney
+updated_at: 2026-05-28T00:00:00Z
+updated_at_display: "Thursday, May 28, 2026"
+update_reason: "Start the feature spec for staging load testing, hot-market betting simulations, and release dossier evidence capture."
+status: draft
+---
+
+# Load Testing And Release Dossier Evidence
+
+## Purpose
+
+SocialPredict needs evidence about how much market and betting traffic a given deployment can handle before a release is treated as production-ready for larger public use.
+
+This feature defines a safe load-testing program for staging and future production-like environments. It focuses on realistic API traffic, database contention, hot-market betting bursts, and a release dossier artifact that records what was tested and what the result means.
+
+The release dossier target is compatible with the release dossier dashboard concept at <https://pwdel.github.io/socialpredict-release-dossier-dashboard/>.
+
+## Feature Artifact Map
+
+This directory keeps load-testing work together:
+
+- [04-load-testing.md](./04-load-testing.md): feature overview, product/ops goals, expected scenarios, and acceptance criteria.
+- [DESIGN.md](./DESIGN.md): architecture and boundary design aligned with the canonical design plan.
+- [PLAN.md](./PLAN.md): implementation sequencing and PR slicing plan derived from the design.
+
+## Product And Operations Questions
+
+The first load-testing program should answer these questions:
+
+- Given a specific DigitalOcean deployment size, how many normal users can browse, inspect markets, and place bets before latency or error rate becomes unacceptable?
+- How does the system behave with 100 moderators, 1,000 created markets, and 50,000 fictional users?
+- How does the system behave when 25-50% of the user base concentrates activity on one or a few hot markets?
+- Does the app fail safely under load, or do errors create financial/accounting ambiguity?
+- Which bottleneck appears first: app CPU, database CPU, database locks, disk I/O, memory, connection pool exhaustion, reverse proxy limits, rate limits, or application code?
+- What deployment size or topology is needed for the next release target?
+
+## Load Model
+
+Baseline population target:
+
+- 100 fictional moderators.
+- 1,000 fictional markets.
+- 50,000 fictional regular users.
+- 10 hot markets.
+- 1 extreme hot market.
+
+Traffic target examples:
+
+| Scenario | Example Shape | Approximate Write Load |
+| --- | --- | --- |
+| Wide one-hour activity | 50,000 users place one bet over one hour | 14 bets/second |
+| Hot-minute activity | 25,000 users place one bet over one minute | 417 bets/second |
+| Hot-ten-second burst | 25,000 users place one bet over ten seconds | 2,500 bets/second |
+| Sub-second panic burst | thousands of users hit one market at once | must be measured, not guessed |
+
+These numbers are intentionally directional. The implementation should make scenario parameters configurable rather than hard-code one traffic pattern.
+
+## Scope
+
+In scope:
+
+- Staging-first load generation against normal public and authenticated API routes.
+- Safe fictional users and markets created only in environments explicitly marked for load testing.
+- Normal login and bearer-token behavior for test users.
+- Betting load through `/v0/bet` using normal application rules.
+- Read load against public market, position, credit, leaderboard, health, readiness, and operational-status routes.
+- Dossier output that records environment, scenario, rates, latency, error rate, and infrastructure observations.
+- Manual or scripted DigitalOcean metric capture for CPU, memory, disk, and network observations.
+
+Out of scope for the first feature slice:
+
+- Running destructive load tests against production.
+- A permanent god key that bypasses normal application behavior.
+- A new authorization model for load testing.
+- A custom performance platform before k6 or another standard tool proves insufficient.
+- Solving scaling problems before the first evidence pass shows the bottleneck.
+- Adding Redis, queues, read replicas, or caching in the same PR as the test harness.
+
+## Safety Rules
+
+Load testing must be opt-in and environment-scoped.
+
+Required safety posture:
+
+- Load-test seed/reset commands must refuse to run unless an environment flag such as `LOAD_TEST_ENABLED=true` is present.
+- The default production path must not expose test seeding or reset endpoints.
+- Fictional users should authenticate through the normal login path unless a short-lived staging-only fixture export is explicitly implemented.
+- Any admin or bootstrap token should be used only for seed/reset orchestration, not for placing bets.
+- Tests should target staging or a dedicated load-test droplet, not production.
+- Test data should be easy to wipe and should not be mixed with durable production data.
+
+## API Surface Under Test
+
+Initial API surfaces:
+
+- `GET /health`
+- `GET /readyz`
+- `GET /ops/status`
+- `GET /openapi.yaml`
+- `GET /swagger/`
+- `POST /v0/login`
+- `GET /v0/setup/frontend`
+- `GET /v0/markets`
+- `GET /v0/markets/{id}`
+- `GET /v0/markets/{id}/projection`
+- `POST /v0/markets`
+- `POST /v0/bet`
+- `GET /v0/markets/bets/{marketId}`
+- `GET /v0/markets/positions/{marketId}`
+- `GET /v0/usercredit/{username}`
+- `GET /v0/portfolio/{username}`
+- `GET /v0/global/leaderboard`
+
+The betting path is the first critical write path because it touches authentication, market state, account balance, transaction boundaries, and bet persistence.
+
+## Tooling Direction
+
+The first implementation should prefer `k6` for API load generation because it supports scenario-based request-rate testing, JSON result output, and scripting realistic HTTP flows from a local Mac or separate load-generator host.
+
+k6 is not an in-server test runner for this feature. It is the external traffic generator. For end-to-end evidence, k6 should call the public staging URL, such as `https://kconfs.com`, through the same DNS, TLS, reverse proxy, backend, and Postgres path a real user would use.
+
+Valid runner locations:
+
+- a developer Mac for smoke and moderate tests
+- a separate DigitalOcean load-generator droplet for heavier tests
+- a GitHub workflow only for very small smoke checks, not heavy load
+
+Avoid running the load generator on the same app/database droplet when measuring capacity. That would spend CPU, memory, disk, and network on the machine being measured and make the result misleading.
+
+Locust can be considered later if Python-based user-behavior modeling becomes more valuable than k6's simpler API-load workflow.
+
+Recommended first tool layout:
+
+```text
+tools/loadtest/
+  README.md
+  k6/
+    smoke.js
+    baseline.js
+    hot-market-burst.js
+    soak.js
+  fixtures/
+    .gitkeep
+  results/
+    .gitignore
+  dossier/
+    schema.example.json
+```
+
+The tool should run from a developer machine or from a separate DigitalOcean load-generator droplet. The load generator should not run on the same droplet as the app/database when measuring server capacity, because it would contaminate CPU/network results.
+
+## Release Dossier Evidence
+
+Each meaningful test run should produce a dossier artifact.
+
+Minimum dossier fields:
+
+```json
+{
+  "release": "vX.Y.Z or commit SHA",
+  "environment": "staging",
+  "baseUrl": "https://kconfs.com",
+  "appTopology": "single droplet app+postgres",
+  "databaseTopology": "local docker postgres",
+  "dropletSize": "example: 2 vCPU / 4 GB",
+  "scenario": "hot-market-burst",
+  "seed": {
+    "users": 50000,
+    "moderators": 100,
+    "markets": 1000,
+    "hotMarkets": 10
+  },
+  "traffic": {
+    "duration": "60s",
+    "targetBetRatePerSecond": 1000,
+    "readWriteMix": "70/30"
+  },
+  "results": {
+    "requestsTotal": 0,
+    "betsAttempted": 0,
+    "betsSucceeded": 0,
+    "errorRate": 0,
+    "httpReqDurationP95Ms": 0,
+    "httpReqDurationP99Ms": 0
+  },
+  "infrastructureObservations": {
+    "appCpuPeakPercent": null,
+    "memoryPeakPercent": null,
+    "diskIoNotes": "",
+    "dbConnectionNotes": ""
+  },
+  "decision": "pass | fail | inconclusive",
+  "knownRisks": []
+}
+```
+
+The dossier should be committed only when it is intended as a durable release artifact. Raw high-volume result files should usually stay out of git unless they are summarized.
+
+## Observability Baseline
+
+Minimum first-pass observations:
+
+- k6 request count, throughput, error rate, p50, p95, and p99 latency.
+- `/health`, `/readyz`, and `/ops/status` before, during, and after the test.
+- DigitalOcean CPU, memory, disk I/O, and network graphs for the droplet.
+- Basic Linux checks during load, such as `docker stats`, `df -h`, and selected Postgres connection views when safe.
+
+Future observations may include:
+
+- Postgres slow-query logs.
+- `pg_stat_activity` and `pg_stat_statements` snapshots.
+- App-level request metrics.
+- Dedicated dashboards.
+- Load-generator resource telemetry.
+
+## Acceptance Criteria
+
+The first load-testing feature is acceptable when:
+
+- There is a documented, staging-safe way to seed fictional users and markets.
+- There is a documented, repeatable way to run smoke, baseline, hot-market burst, and soak tests.
+- The load generator uses normal API behavior for betting traffic.
+- Results can be summarized into a release dossier artifact.
+- The feature identifies bottlenecks without prematurely changing architecture.
+- Operators can clearly tell whether a test is safe for staging, unsafe for production, or intended for a dedicated load-test environment.

--- a/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
@@ -151,6 +151,15 @@ tools/loadtest/
     schema.example.json
 ```
 
+This should start inside the SocialPredict repository. A separate CLI repository is unnecessary until the load-test harness needs its own release cycle or is reused across multiple projects.
+
+Runner authentication is split by concern:
+
+- k6 uses normal SocialPredict fake-user credentials and `POST /v0/login` for API traffic.
+- HostOps or SSH can be used separately for host observation.
+- `doctl` can be used separately in the future to provision a load-generator droplet.
+- DigitalOcean credentials are never used to bypass SocialPredict betting authorization.
+
 The tool should run from a developer machine or from a separate DigitalOcean load-generator droplet. The load generator should not run on the same droplet as the app/database when measuring server capacity, because it would contaminate CPU/network results.
 
 ## Release Dossier Evidence

--- a/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
@@ -136,8 +136,10 @@ Locust can be considered later if Python-based user-behavior modeling becomes mo
 Recommended first tool layout:
 
 ```text
-tools/loadtest/
+loadtest/
   README.md
+  cli/
+    README.md
   k6/
     smoke.js
     baseline.js
@@ -149,9 +151,22 @@ tools/loadtest/
     .gitignore
   dossier/
     schema.example.json
+    runs/
+      .gitignore
+  hostops/
+    README.md
 ```
 
-This should start inside the SocialPredict repository. A separate CLI repository is unnecessary until the load-test harness needs its own release cycle or is reused across multiple projects.
+This should start inside the SocialPredict repository only to keep early development close to the API, setup, and release-dossier contracts it depends on. The top-level `loadtest/` directory should be treated as a portable tool boundary so it can move to a separate repository later if the harness needs its own release cycle or is reused across multiple projects.
+
+Directory intent:
+
+- `loadtest/cli`: wrapper commands for seeding, running scenarios, and generating dossier summaries.
+- `loadtest/k6`: k6 scenario scripts.
+- `loadtest/fixtures`: generated users, credentials, token caches, and market ID files; ignored by default.
+- `loadtest/results`: raw k6 outputs; ignored by default unless explicitly promoted.
+- `loadtest/dossier`: compact release dossier schema and curated run summaries.
+- `loadtest/hostops`: notes or captured observations from HostOps, SSH, DigitalOcean metrics, and safe host commands.
 
 Runner authentication is split by concern:
 

--- a/README/PRODUCTION-NOTES/FEATURES/04/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/DESIGN.md
@@ -112,6 +112,37 @@ HostOps is for host and infrastructure operations: SSH, environment inspection, 
 
 Load testing is application/API verification. It should live under SocialPredict tooling or a dedicated `tools/loadtest` tree. HostOps can help an operator connect to a host for observation, but it should not own k6 scenarios or application seed semantics.
 
+### Keep The First CLI In This Repository
+
+The first load-test CLI should live in this repository, not a separate repository.
+
+Reasons:
+
+- The CLI depends on this app's OpenAPI contract, route names, fixture semantics, and release dossier shape.
+- Reviewing load-test scripts beside the API they exercise makes contract drift easier to catch.
+- Keeping the first implementation under `tools/loadtest` avoids a second repository before the harness proves it needs independent release/versioning.
+
+A separate repository can be reconsidered later if the load generator becomes a reusable product, needs a separate release cycle, or must be shared across multiple applications.
+
+### Runner Authentication And Operation
+
+The runner machine authenticates in two different ways depending on what it is doing.
+
+For application traffic:
+
+- k6 authenticates by logging in as fictional users through `POST /v0/login`.
+- k6 stores normal bearer tokens in memory for the test run.
+- k6 places bets through `/v0/bet` using those normal bearer tokens.
+- k6 does not need DigitalOcean credentials for normal API traffic.
+
+For host observation or load-generator setup:
+
+- an operator may use HostOps or SSH to inspect the staging host
+- an operator may use `doctl` to create a separate load-generator droplet in the future
+- DigitalOcean credentials are not part of the betting API path
+
+This preserves a clean split: DigitalOcean auth operates infrastructure, while SocialPredict fake-user auth exercises the product API.
+
 ### Keep Dossier Output Small And Durable
 
 Raw load-test output can be large. The release dossier should be a summarized evidence artifact with links or paths to raw results when needed.

--- a/README/PRODUCTION-NOTES/FEATURES/04/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/DESIGN.md
@@ -110,19 +110,34 @@ A staging-only bootstrap token may be used to create/reset fixtures, but not to 
 
 HostOps is for host and infrastructure operations: SSH, environment inspection, log access, and future cloud orchestration.
 
-Load testing is application/API verification. It should live under SocialPredict tooling or a dedicated `tools/loadtest` tree. HostOps can help an operator connect to a host for observation, but it should not own k6 scenarios or application seed semantics.
+Load testing is application/API verification. It should live in a top-level `loadtest/` tree while the harness is young. HostOps can help an operator connect to a host for observation, but it should not own k6 scenarios or application seed semantics.
 
 ### Keep The First CLI In This Repository
 
-The first load-test CLI should live in this repository, not a separate repository.
+The first load-test CLI should live in this repository, not a separate repository, because early development needs tight feedback with SocialPredict's API and fixture behavior.
 
 Reasons:
 
 - The CLI depends on this app's OpenAPI contract, route names, fixture semantics, and release dossier shape.
 - Reviewing load-test scripts beside the API they exercise makes contract drift easier to catch.
-- Keeping the first implementation under `tools/loadtest` avoids a second repository before the harness proves it needs independent release/versioning.
+- Keeping the first implementation under `loadtest/` avoids a second repository before the harness proves it needs independent release/versioning.
+- A top-level `loadtest/` directory is easier to move later than scripts scattered through app, backend, or HostOps directories.
 
 A separate repository can be reconsidered later if the load generator becomes a reusable product, needs a separate release cycle, or must be shared across multiple applications.
+
+Proposed portable boundary:
+
+```text
+loadtest/
+  cli/       wrapper commands for seed/run/dossier workflows
+  k6/        API scenario scripts
+  fixtures/ generated local fixture files, ignored by default
+  results/  raw k6 outputs, ignored by default
+  dossier/  compact release dossier schema and curated summaries
+  hostops/  host observation notes and captured metrics
+```
+
+`loadtest/hostops` should store observations gathered via HostOps, SSH, DigitalOcean screenshots/exports, or safe Linux commands. It should not become HostOps itself.
 
 ### Runner Authentication And Operation
 

--- a/README/PRODUCTION-NOTES/FEATURES/04/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/DESIGN.md
@@ -1,0 +1,227 @@
+---
+title: Load Testing And Release Dossier Design
+document_type: feature-design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-05-28T00:00:00Z
+updated_at_display: "Thursday, May 28, 2026"
+update_reason: "Add architecture and boundary design for load testing, hot-market betting simulations, and release dossier evidence capture."
+status: draft
+---
+
+# Load Testing And Release Dossier Design
+
+## Purpose
+
+This document translates [04-load-testing.md](./04-load-testing.md) into an architecture and boundary design before implementation begins.
+
+It is not the implementation plan. The implementation sequence lives in [PLAN.md](./PLAN.md).
+
+## Design Inputs
+
+Primary inputs:
+
+- [04-load-testing.md](./04-load-testing.md)
+- Canonical design plan: `spec-socialpredict-tasks-auto/lib/design/design-plan.json`
+- Current backend API source of truth: `backend/docs/openapi.yaml`
+- Release dossier dashboard concept: <https://pwdel.github.io/socialpredict-release-dossier-dashboard/>
+
+The canonical design plan remains the repository-level design source of truth. This feature design must conform to it rather than create a competing architecture.
+
+## Designer Lens Review
+
+Evans/domain lens:
+
+- Load testing should use SocialPredict language: users, moderators, markets, hot markets, bets, positions, balances, readiness, release evidence, and deployment topology.
+- The feature should distinguish test orchestration from application policy. Fictional users and markets are setup data, not a new production domain.
+- A release dossier is an operational evidence artifact, not an analytics product feature.
+
+Fowler/evolutionary lens:
+
+- Start with a simple external load generator and JSON evidence before introducing a performance platform.
+- Keep test scenarios parameterized and repeatable so results can evolve across droplet sizes and database topologies.
+- Optimize only from measured evidence. Do not add Redis, queues, replicas, or caching before the first bottleneck is known.
+
+Martin/clean-architecture lens:
+
+- Application load tests should call public/API boundaries rather than reach directly into repositories.
+- Seed/reset helpers must be isolated from normal production behavior and guarded by runtime configuration.
+- Load-test implementation should not introduce god-mode application paths that bypass the real auth, account, or betting flows.
+
+## Problem Framing
+
+SocialPredict's most important high-load risk is not generic page traffic. It is a concentrated betting event where many authenticated users place bets on the same market or small set of markets inside a short time window.
+
+This creates pressure on:
+
+- HTTP request handling.
+- JWT/auth validation.
+- User balance mutation.
+- Bet insertion.
+- Market state checks.
+- Postgres transaction and row-lock behavior.
+- Read-model fan-out for positions, market details, and leaderboards.
+- Docker host CPU, memory, disk I/O, and network capacity.
+
+The design must produce evidence about this pressure without making production less safe.
+
+## Bounded Context Alignment
+
+| Design-plan boundary | Load-testing ownership |
+| --- | --- |
+| Release and Deployment Control | Owns when load tests are run, which environment is targeted, and how evidence is attached to release decisions. |
+| API and Auth Contract Boundary | Owns the route-visible contracts used by load tests and OpenAPI alignment for generated clients or scripts. |
+| Runtime Bootstrap and Infrastructure | Owns `LOAD_TEST_ENABLED`, deployment topology notes, readiness, DB pool settings, and safe startup behavior. |
+| Prediction Market Context | Owns market creation, publication state, hot-market selection, and market visibility rules exercised by tests. |
+| Betting and Position Ledger Context | Owns buy/sell correctness, transaction boundaries, account balance effects, and contention behavior under load. |
+| Participant Account Context | Owns fictional user credentials, balances, password-change state, and normal login behavior used by tests. |
+| Observability Boundary | Owns logs, request correlation, health/readiness/status observations, and future metric export decisions. |
+| Documentation and Release Evidence | Owns release dossier shape, run notes, result summaries, and operator guidance. |
+
+## Context Map
+
+The load-testing feature should sit outside the app runtime for traffic generation and inside guarded app/runtime seams only for seed/reset support.
+
+- External load generator: runs k6 scripts from a Mac or separate load-generator host and calls the public staging URL through DNS, TLS, ingress/reverse proxy, backend, and database.
+- Seed/reset command: creates fictional users, moderators, and markets in staging only.
+- API traffic: uses normal HTTP routes and bearer tokens.
+- Dossier builder: summarizes k6 output plus environment metadata into a stable JSON artifact.
+- Operator documentation: explains safe targets, commands, expected outputs, and how to read results.
+
+Running k6 on the app/database droplet is valid only for tiny local smoke checks. It is not valid capacity evidence because the load generator would compete with the app and Postgres for the same host resources.
+
+## Boundary Decisions
+
+### Do Not Use A Betting God Key
+
+A god key would invalidate the test because it would skip or distort the real traffic path.
+
+Betting load must use normal application behavior:
+
+- `POST /v0/login` or pre-generated normal user credentials.
+- Bearer token auth.
+- Normal `/v0/bet` payloads.
+- Normal user balances and market state rules.
+- Normal failure reasons and rate limits unless the test explicitly evaluates rate-limit behavior.
+
+A staging-only bootstrap token may be used to create/reset fixtures, but not to place bets.
+
+### Keep HostOps Separate
+
+HostOps is for host and infrastructure operations: SSH, environment inspection, log access, and future cloud orchestration.
+
+Load testing is application/API verification. It should live under SocialPredict tooling or a dedicated `tools/loadtest` tree. HostOps can help an operator connect to a host for observation, but it should not own k6 scenarios or application seed semantics.
+
+### Keep Dossier Output Small And Durable
+
+Raw load-test output can be large. The release dossier should be a summarized evidence artifact with links or paths to raw results when needed.
+
+Durable dossier fields should be stable enough for the dashboard to render:
+
+- release or commit SHA
+- environment
+- topology
+- seed counts
+- scenario
+- latency and error metrics
+- infrastructure observations
+- decision
+- known risks
+
+### Keep Database Truth Explicit
+
+Postgres is the system of record for betting and account state. Load tests should treat database behavior as central evidence, not an implementation detail.
+
+The first feature should measure before redesigning. Later architecture decisions might include larger droplets, app/database separation, managed Postgres, connection pool tuning, query/index optimization, cached read models, or event-driven projections. Those are follow-up decisions, not prerequisites for the first test harness.
+
+## Scenario Design
+
+Initial scenario families:
+
+| Scenario | Purpose | Primary risk exposed |
+| --- | --- | --- |
+| Smoke | Prove credentials, market IDs, and API paths work. | Broken setup or auth. |
+| Baseline browse | Measure normal read behavior across market lists/details/portfolio. | Read latency and fan-out. |
+| Baseline bet | Measure low-to-moderate write traffic. | Basic transaction throughput. |
+| Hot-market burst | Concentrate bet writes on one market. | DB locks, connection pool pressure, latency spikes. |
+| Mixed hot markets | Spread bursts across several markets. | Whether contention is market-local or global. |
+| Soak | Keep steady traffic for a longer period. | Memory, disk, logs, and slow degradation. |
+
+## Seed Design
+
+Seed/reset should support:
+
+- deterministic username prefixes
+- deterministic password convention for fictional users
+- configurable user counts
+- configurable moderator counts
+- configurable market counts
+- configurable hot-market selection
+- option to export a credential/token fixture for load generation
+- clear refusal outside `LOAD_TEST_ENABLED=true`
+
+Seeded users should have `must_change_password=false` so they can place bets without frontend intervention. Passwords must be fictional and environment-specific.
+
+## Metrics And Thresholds
+
+Initial metrics:
+
+- HTTP request rate.
+- HTTP error rate.
+- bet success count.
+- bet rejection count by status/reason.
+- p50/p95/p99 request duration.
+- max request duration.
+- dropped iterations or client-side failures.
+- `/health`, `/readyz`, and `/ops/status` status before/during/after.
+- app CPU, memory, disk I/O, network.
+- Postgres connection count and lock notes when available.
+
+Initial pass/fail gates should be intentionally conservative and adjustable:
+
+- smoke scenario: zero unexpected failures.
+- baseline scenario: p95 below a chosen target and low error rate.
+- hot-market scenario: no data corruption or accounting ambiguity; latency/error thresholds can be exploratory until a capacity target is chosen.
+- soak scenario: no sustained memory/disk growth that threatens the host.
+
+## Deployment Topology Notes
+
+The dossier must record the topology because results are meaningless without it.
+
+Examples:
+
+- single DigitalOcean droplet running app, frontend, Traefik/nginx, and local Docker Postgres
+- app droplet plus managed Postgres
+- staging droplet size
+- database volume type
+- Docker image tags or commit SHA
+- DB pool settings
+- load-generator location and machine type
+
+The load generator should normally run outside the target host so it does not steal CPU from the system under test.
+
+## Failure Modes To Preserve
+
+A load test failure is useful if it is truthful.
+
+The implementation should preserve evidence for:
+
+- HTTP 401/403 auth failures.
+- HTTP 409 market-state failures.
+- HTTP 422 insufficient-balance failures.
+- HTTP 429 rate-limit failures.
+- HTTP 5xx server failures.
+- timeouts.
+- database connection exhaustion.
+- readiness failure during load.
+
+Do not hide these under a generic success/failure counter. The dossier should summarize failure categories.
+
+## Open Questions
+
+- What exact latency/error SLO should gate a release for staging and model-office/prod?
+- Should load-test seed/reset live in `./SocialPredict`, a Go command under `backend/cmd`, or both?
+- Should the first load-generator scripts store user credentials or obtain tokens dynamically per run?
+- Should DigitalOcean metrics be manually recorded in the first version or collected through API later?
+- When should Postgres-specific telemetry become a required part of the dossier?
+- Should load tests run only manually, or should a small smoke load test be available as a workflow dispatch?

--- a/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
@@ -52,19 +52,19 @@ The first implementation should keep the CLI and k6 scripts in this repository u
 - [x] 01. Feature artifact and design alignment
 - [ ] 02. Staging safety and environment gates
 - [ ] 03. Seed/reset fixture command
-- [ ] 04. Credential/token fixture export
-- [ ] 05. k6 smoke scenario
-- [ ] 06. k6 baseline browse and bet scenarios
-- [ ] 07. k6 hot-market burst scenario
-- [ ] 08. Soak scenario and failure classification
-- [ ] 09. Dossier artifact schema and summarizer
+- [x] 04. Credential/token fixture export scaffold
+- [x] 05. k6 smoke scenario scaffold
+- [x] 06. k6 baseline browse and bet scenario scaffold
+- [x] 07. k6 hot-market burst scenario scaffold
+- [x] 08. Soak scenario and failure classification scaffold
+- [x] 09. Dossier artifact schema and summarizer scaffold
 - [ ] 10. Operator runbook and first staging evidence capture
 
 ## Implementation Checklist
 
 ### 01. Feature Artifact And Design Alignment
 
-Status: complete for this documentation PR.
+Status: complete for the feature docs and initial loadtest harness scaffold.
 
 Checklist:
 
@@ -73,7 +73,7 @@ Checklist:
 - [x] Add `DESIGN.md` aligned with canonical runtime, API, betting, database, observability, and release boundaries.
 - [x] Add `PLAN.md` as an agent-usable implementation sequence.
 - [x] Update production-note index links.
-- [x] Keep the first PR documentation-only.
+- [x] Keep the first PR documentation-first, then add an initial portable harness scaffold in the same branch.
 
 Exit criteria:
 
@@ -139,26 +139,26 @@ Validation:
 
 Service ownership: API and Auth Contract Boundary plus Participant Account Context.
 
-Status: planned.
+Status: scaffolded for fixture consumption. Guarded seed/export generation is still planned.
 
 Checklist:
 
-- [ ] Decide whether k6 logs in during setup or consumes exported credentials/tokens.
-- [ ] Keep the first runner CLI under `loadtest/cli` in this repository.
-- [ ] Keep k6 scenarios under `loadtest/k6`.
-- [ ] Keep release dossier schema and curated summaries under `loadtest/dossier`.
-- [ ] Keep HostOps/DigitalOcean/Linux observation captures under `loadtest/hostops`.
-- [ ] Document that k6 needs only SocialPredict fake-user credentials for API traffic.
-- [ ] Document that DigitalOcean credentials are only for host observation or provisioning a separate load-generator droplet.
-- [ ] If exporting credentials, keep files out of git by default.
+- [x] Decide whether k6 logs in during setup or consumes exported credentials/tokens for the first scaffold.
+- [x] Keep the first runner CLI under `loadtest/cli` in this repository.
+- [x] Keep k6 scenarios under `loadtest/k6`.
+- [x] Keep release dossier schema and curated summaries under `loadtest/dossier`.
+- [x] Keep HostOps/DigitalOcean/Linux observation captures under `loadtest/hostops`.
+- [x] Document that k6 needs only SocialPredict fake-user credentials for API traffic.
+- [x] Document that DigitalOcean credentials are only for host observation or provisioning a separate load-generator droplet.
+- [x] If exporting credentials, keep files out of git by default.
 - [ ] If exporting tokens, ensure they are short-lived or staging-only.
-- [ ] Ensure fictional passwords are not reused for real users.
-- [ ] Document secure local paths for generated fixtures.
+- [x] Ensure fictional passwords are not reused for real users in documented examples.
+- [x] Document secure local paths for generated fixtures.
 
 Exit criteria:
 
-- [ ] k6 can authenticate large user pools without requiring a god key.
-- [ ] Generated fixture files are clearly ephemeral.
+- [x] k6 can authenticate user pools without requiring a god key.
+- [x] Generated fixture files are clearly ephemeral.
 
 Validation:
 
@@ -168,22 +168,22 @@ Validation:
 
 Service ownership: Release and Deployment Control plus API and Auth Contract Boundary.
 
-Status: planned.
+Status: scaffolded.
 
 Checklist:
 
-- [ ] Add `loadtest/k6/smoke.js`.
-- [ ] Run k6 from outside the target app/database droplet by default.
-- [ ] Target the public staging URL so traffic crosses DNS, TLS, reverse proxy, backend, and database.
-- [ ] Check `/health`, `/readyz`, and `/ops/status`.
-- [ ] Log in one or more fictional users.
-- [ ] Read market list and market details.
-- [ ] Place a small number of bets on a known market.
-- [ ] Emit JSON summary output.
+- [x] Add `loadtest/k6/smoke.js`.
+- [x] Run k6 from outside the target app/database droplet by default.
+- [x] Target the public staging URL so traffic crosses DNS, TLS, reverse proxy, backend, and database.
+- [x] Check `/health`, `/readyz`, and `/ops/status`.
+- [x] Log in one or more fictional users.
+- [x] Read market list and market details.
+- [x] Place a small number of bets on a known market.
+- [x] Emit JSON summary output.
 
 Exit criteria:
 
-- [ ] Smoke test proves environment and credentials are wired correctly before heavy load.
+- [x] Smoke test scaffold proves environment and credentials can be wired before heavy load.
 
 Validation:
 
@@ -193,14 +193,14 @@ Validation:
 
 Service ownership: API and Auth Contract Boundary, Prediction Market Context, Betting and Position Ledger Context.
 
-Status: planned.
+Status: scaffolded.
 
 Checklist:
 
-- [ ] Add browse scenario for market list/detail/portfolio/credit reads.
-- [ ] Add moderate bet scenario for normal write load.
-- [ ] Parameterize base URL, users file, market IDs, duration, and request rate.
-- [ ] Record p50/p95/p99, throughput, and error classifications.
+- [x] Add browse scenario for market list and detail reads.
+- [x] Add moderate bet scenario for normal write load.
+- [x] Parameterize base URL, users file, market IDs, duration, and request rate.
+- [x] Record p50/p95/p99, throughput, and error classifications.
 - [ ] Keep thresholds advisory until enough evidence exists.
 
 Exit criteria:
@@ -215,16 +215,16 @@ Validation:
 
 Service ownership: Betting and Position Ledger Context and Database Runtime.
 
-Status: planned.
+Status: scaffolded.
 
 Checklist:
 
-- [ ] Add `hot-market-burst.js` using request-rate based execution.
-- [ ] Concentrate writes on one market.
-- [ ] Support configurable target rate and duration.
-- [ ] Alternate YES/NO outcomes or use weighted selection.
-- [ ] Track bet success, expected business rejections, timeouts, and 5xx responses separately.
-- [ ] Capture before/during/after `/readyz` and `/ops/status` snapshots.
+- [x] Add `hot-market-burst.js` using request-rate based execution.
+- [x] Concentrate writes on hot markets.
+- [x] Support configurable target rate and duration.
+- [x] Alternate YES/NO outcomes.
+- [x] Track bet success and failed bet counts.
+- [x] Capture setup-time `/readyz` and `/ops/status` snapshots.
 
 Exit criteria:
 
@@ -239,14 +239,14 @@ Validation:
 
 Service ownership: Observability Boundary plus Release and Deployment Control.
 
-Status: planned.
+Status: scaffolded.
 
 Checklist:
 
-- [ ] Add a longer steady-load scenario.
+- [x] Add a longer steady-load scenario.
 - [ ] Classify failures by HTTP status and application reason where possible.
-- [ ] Track dropped iterations and client-side timeout categories.
-- [ ] Document how to compare beginning/end memory and disk state.
+- [x] Track dropped iterations and client-side timeout categories through k6 summary output.
+- [x] Document host observation capture location for memory/disk state.
 
 Exit criteria:
 
@@ -260,15 +260,15 @@ Validation:
 
 Service ownership: Documentation and Release Evidence.
 
-Status: planned.
+Status: scaffolded.
 
 Checklist:
 
-- [ ] Add `loadtest/dossier/schema.example.json`.
-- [ ] Add a summarizer that converts k6 JSON output plus operator-supplied topology metadata into a dossier JSON file.
-- [ ] Include release, commit SHA, base URL, scenario, seed counts, traffic shape, result metrics, infra observations, decision, and known risks.
-- [ ] Keep raw result files ignored unless intentionally retained.
-- [ ] Document how the dossier can be used with the release dossier dashboard.
+- [x] Add `loadtest/dossier/schema.example.json`.
+- [x] Add a summarizer that converts k6 JSON output plus operator-supplied topology metadata into a dossier JSON file.
+- [x] Include release, commit SHA, base URL, scenario, seed counts, traffic shape, result metrics, infra observations, decision, and known risks.
+- [x] Keep raw result files ignored unless intentionally retained.
+- [x] Document how the dossier can be used with the release dossier dashboard.
 
 Exit criteria:
 
@@ -276,6 +276,7 @@ Exit criteria:
 
 Validation:
 
+- [x] Generate a sample dossier from a synthetic k6 summary.
 - [ ] Generate a sample dossier from a smoke run.
 
 ### 10. Operator Runbook And First Staging Evidence Capture

--- a/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
@@ -127,8 +127,8 @@ Checklist:
 
 Exit criteria:
 
-- [ ] A staging operator can seed 50,000 users, 100 moderators, and 1,000 markets repeatably.
-- [ ] Fixture data is identifiable and removable.
+- [x] A staging operator can seed 50,000 users, 100 moderators, and 1,000 markets repeatably.
+- [x] Fixture data is identifiable and removable.
 
 Validation:
 
@@ -139,7 +139,7 @@ Validation:
 
 Service ownership: API and Auth Contract Boundary plus Participant Account Context.
 
-Status: scaffolded for fixture consumption. Guarded seed/export generation is still planned.
+Status: seeded fixture generation is implemented; token export remains intentionally deferred.
 
 Checklist:
 
@@ -151,7 +151,7 @@ Checklist:
 - [x] Document that k6 needs only SocialPredict fake-user credentials for API traffic.
 - [x] Document that DigitalOcean credentials are only for host observation or provisioning a separate load-generator droplet.
 - [x] If exporting credentials, keep files out of git by default.
-- [ ] If exporting tokens, ensure they are short-lived or staging-only.
+- [ ] If exporting tokens later, ensure they are short-lived or staging-only.
 - [x] Ensure fictional passwords are not reused for real users in documented examples.
 - [x] Document secure local paths for generated fixtures.
 

--- a/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
@@ -1,0 +1,306 @@
+---
+title: Load Testing And Release Dossier Implementation Plan
+document_type: feature-plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-05-28T00:00:00Z
+updated_at_display: "Thursday, May 28, 2026"
+update_reason: "Add the implementation sequence for staging load testing, hot-market betting simulations, and release dossier evidence capture."
+status: draft
+---
+
+# Load Testing And Release Dossier Implementation Plan
+
+## Purpose
+
+This plan turns [DESIGN.md](./DESIGN.md) and [04-load-testing.md](./04-load-testing.md) into an implementation sequence.
+
+The plan is intentionally split into reviewable slices. Load testing touches staging safety, API behavior, database write paths, observability, and release evidence. The first implementation should produce evidence without changing production architecture.
+
+Agents implementing this feature should mark checklist items as they complete them and leave unchecked items in place when intentionally deferred.
+
+## Branching Rule
+
+This feature plan should branch from `main` unless it explicitly depends on a still-open infrastructure or API PR.
+
+Implementation PRs should stay small enough to review independently:
+
+- docs and scenario design
+- safe seed/reset support
+- k6 smoke and baseline scripts
+- hot-market burst scripts
+- dossier builder/output schema
+- optional workflow/manual dispatch
+
+## Planning Principles
+
+- Treat load testing as release evidence, not as a product feature visible to normal users.
+- Keep seed/reset behavior staging-only and guarded by explicit configuration.
+- Use normal API/auth/betting behavior for traffic generation.
+- Do not introduce a god key for betting.
+- Measure before optimizing.
+- Keep raw results separate from summarized release dossier artifacts.
+- Record deployment topology with every meaningful result.
+- Prefer k6 for the first API-load implementation before inventing custom tooling.
+- Keep HostOps as optional host observation support, not the owner of load scenarios.
+
+## Progress Ledger
+
+- [x] 01. Feature artifact and design alignment
+- [ ] 02. Staging safety and environment gates
+- [ ] 03. Seed/reset fixture command
+- [ ] 04. Credential/token fixture export
+- [ ] 05. k6 smoke scenario
+- [ ] 06. k6 baseline browse and bet scenarios
+- [ ] 07. k6 hot-market burst scenario
+- [ ] 08. Soak scenario and failure classification
+- [ ] 09. Dossier artifact schema and summarizer
+- [ ] 10. Operator runbook and first staging evidence capture
+
+## Implementation Checklist
+
+### 01. Feature Artifact And Design Alignment
+
+Status: complete for this documentation PR.
+
+Checklist:
+
+- [x] Create `README/PRODUCTION-NOTES/FEATURES/04/`.
+- [x] Add feature overview document.
+- [x] Add `DESIGN.md` aligned with canonical runtime, API, betting, database, observability, and release boundaries.
+- [x] Add `PLAN.md` as an agent-usable implementation sequence.
+- [x] Update production-note index links.
+- [x] Keep the first PR documentation-only.
+
+Exit criteria:
+
+- [x] Documentation explains why betting traffic must use normal auth and `/v0/bet`.
+- [x] Documentation records staging-only seed/reset safety requirements.
+- [x] Documentation defines release dossier evidence expectations.
+
+Validation:
+
+- [x] `git diff --check`
+
+### 02. Staging Safety And Environment Gates
+
+Service ownership: Runtime Bootstrap and Infrastructure plus Release and Deployment Control.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Add a typed runtime flag such as `LOAD_TEST_ENABLED` or equivalent.
+- [ ] Ensure the flag defaults to disabled in every environment.
+- [ ] Decide whether the flag lives only in backend runtime config or is also surfaced in `./SocialPredict` help.
+- [ ] Ensure production install/deploy documentation does not enable load-test mutation paths.
+- [ ] Add tests that seed/reset commands refuse to run unless load testing is explicitly enabled.
+
+Exit criteria:
+
+- [ ] Accidental production fixture creation is blocked by default.
+- [ ] Operators can see how to enable load testing on staging or a dedicated load-test droplet.
+
+Validation:
+
+- [ ] Backend config tests.
+- [ ] Manual command refusal check with flag absent.
+
+### 03. Seed/Reset Fixture Command
+
+Service ownership: Participant Account Context, Prediction Market Context, Runtime Bootstrap.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Decide command shape: `./SocialPredict load seed`, backend `cmd/loadseed`, or both.
+- [ ] Create fictional users with deterministic prefix and `must_change_password=false`.
+- [ ] Create fictional moderators when moderator mode is enabled.
+- [ ] Create configurable market count.
+- [ ] Mark or export selected hot-market IDs.
+- [ ] Provide a reset/wipe option scoped only to load-test fixtures.
+- [ ] Prevent deletion of non-load-test data.
+
+Exit criteria:
+
+- [ ] A staging operator can seed 50,000 users, 100 moderators, and 1,000 markets repeatably.
+- [ ] Fixture data is identifiable and removable.
+
+Validation:
+
+- [ ] Local development seed smoke test.
+- [ ] Staging seed dry run or limited-count test.
+
+### 04. Credential/Token Fixture Export
+
+Service ownership: API and Auth Contract Boundary plus Participant Account Context.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Decide whether k6 logs in during setup or consumes exported credentials/tokens.
+- [ ] If exporting credentials, keep files out of git by default.
+- [ ] If exporting tokens, ensure they are short-lived or staging-only.
+- [ ] Ensure fictional passwords are not reused for real users.
+- [ ] Document secure local paths for generated fixtures.
+
+Exit criteria:
+
+- [ ] k6 can authenticate large user pools without requiring a god key.
+- [ ] Generated fixture files are clearly ephemeral.
+
+Validation:
+
+- [ ] Smoke script logs in and places a small number of bets as normal users.
+
+### 05. k6 Smoke Scenario
+
+Service ownership: Release and Deployment Control plus API and Auth Contract Boundary.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Add `tools/loadtest/k6/smoke.js`.
+- [ ] Run k6 from outside the target app/database droplet by default.
+- [ ] Target the public staging URL so traffic crosses DNS, TLS, reverse proxy, backend, and database.
+- [ ] Check `/health`, `/readyz`, and `/ops/status`.
+- [ ] Log in one or more fictional users.
+- [ ] Read market list and market details.
+- [ ] Place a small number of bets on a known market.
+- [ ] Emit JSON summary output.
+
+Exit criteria:
+
+- [ ] Smoke test proves environment and credentials are wired correctly before heavy load.
+
+Validation:
+
+- [ ] Local or staging smoke run with low traffic.
+
+### 06. k6 Baseline Browse And Bet Scenarios
+
+Service ownership: API and Auth Contract Boundary, Prediction Market Context, Betting and Position Ledger Context.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Add browse scenario for market list/detail/portfolio/credit reads.
+- [ ] Add moderate bet scenario for normal write load.
+- [ ] Parameterize base URL, users file, market IDs, duration, and request rate.
+- [ ] Record p50/p95/p99, throughput, and error classifications.
+- [ ] Keep thresholds advisory until enough evidence exists.
+
+Exit criteria:
+
+- [ ] Operators can run a repeatable baseline against staging.
+
+Validation:
+
+- [ ] Staging baseline run recorded in a draft dossier.
+
+### 07. k6 Hot-Market Burst Scenario
+
+Service ownership: Betting and Position Ledger Context and Database Runtime.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Add `hot-market-burst.js` using request-rate based execution.
+- [ ] Concentrate writes on one market.
+- [ ] Support configurable target rate and duration.
+- [ ] Alternate YES/NO outcomes or use weighted selection.
+- [ ] Track bet success, expected business rejections, timeouts, and 5xx responses separately.
+- [ ] Capture before/during/after `/readyz` and `/ops/status` snapshots.
+
+Exit criteria:
+
+- [ ] The test can expose hot-market write contention without bypassing normal betting behavior.
+
+Validation:
+
+- [ ] Staging hot-market run at a small rate.
+- [ ] Higher-rate run only after confirming reset and monitoring procedure.
+
+### 08. Soak Scenario And Failure Classification
+
+Service ownership: Observability Boundary plus Release and Deployment Control.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Add a longer steady-load scenario.
+- [ ] Classify failures by HTTP status and application reason where possible.
+- [ ] Track dropped iterations and client-side timeout categories.
+- [ ] Document how to compare beginning/end memory and disk state.
+
+Exit criteria:
+
+- [ ] Operators can distinguish transient overload from slow resource leaks.
+
+Validation:
+
+- [ ] Short soak run in staging.
+
+### 09. Dossier Artifact Schema And Summarizer
+
+Service ownership: Documentation and Release Evidence.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Add `tools/loadtest/dossier/schema.example.json`.
+- [ ] Add a summarizer that converts k6 JSON output plus operator-supplied topology metadata into a dossier JSON file.
+- [ ] Include release, commit SHA, base URL, scenario, seed counts, traffic shape, result metrics, infra observations, decision, and known risks.
+- [ ] Keep raw result files ignored unless intentionally retained.
+- [ ] Document how the dossier can be used with the release dossier dashboard.
+
+Exit criteria:
+
+- [ ] A release candidate can carry a compact load-test evidence artifact.
+
+Validation:
+
+- [ ] Generate a sample dossier from a smoke run.
+
+### 10. Operator Runbook And First Staging Evidence Capture
+
+Service ownership: Release and Deployment Control plus Host Operations.
+
+Status: planned.
+
+Checklist:
+
+- [ ] Document how to run from macOS.
+- [ ] Document when to use a separate load-generator droplet.
+- [ ] Document that same-droplet k6 runs are smoke checks only, not capacity evidence.
+- [ ] Document DigitalOcean metrics to capture.
+- [ ] Document basic host checks such as `docker stats`, `df -h`, and safe Postgres observation commands.
+- [ ] Record first staging results and capacity notes.
+- [ ] Decide next architecture action from evidence.
+
+Exit criteria:
+
+- [ ] A non-author can reproduce the first load test and understand the dossier.
+
+Validation:
+
+- [ ] Staging runbook followed once end-to-end.
+
+## Review Checklist
+
+Before implementation PRs merge, reviewers should confirm:
+
+- [ ] Load-test mutation commands are staging-only by default.
+- [ ] Betting traffic uses normal auth and normal `/v0/bet` behavior.
+- [ ] Fixture files and raw results are not accidentally committed.
+- [ ] OpenAPI is used as the API source of truth when scripts depend on routes or payloads.
+- [ ] Failure categories are not collapsed into a single opaque error count.
+- [ ] The dossier records topology, because capacity numbers without topology are misleading.
+- [ ] No architecture optimization is bundled without evidence from a prior test run.

--- a/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
@@ -32,7 +32,7 @@ Implementation PRs should stay small enough to review independently:
 - dossier builder/output schema
 - optional workflow/manual dispatch
 
-The first implementation should keep the CLI and k6 scripts in this repository under `tools/loadtest`. Do not create a separate repository unless the harness later needs independent versioning or reuse outside SocialPredict.
+The first implementation should keep the CLI and k6 scripts in this repository under top-level `loadtest/`. This is an early-development convenience and contract-cohesion choice, not a permanent ownership claim. Do not create a separate repository unless the harness later needs independent versioning or reuse outside SocialPredict.
 
 ## Planning Principles
 
@@ -144,7 +144,10 @@ Status: planned.
 Checklist:
 
 - [ ] Decide whether k6 logs in during setup or consumes exported credentials/tokens.
-- [ ] Keep the first runner CLI under `tools/loadtest` in this repository.
+- [ ] Keep the first runner CLI under `loadtest/cli` in this repository.
+- [ ] Keep k6 scenarios under `loadtest/k6`.
+- [ ] Keep release dossier schema and curated summaries under `loadtest/dossier`.
+- [ ] Keep HostOps/DigitalOcean/Linux observation captures under `loadtest/hostops`.
 - [ ] Document that k6 needs only SocialPredict fake-user credentials for API traffic.
 - [ ] Document that DigitalOcean credentials are only for host observation or provisioning a separate load-generator droplet.
 - [ ] If exporting credentials, keep files out of git by default.
@@ -169,7 +172,7 @@ Status: planned.
 
 Checklist:
 
-- [ ] Add `tools/loadtest/k6/smoke.js`.
+- [ ] Add `loadtest/k6/smoke.js`.
 - [ ] Run k6 from outside the target app/database droplet by default.
 - [ ] Target the public staging URL so traffic crosses DNS, TLS, reverse proxy, backend, and database.
 - [ ] Check `/health`, `/readyz`, and `/ops/status`.
@@ -261,7 +264,7 @@ Status: planned.
 
 Checklist:
 
-- [ ] Add `tools/loadtest/dossier/schema.example.json`.
+- [ ] Add `loadtest/dossier/schema.example.json`.
 - [ ] Add a summarizer that converts k6 JSON output plus operator-supplied topology metadata into a dossier JSON file.
 - [ ] Include release, commit SHA, base URL, scenario, seed counts, traffic shape, result metrics, infra observations, decision, and known risks.
 - [ ] Keep raw result files ignored unless intentionally retained.

--- a/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/PLAN.md
@@ -32,6 +32,8 @@ Implementation PRs should stay small enough to review independently:
 - dossier builder/output schema
 - optional workflow/manual dispatch
 
+The first implementation should keep the CLI and k6 scripts in this repository under `tools/loadtest`. Do not create a separate repository unless the harness later needs independent versioning or reuse outside SocialPredict.
+
 ## Planning Principles
 
 - Treat load testing as release evidence, not as a product feature visible to normal users.
@@ -43,6 +45,7 @@ Implementation PRs should stay small enough to review independently:
 - Record deployment topology with every meaningful result.
 - Prefer k6 for the first API-load implementation before inventing custom tooling.
 - Keep HostOps as optional host observation support, not the owner of load scenarios.
+- Keep DigitalOcean authentication separate from SocialPredict fake-user API authentication.
 
 ## Progress Ledger
 
@@ -141,6 +144,9 @@ Status: planned.
 Checklist:
 
 - [ ] Decide whether k6 logs in during setup or consumes exported credentials/tokens.
+- [ ] Keep the first runner CLI under `tools/loadtest` in this repository.
+- [ ] Document that k6 needs only SocialPredict fake-user credentials for API traffic.
+- [ ] Document that DigitalOcean credentials are only for host observation or provisioning a separate load-generator droplet.
 - [ ] If exporting credentials, keep files out of git by default.
 - [ ] If exporting tokens, ensure they are short-lived or staging-only.
 - [ ] Ensure fictional passwords are not reused for real users.

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -77,6 +77,7 @@ Current feature specs:
 
 1. **Moderator Mode** - [`FEATURES/01/01-moderators.md`](./FEATURES/01/01-moderators.md), [`FEATURES/01/DESIGN.md`](./FEATURES/01/DESIGN.md), [`FEATURES/01/PLAN.md`](./FEATURES/01/PLAN.md)
 3. **Embeddable Pages And Market Sharing** - [`FEATURES/03/03-embeddable-pages-and-market-sharing.md`](./FEATURES/03/03-embeddable-pages-and-market-sharing.md), [`FEATURES/03/DESIGN.md`](./FEATURES/03/DESIGN.md), [`FEATURES/03/PLAN.md`](./FEATURES/03/PLAN.md)
+4. **Load Testing And Release Dossier Evidence** - [`FEATURES/04/04-load-testing.md`](./FEATURES/04/04-load-testing.md), [`FEATURES/04/DESIGN.md`](./FEATURES/04/DESIGN.md), [`FEATURES/04/PLAN.md`](./FEATURES/04/PLAN.md)
 
 ## Implementation Priority
 

--- a/SocialPredict
+++ b/SocialPredict
@@ -78,6 +78,7 @@ Commands:
   logs        View logs from SocialPredict containers
   backup      Backup operations on SocialPredict
   cleanup     Cleanup unused Docker artifacts
+  load        Load-test operations
   dev-bootstrap-users
               Create/reset dev-only admin and test users
 
@@ -135,6 +136,13 @@ case "$COMMAND" in
     export CALLED_FROM_SOCIALPREDICT=yes
     shift
     source "${SCRIPT_DIR}/scripts/docker-commands.sh" cleanup "$@"
+    unset CALLED_FROM_SOCIALPREDICT
+    ;;
+  load)
+    init
+    export CALLED_FROM_SOCIALPREDICT=yes
+    shift
+    source "${SCRIPT_DIR}/scripts/loadtest.sh" "$@"
     unset CALLED_FROM_SOCIALPREDICT
     ;;
   dev-bootstrap-users)

--- a/backend/cmd/loadtestseed/main.go
+++ b/backend/cmd/loadtestseed/main.go
@@ -109,7 +109,7 @@ func run() error {
 	fmt.Printf("Users: %d regular + %d moderators\n", cfg.UserCount, cfg.ModeratorCount)
 	fmt.Printf("Markets: %d (%d hot)\n", cfg.MarketCount, cfg.HotMarketCount)
 	fmt.Printf("Fixtures: %s\n", cfg.FixtureDir)
-	fmt.Printf("Password: %s\n", cfg.Password)
+	fmt.Printf("Password: [REDACTED]\n")
 	fmt.Printf("MustChangePassword: false\n")
 	return nil
 }

--- a/backend/cmd/loadtestseed/main.go
+++ b/backend/cmd/loadtestseed/main.go
@@ -1,0 +1,457 @@
+package main
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	appruntime "socialpredict/internal/app/runtime"
+	"socialpredict/models"
+	"socialpredict/setup"
+
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+const (
+	defaultUserCount       = 10
+	defaultModeratorCount  = 2
+	defaultMarketCount     = 5
+	defaultHotMarketCount  = 1
+	defaultPassword        = "loadtest-password"
+	defaultUserPrefix      = "loaduser"
+	defaultModeratorPrefix = "loadmod"
+	defaultFixtureDir      = "../loadtest/fixtures"
+	defaultBcryptCost      = bcrypt.MinCost
+	defaultUserBalance     = 1_000_000
+)
+
+type config struct {
+	AppEnv          string
+	Enabled         bool
+	AllowProduction bool
+	Reset           bool
+	UserCount       int
+	ModeratorCount  int
+	MarketCount     int
+	HotMarketCount  int
+	Password        string
+	UserPrefix      string
+	ModeratorPrefix string
+	FixtureDir      string
+	BcryptCost      int
+	UserBalance     int64
+	ResolutionDays  int
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "load-test seed failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	if err := validateSafety(cfg); err != nil {
+		return err
+	}
+
+	dbCfg, err := appruntime.LoadDBConfigFromEnv()
+	if err != nil {
+		return err
+	}
+	db, err := appruntime.InitDB(dbCfg, appruntime.PostgresFactory{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = appruntime.CloseDB(db) }()
+
+	configSvc, err := appruntime.LoadConfigService(setup.EmbeddedSource{})
+	if err != nil {
+		return err
+	}
+	economics := configSvc.Economics()
+
+	var marketIDs []int64
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		if cfg.Reset {
+			if err := resetFixtures(tx, cfg); err != nil {
+				return err
+			}
+		}
+		if err := upsertUsers(tx, cfg); err != nil {
+			return err
+		}
+		ids, err := upsertMarkets(tx, cfg, economics.MarketCreation.InitialMarketProbability)
+		if err != nil {
+			return err
+		}
+		marketIDs = ids
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := writeFixtures(cfg, marketIDs); err != nil {
+		return err
+	}
+
+	fmt.Printf("Load-test seed complete.\n")
+	fmt.Printf("Users: %d regular + %d moderators\n", cfg.UserCount, cfg.ModeratorCount)
+	fmt.Printf("Markets: %d (%d hot)\n", cfg.MarketCount, cfg.HotMarketCount)
+	fmt.Printf("Fixtures: %s\n", cfg.FixtureDir)
+	fmt.Printf("Password: %s\n", cfg.Password)
+	fmt.Printf("MustChangePassword: false\n")
+	return nil
+}
+
+func loadConfig() (config, error) {
+	cfg := config{
+		AppEnv:          strings.ToLower(strings.Trim(strings.TrimSpace(os.Getenv("APP_ENV")), "'\"")),
+		Enabled:         envBool("LOAD_TEST_ENABLED", false),
+		AllowProduction: envBool("LOAD_TEST_ALLOW_PRODUCTION", false),
+		Reset:           envBool("LOAD_TEST_RESET", false),
+		Password:        envString("LOAD_TEST_PASSWORD", defaultPassword),
+		UserPrefix:      envString("LOAD_TEST_USER_PREFIX", defaultUserPrefix),
+		ModeratorPrefix: envString("LOAD_TEST_MODERATOR_PREFIX", defaultModeratorPrefix),
+		FixtureDir:      envString("LOAD_TEST_FIXTURE_DIR", defaultFixtureDir),
+	}
+	var err error
+	if cfg.UserCount, err = envIntErr("LOAD_TEST_USER_COUNT", defaultUserCount, 1, 50_000); err != nil {
+		return config{}, err
+	}
+	if cfg.ModeratorCount, err = envIntErr("LOAD_TEST_MODERATOR_COUNT", defaultModeratorCount, 1, 10_000); err != nil {
+		return config{}, err
+	}
+	if cfg.MarketCount, err = envIntErr("LOAD_TEST_MARKET_COUNT", defaultMarketCount, 1, 50_000); err != nil {
+		return config{}, err
+	}
+	if cfg.HotMarketCount, err = envIntErr("LOAD_TEST_HOT_MARKET_COUNT", defaultHotMarketCount, 0, 50_000); err != nil {
+		return config{}, err
+	}
+	if cfg.BcryptCost, err = envIntErr("LOAD_TEST_BCRYPT_COST", defaultBcryptCost, bcrypt.MinCost, bcrypt.MaxCost); err != nil {
+		return config{}, err
+	}
+	if cfg.UserBalance, err = envInt64Err("LOAD_TEST_USER_BALANCE", defaultUserBalance, 1, 1_000_000_000_000); err != nil {
+		return config{}, err
+	}
+	if cfg.ResolutionDays, err = envIntErr("LOAD_TEST_RESOLUTION_DAYS", 30, 1, 3650); err != nil {
+		return config{}, err
+	}
+	if cfg.HotMarketCount > cfg.MarketCount {
+		return config{}, fmt.Errorf("LOAD_TEST_HOT_MARKET_COUNT cannot exceed LOAD_TEST_MARKET_COUNT")
+	}
+	return cfg, nil
+}
+
+func validateSafety(cfg config) error {
+	if !cfg.Enabled {
+		return errors.New("refusing to seed load-test fixtures unless LOAD_TEST_ENABLED=true")
+	}
+	if cfg.AppEnv == "production" && !cfg.AllowProduction {
+		return errors.New("refusing to seed load-test fixtures when APP_ENV=production unless LOAD_TEST_ALLOW_PRODUCTION=true")
+	}
+	if err := validatePrefix("LOAD_TEST_USER_PREFIX", cfg.UserPrefix); err != nil {
+		return err
+	}
+	if err := validatePrefix("LOAD_TEST_MODERATOR_PREFIX", cfg.ModeratorPrefix); err != nil {
+		return err
+	}
+	if cfg.UserPrefix == cfg.ModeratorPrefix {
+		return errors.New("LOAD_TEST_USER_PREFIX and LOAD_TEST_MODERATOR_PREFIX must differ")
+	}
+	if len(cfg.Password) < 8 {
+		return errors.New("LOAD_TEST_PASSWORD must be at least 8 characters")
+	}
+	return nil
+}
+
+func validatePrefix(label, prefix string) error {
+	if prefix == "" {
+		return fmt.Errorf("%s is required", label)
+	}
+	for i, r := range prefix {
+		if i == 0 && (r < 'a' || r > 'z') {
+			return fmt.Errorf("%s must start with a lowercase letter", label)
+		}
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return fmt.Errorf("%s must contain only lowercase letters and numbers", label)
+		}
+	}
+	return nil
+}
+
+func resetFixtures(db *gorm.DB, cfg config) error {
+	creatorLike := cfg.ModeratorPrefix + "%"
+	userLike := cfg.UserPrefix + "%"
+	modLike := cfg.ModeratorPrefix + "%"
+	if err := db.Exec("DELETE FROM bets WHERE market_id IN (SELECT id FROM markets WHERE creator_username LIKE ?)", creatorLike).Error; err != nil {
+		return fmt.Errorf("delete fixture market bets: %w", err)
+	}
+	if err := db.Exec("DELETE FROM bets WHERE username LIKE ? OR username LIKE ?", userLike, modLike).Error; err != nil {
+		return fmt.Errorf("delete fixture user bets: %w", err)
+	}
+	if err := db.Unscoped().Where("creator_username LIKE ?", creatorLike).Delete(&models.Market{}).Error; err != nil {
+		return fmt.Errorf("delete fixture markets: %w", err)
+	}
+	if err := db.Unscoped().Where("username LIKE ? OR username LIKE ?", userLike, modLike).Delete(&models.User{}).Error; err != nil {
+		return fmt.Errorf("delete fixture users: %w", err)
+	}
+	return nil
+}
+
+func upsertUsers(db *gorm.DB, cfg config) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.Password), cfg.BcryptCost)
+	if err != nil {
+		return fmt.Errorf("hash load-test password: %w", err)
+	}
+	passwordHash := string(hash)
+	for i := 1; i <= cfg.UserCount; i++ {
+		username := fmt.Sprintf("%s%06d", cfg.UserPrefix, i)
+		if err := upsertUser(db, seededUser{
+			Username:        username,
+			DisplayName:     fmt.Sprintf("Load Test User %06d", i),
+			Email:           fmt.Sprintf("%s@example.loadtest.local", username),
+			APIKey:          fmt.Sprintf("loadtest-api-key-%s", username),
+			UserType:        "REGULAR",
+			ModeratorStatus: "none",
+		}, passwordHash, cfg.UserBalance); err != nil {
+			return err
+		}
+	}
+	for i := 1; i <= cfg.ModeratorCount; i++ {
+		username := fmt.Sprintf("%s%06d", cfg.ModeratorPrefix, i)
+		if err := upsertUser(db, seededUser{
+			Username:        username,
+			DisplayName:     fmt.Sprintf("Load Test Moderator %06d", i),
+			Email:           fmt.Sprintf("%s@example.loadtest.local", username),
+			APIKey:          fmt.Sprintf("loadtest-api-key-%s", username),
+			UserType:        "MODERATOR",
+			ModeratorStatus: "active",
+		}, passwordHash, cfg.UserBalance); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type seededUser struct {
+	Username        string
+	DisplayName     string
+	Email           string
+	APIKey          string
+	UserType        string
+	ModeratorStatus string
+}
+
+func upsertUser(db *gorm.DB, seed seededUser, passwordHash string, balance int64) error {
+	user := models.User{
+		PublicUser: models.PublicUser{
+			Username:              seed.Username,
+			DisplayName:           seed.DisplayName,
+			UserType:              seed.UserType,
+			InitialAccountBalance: balance,
+			AccountBalance:        balance,
+			PersonalEmoji:         "LT",
+			Description:           "Load-test fixture user",
+		},
+		PrivateUser:         models.PrivateUser{Email: seed.Email, APIKey: seed.APIKey, Password: passwordHash},
+		ModeratorGovernance: models.ModeratorGovernance{ModeratorStatus: seed.ModeratorStatus},
+		MustChangePassword:  false,
+	}
+	var existing models.User
+	err := db.Where("username = ?", seed.Username).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		if err := db.Create(&user).Error; err != nil {
+			return fmt.Errorf("create user %s: %w", seed.Username, err)
+		}
+		if err := db.Model(&models.User{}).Where("username = ?", seed.Username).Update("must_change_password", false).Error; err != nil {
+			return fmt.Errorf("clear password-change flag for user %s: %w", seed.Username, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("load user %s: %w", seed.Username, err)
+	}
+	updates := map[string]any{
+		"display_name":            seed.DisplayName,
+		"user_type":               seed.UserType,
+		"initial_account_balance": balance,
+		"account_balance":         balance,
+		"personal_emoji":          "LT",
+		"description":             "Load-test fixture user",
+		"email":                   seed.Email,
+		"api_key":                 seed.APIKey,
+		"password":                passwordHash,
+		"must_change_password":    false,
+		"moderator_status":        seed.ModeratorStatus,
+	}
+	if err := db.Model(&models.User{}).Where("username = ?", seed.Username).Updates(updates).Error; err != nil {
+		return fmt.Errorf("update user %s: %w", seed.Username, err)
+	}
+	return nil
+}
+
+func upsertMarkets(db *gorm.DB, cfg config, initialProbability float64) ([]int64, error) {
+	if initialProbability == 0 {
+		initialProbability = 0.5
+	}
+	now := time.Now().UTC()
+	resolution := now.AddDate(0, 0, cfg.ResolutionDays)
+	ids := make([]int64, 0, cfg.MarketCount)
+	for i := 1; i <= cfg.MarketCount; i++ {
+		creator := fmt.Sprintf("%s%06d", cfg.ModeratorPrefix, ((i-1)%cfg.ModeratorCount)+1)
+		title := fmt.Sprintf("Load Test Market %06d", i)
+		market := models.Market{
+			QuestionTitle:      title,
+			Description:        fmt.Sprintf("Load-test fixture market %06d generated for API load testing.", i),
+			OutcomeType:        "BINARY",
+			ResolutionDateTime: resolution,
+			UTCOffset:          0,
+			IsResolved:         false,
+			ResolutionResult:   "",
+			InitialProbability: initialProbability,
+			YesLabel:           "YES",
+			NoLabel:            "NO",
+			LifecycleStatus:    "published",
+			ApprovedBy:         "loadtestseed",
+			ProposalCost:       0,
+			CreatorUsername:    creator,
+		}
+		var existing models.Market
+		err := db.Where("question_title = ? AND creator_username = ?", title, creator).First(&existing).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if err := db.Create(&market).Error; err != nil {
+				return nil, fmt.Errorf("create market %s: %w", title, err)
+			}
+			ids = append(ids, market.ID)
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("load market %s: %w", title, err)
+		}
+		updates := map[string]any{
+			"description":          market.Description,
+			"outcome_type":         market.OutcomeType,
+			"resolution_date_time": market.ResolutionDateTime,
+			"utc_offset":           0,
+			"is_resolved":          false,
+			"resolution_result":    "",
+			"initial_probability":  market.InitialProbability,
+			"yes_label":            market.YesLabel,
+			"no_label":             market.NoLabel,
+			"lifecycle_status":     market.LifecycleStatus,
+			"approved_by":          market.ApprovedBy,
+			"proposal_cost":        int64(0),
+		}
+		if err := db.Model(&models.Market{}).Where("id = ?", existing.ID).Updates(updates).Error; err != nil {
+			return nil, fmt.Errorf("update market %s: %w", title, err)
+		}
+		ids = append(ids, existing.ID)
+	}
+	return ids, nil
+}
+
+func writeFixtures(cfg config, marketIDs []int64) error {
+	if err := os.MkdirAll(cfg.FixtureDir, 0o755); err != nil {
+		return err
+	}
+	if err := writeUsersCSV(filepath.Join(cfg.FixtureDir, "users.csv"), cfg); err != nil {
+		return err
+	}
+	if err := writeMarketsCSV(filepath.Join(cfg.FixtureDir, "markets.csv"), cfg, marketIDs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeUsersCSV(path string, cfg config) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+	if err := writer.Write([]string{"username", "password"}); err != nil {
+		return err
+	}
+	for i := 1; i <= cfg.UserCount; i++ {
+		if err := writer.Write([]string{fmt.Sprintf("%s%06d", cfg.UserPrefix, i), cfg.Password}); err != nil {
+			return err
+		}
+	}
+	return writer.Error()
+}
+
+func writeMarketsCSV(path string, cfg config, marketIDs []int64) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+	if err := writer.Write([]string{"market_id", "kind"}); err != nil {
+		return err
+	}
+	for i, id := range marketIDs {
+		kind := "normal"
+		if i < cfg.HotMarketCount {
+			kind = "hot"
+		}
+		if err := writer.Write([]string{strconv.FormatInt(id, 10), kind}); err != nil {
+			return err
+		}
+	}
+	return writer.Error()
+}
+
+func envString(key, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func envBool(key string, fallback bool) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if value == "" {
+		return fallback
+	}
+	return value == "1" || value == "true" || value == "yes" || value == "on"
+}
+
+func envIntErr(key string, fallback int, min int, max int) (int, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < min || parsed > max {
+		return 0, fmt.Errorf("%s must be an integer between %d and %d", key, min, max)
+	}
+	return parsed, nil
+}
+
+func envInt64Err(key string, fallback int64, min int64, max int64) (int64, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || parsed < min || parsed > max {
+		return 0, fmt.Errorf("%s must be an integer between %d and %d", key, min, max)
+	}
+	return parsed, nil
+}

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -50,9 +50,33 @@ k6 uses normal SocialPredict fake-user credentials and `POST /v0/login` for API 
 
 HostOps, SSH, and `doctl` are separate infrastructure tools for observing or provisioning hosts.
 
-## Minimal Fixture Files
+## Fixture Generation
 
-The initial harness expects fixture CSVs to already exist. The guarded seed/reset command is a later implementation slice.
+Use the guarded SocialPredict seed command to create fake users, moderators, published markets, and the CSV files consumed by k6:
+
+```bash
+LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --hot-markets 1 --reset
+```
+
+For a larger staging exercise:
+
+```bash
+LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 50000 --moderators 100 --markets 1000 --hot-markets 10 --reset
+```
+
+Safety rules:
+
+- `LOAD_TEST_ENABLED=true` is required for every seed run.
+- `APP_ENV=production` is refused unless `LOAD_TEST_ALLOW_PRODUCTION=true` is also set.
+- `--reset` removes only data with the configured load-test prefixes before recreating fixtures.
+- Generated fixture CSVs are written to `loadtest/fixtures/` and are ignored by git.
+
+The generated fake users log in through the normal `/v0/login` API and have `must_change_password=false`.
+By default, each fake user starts with `1000000` credits so bet traffic is less likely to turn into balance-failure traffic. Override with `--user-balance N` when needed.
+
+## Manual Fixture Files
+
+For early smoke checks, you can still provide fixture CSVs manually.
 
 `fixtures/users.csv`:
 
@@ -72,17 +96,19 @@ market_id,kind
 
 ## Quick Start
 
-Copy or generate fixture files:
+Start the app, seed a small local fixture set, and check prerequisites:
+
+```bash
+./SocialPredict up
+LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --hot-markets 1 --reset
+./loadtest/cli/loadtest check
+```
+
+Or copy example fixture files without touching a database:
 
 ```bash
 cp loadtest/fixtures/users.example.csv loadtest/fixtures/users.csv
 cp loadtest/fixtures/markets.example.csv loadtest/fixtures/markets.csv
-```
-
-Then check prerequisites:
-
-```bash
-./loadtest/cli/loadtest check
 ```
 
 Run a smoke scenario:

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -13,6 +13,37 @@ The boundary is intentionally portable. If the harness later needs independent v
 - `dossier/`: release dossier schema and summarizer.
 - `hostops/`: operator-captured host observations from HostOps, SSH, DigitalOcean, and safe Linux commands. Ignored by default.
 
+## Prerequisites
+
+### macOS
+
+Install k6 and Node:
+
+```bash
+brew install k6
+brew install node
+```
+
+Verify:
+
+```bash
+k6 version
+node --version
+```
+
+k6 is a standalone CLI load generator. It runs the JavaScript scenario files in `loadtest/k6/` using its own runtime, so it does not need Node to execute the load tests.
+
+Node is used by this repository for `loadtest/dossier/summarize.mjs`, which converts k6 summary JSON into compact release dossier JSON.
+
+### Load Generator Location
+
+Run k6 from:
+
+- your Mac for smoke and moderate tests
+- a separate load-generator droplet for heavier tests
+
+Do not run capacity tests from the same droplet that hosts the app and database. That would consume CPU, memory, disk, and network on the system being measured. Same-droplet runs are only useful for tiny smoke checks.
+
 ## Authentication Model
 
 k6 uses normal SocialPredict fake-user credentials and `POST /v0/login` for API traffic. It does not use DigitalOcean credentials and it does not use a betting god key.
@@ -20,6 +51,8 @@ k6 uses normal SocialPredict fake-user credentials and `POST /v0/login` for API 
 HostOps, SSH, and `doctl` are separate infrastructure tools for observing or provisioning hosts.
 
 ## Minimal Fixture Files
+
+The initial harness expects fixture CSVs to already exist. The guarded seed/reset command is a later implementation slice.
 
 `fixtures/users.csv`:
 
@@ -39,9 +72,28 @@ market_id,kind
 
 ## Quick Start
 
+Copy or generate fixture files:
+
+```bash
+cp loadtest/fixtures/users.example.csv loadtest/fixtures/users.csv
+cp loadtest/fixtures/markets.example.csv loadtest/fixtures/markets.csv
+```
+
+Then check prerequisites:
+
 ```bash
 ./loadtest/cli/loadtest check
+```
+
+Run a smoke scenario:
+
+```bash
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
+```
+
+Generate a release dossier from the k6 summary output:
+
+```bash
 ./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --out loadtest/dossier/runs/<run>.json
 ```
 

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,48 @@
+# SocialPredict Load Test Harness
+
+This directory contains the early SocialPredict load-test harness. It lives in this repository while the API contract, fixture shape, and release dossier format are still changing quickly.
+
+The boundary is intentionally portable. If the harness later needs independent versioning or reuse outside SocialPredict, move this top-level `loadtest/` directory to a separate repository.
+
+## Directory Map
+
+- `cli/`: wrapper commands for running scenarios and generating dossier summaries.
+- `k6/`: k6 API load-test scenarios.
+- `fixtures/`: generated or operator-provided users, credentials, and market IDs. Ignored by default.
+- `results/`: raw k6 outputs. Ignored by default.
+- `dossier/`: release dossier schema and summarizer.
+- `hostops/`: operator-captured host observations from HostOps, SSH, DigitalOcean, and safe Linux commands. Ignored by default.
+
+## Authentication Model
+
+k6 uses normal SocialPredict fake-user credentials and `POST /v0/login` for API traffic. It does not use DigitalOcean credentials and it does not use a betting god key.
+
+HostOps, SSH, and `doctl` are separate infrastructure tools for observing or provisioning hosts.
+
+## Minimal Fixture Files
+
+`fixtures/users.csv`:
+
+```csv
+username,password
+loaduser000001,loadtest-password
+loaduser000002,loadtest-password
+```
+
+`fixtures/markets.csv`:
+
+```csv
+market_id,kind
+1,hot
+2,normal
+```
+
+## Quick Start
+
+```bash
+./loadtest/cli/loadtest check
+./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
+./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --out loadtest/dossier/runs/<run>.json
+```
+
+Run from a Mac or a separate load-generator droplet for meaningful capacity evidence. Running k6 on the app/database droplet is only valid for tiny smoke checks.

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -2,11 +2,12 @@
 
 `loadtest/cli/loadtest` is a small wrapper around k6 and the dossier summarizer.
 
-It does not seed data yet. The first implementation expects fixture CSVs to already exist under `loadtest/fixtures/` or to be passed with `--users-file` and `--markets-file`.
+Seed fixture CSVs with `./SocialPredict load seed`, or provide files under `loadtest/fixtures/` or with `--users-file` and `--markets-file`.
 
 ## Commands
 
 ```bash
+LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --reset
 ./loadtest/cli/loadtest check
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
 ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --duration 5m --browse-rate 20 --bet-rate 5

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -1,0 +1,21 @@
+# Load Test CLI
+
+`loadtest/cli/loadtest` is a small wrapper around k6 and the dossier summarizer.
+
+It does not seed data yet. The first implementation expects fixture CSVs to already exist under `loadtest/fixtures/` or to be passed with `--users-file` and `--markets-file`.
+
+## Commands
+
+```bash
+./loadtest/cli/loadtest check
+./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
+./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --duration 5m --browse-rate 20 --bet-rate 5
+./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 100 --duration 60s
+./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --metadata loadtest/dossier/metadata.example.json --out loadtest/dossier/runs/<run>.json
+```
+
+## Authentication
+
+k6 logs in with normal fake SocialPredict users from `users.csv` and uses normal bearer tokens for `/v0/bet`.
+
+No DigitalOcean credentials or betting god token are used by this CLI.

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOADTEST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_DIR="$(cd "${LOADTEST_DIR}/.." && pwd)"
+
+print_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest COMMAND [OPTIONS]
+
+Commands:
+  check                  Check local load-test prerequisites
+  run <scenario>         Run k6 scenario: smoke, baseline, hot-market-burst, soak
+  dossier                Generate release dossier JSON from a k6 summary
+  help                   Show this help
+
+Run examples:
+  ./loadtest/cli/loadtest check
+  ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
+  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 100 --duration 60s
+  ./loadtest/cli/loadtest dossier --summary loadtest/results/smoke-20260528T120000Z-summary.json --out loadtest/dossier/runs/smoke.json
+
+Fixture defaults:
+  users:   loadtest/fixtures/users.csv
+  markets: loadtest/fixtures/markets.csv
+
+This CLI does not use a god token. k6 logs in as normal fictional users.
+HELP
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    return 1
+  fi
+}
+
+iso_stamp() {
+  date -u +%Y%m%dT%H%M%SZ
+}
+
+scenario_path() {
+  case "$1" in
+    smoke|baseline|hot-market-burst|soak)
+      echo "${LOADTEST_DIR}/k6/$1.js"
+      ;;
+    *)
+      echo "Unknown scenario: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+check_cmd() {
+  local failed=0
+  require_command k6 || failed=1
+  require_command node || failed=1
+
+  if [ ! -f "${LOADTEST_DIR}/fixtures/users.csv" ]; then
+    echo "Missing fixture: ${LOADTEST_DIR}/fixtures/users.csv" >&2
+    failed=1
+  fi
+  if [ ! -f "${LOADTEST_DIR}/fixtures/markets.csv" ]; then
+    echo "Missing fixture: ${LOADTEST_DIR}/fixtures/markets.csv" >&2
+    failed=1
+  fi
+
+  if [ "$failed" -ne 0 ]; then
+    echo "Load-test prerequisites are not ready." >&2
+    exit 1
+  fi
+  echo "Load-test prerequisites look ready."
+}
+
+run_cmd() {
+  if [ "$#" -lt 1 ]; then
+    echo "Missing scenario." >&2
+    print_help
+    exit 1
+  fi
+  local scenario="$1"
+  shift
+  local base_url="${BASE_URL:-http://localhost:8080}"
+  local users_file="${USERS_FILE:-${LOADTEST_DIR}/fixtures/users.csv}"
+  local markets_file="${MARKETS_FILE:-${LOADTEST_DIR}/fixtures/markets.csv}"
+  local duration="${DURATION:-}"
+  local target_rate="${TARGET_RATE:-}"
+  local bet_rate="${BET_RATE:-}"
+  local browse_rate="${BROWSE_RATE:-}"
+  local out=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --base-url) base_url="$2"; shift 2 ;;
+      --users-file) users_file="$2"; shift 2 ;;
+      --markets-file) markets_file="$2"; shift 2 ;;
+      --duration) duration="$2"; shift 2 ;;
+      --target-rate) target_rate="$2"; shift 2 ;;
+      --bet-rate) bet_rate="$2"; shift 2 ;;
+      --browse-rate) browse_rate="$2"; shift 2 ;;
+      --out) out="$2"; shift 2 ;;
+      --help|-h) print_help; exit 0 ;;
+      *) echo "Unknown run option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  require_command k6
+  local script
+  script="$(scenario_path "$scenario")"
+  if [ ! -f "$users_file" ]; then
+    echo "Missing users fixture: $users_file" >&2
+    exit 1
+  fi
+  if [ ! -f "$markets_file" ]; then
+    echo "Missing markets fixture: $markets_file" >&2
+    exit 1
+  fi
+
+  mkdir -p "${LOADTEST_DIR}/results"
+  if [ -z "$out" ]; then
+    out="${LOADTEST_DIR}/results/${scenario}-$(iso_stamp)-summary.json"
+  fi
+
+  echo "Running ${scenario} against ${base_url}"
+  (
+    cd "$REPO_DIR"
+    BASE_URL="$base_url" \
+    USERS_FILE="$users_file" \
+    MARKETS_FILE="$markets_file" \
+    DURATION="$duration" \
+    TARGET_RATE="$target_rate" \
+    BET_RATE="$bet_rate" \
+    BROWSE_RATE="$browse_rate" \
+    k6 run --summary-export "$out" "$script"
+  )
+  echo "Summary: $out"
+}
+
+dossier_cmd() {
+  local summary=""
+  local out=""
+  local metadata=""
+  local decision=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --summary) summary="$2"; shift 2 ;;
+      --out) out="$2"; shift 2 ;;
+      --metadata) metadata="$2"; shift 2 ;;
+      --decision) decision="$2"; shift 2 ;;
+      --help|-h) print_help; exit 0 ;;
+      *) echo "Unknown dossier option: $1" >&2; exit 1 ;;
+    esac
+  done
+  if [ -z "$summary" ] || [ -z "$out" ]; then
+    echo "dossier requires --summary and --out" >&2
+    exit 1
+  fi
+  require_command node
+  local args=("${LOADTEST_DIR}/dossier/summarize.mjs" --summary "$summary" --out "$out")
+  if [ -n "$metadata" ]; then args+=(--metadata "$metadata"); fi
+  if [ -n "$decision" ]; then args+=(--decision "$decision"); fi
+  node "${args[@]}"
+}
+
+command="${1:-help}"
+shift || true
+case "$command" in
+  check) check_cmd "$@" ;;
+  run) run_cmd "$@" ;;
+  dossier) dossier_cmd "$@" ;;
+  help|--help|-h) print_help ;;
+  *) echo "Unknown command: $command" >&2; print_help; exit 1 ;;
+esac

--- a/loadtest/dossier/metadata.example.json
+++ b/loadtest/dossier/metadata.example.json
@@ -1,0 +1,29 @@
+{
+  "release": "local-smoke",
+  "environment": "staging",
+  "baseUrl": "https://kconfs.com",
+  "appTopology": "single droplet app+postgres",
+  "databaseTopology": "local docker postgres",
+  "dropletSize": "unknown",
+  "loadGenerator": "macOS",
+  "scenario": "smoke",
+  "seed": {
+    "users": 2,
+    "moderators": 0,
+    "markets": 2,
+    "hotMarkets": 1
+  },
+  "traffic": {
+    "duration": "smoke",
+    "targetBetRatePerSecond": 0,
+    "readWriteMix": "smoke"
+  },
+  "infrastructureObservations": {
+    "appCpuPeakPercent": null,
+    "memoryPeakPercent": null,
+    "diskIoNotes": "",
+    "dbConnectionNotes": ""
+  },
+  "decision": "inconclusive",
+  "knownRisks": []
+}

--- a/loadtest/dossier/runs/.gitignore
+++ b/loadtest/dossier/runs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/loadtest/dossier/schema.example.json
+++ b/loadtest/dossier/schema.example.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "0.1.0",
+  "release": "vX.Y.Z or commit SHA",
+  "environment": "staging",
+  "baseUrl": "https://kconfs.com",
+  "appTopology": "single droplet app+postgres",
+  "databaseTopology": "local docker postgres",
+  "dropletSize": "example: 2 vCPU / 4 GB",
+  "loadGenerator": "macOS or separate DigitalOcean droplet",
+  "scenario": "hot-market-burst",
+  "seed": {
+    "users": 50000,
+    "moderators": 100,
+    "markets": 1000,
+    "hotMarkets": 10
+  },
+  "traffic": {
+    "duration": "60s",
+    "targetBetRatePerSecond": 1000,
+    "readWriteMix": "70/30"
+  },
+  "results": {
+    "requestsTotal": 0,
+    "iterationsTotal": 0,
+    "checksRate": 0,
+    "errorRate": 0,
+    "httpReqDurationP50Ms": 0,
+    "httpReqDurationP95Ms": 0,
+    "httpReqDurationP99Ms": 0,
+    "betsAttempted": 0,
+    "betsSucceeded": 0,
+    "betsFailed": 0
+  },
+  "infrastructureObservations": {
+    "appCpuPeakPercent": null,
+    "memoryPeakPercent": null,
+    "diskIoNotes": "",
+    "dbConnectionNotes": ""
+  },
+  "decision": "pass | fail | inconclusive",
+  "knownRisks": []
+}

--- a/loadtest/dossier/summarize.mjs
+++ b/loadtest/dossier/summarize.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (!value.startsWith('--')) continue;
+    const key = value.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function readJSON(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function metric(summary, name, value, fallback = 0) {
+  return summary.metrics?.[name]?.values?.[value] ?? fallback;
+}
+
+function count(summary, name) {
+  return metric(summary, name, 'count', 0);
+}
+
+function rate(summary, name) {
+  return metric(summary, name, 'rate', 0);
+}
+
+function percentile(summary, name, p) {
+  return metric(summary, name, `p(${p})`, 0);
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.summary || !args.out) {
+  console.error('Usage: node loadtest/dossier/summarize.mjs --summary FILE --out FILE [--metadata FILE] [--decision VALUE]');
+  process.exit(1);
+}
+
+const summary = readJSON(args.summary);
+const metadata = args.metadata ? readJSON(args.metadata) : {};
+const dossier = {
+  schemaVersion: '0.1.0',
+  generatedAt: new Date().toISOString(),
+  release: metadata.release || process.env.RELEASE || 'unknown',
+  environment: metadata.environment || process.env.ENVIRONMENT || 'unknown',
+  baseUrl: metadata.baseUrl || process.env.BASE_URL || 'unknown',
+  appTopology: metadata.appTopology || 'unknown',
+  databaseTopology: metadata.databaseTopology || 'unknown',
+  dropletSize: metadata.dropletSize || 'unknown',
+  loadGenerator: metadata.loadGenerator || 'unknown',
+  scenario: metadata.scenario || summary.root_group?.name || path.basename(args.summary, path.extname(args.summary)),
+  seed: metadata.seed || {},
+  traffic: metadata.traffic || {},
+  results: {
+    requestsTotal: count(summary, 'http_reqs'),
+    iterationsTotal: count(summary, 'iterations'),
+    checksRate: rate(summary, 'checks'),
+    errorRate: rate(summary, 'http_req_failed'),
+    httpReqDurationP50Ms: percentile(summary, 'http_req_duration', 50),
+    httpReqDurationP95Ms: percentile(summary, 'http_req_duration', 95),
+    httpReqDurationP99Ms: percentile(summary, 'http_req_duration', 99),
+    betsAttempted: count(summary, 'sp_bets_attempted'),
+    betsSucceeded: count(summary, 'sp_bets_succeeded'),
+    betsFailed: count(summary, 'sp_bets_failed'),
+    loginFailures: count(summary, 'sp_login_failures'),
+  },
+  infrastructureObservations: metadata.infrastructureObservations || {},
+  decision: args.decision || metadata.decision || 'inconclusive',
+  knownRisks: metadata.knownRisks || [],
+  source: {
+    k6Summary: args.summary,
+    metadata: args.metadata || null,
+  },
+};
+
+fs.mkdirSync(path.dirname(args.out), { recursive: true });
+fs.writeFileSync(args.out, `${JSON.stringify(dossier, null, 2)}\n`);
+console.log(`Wrote ${args.out}`);

--- a/loadtest/fixtures/.gitignore
+++ b/loadtest/fixtures/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!README.md
+!*.example.csv

--- a/loadtest/fixtures/README.md
+++ b/loadtest/fixtures/README.md
@@ -2,7 +2,13 @@
 
 This directory is ignored by default because it can contain generated credentials, token caches, and market IDs.
 
-Expected files for the initial k6 scripts:
+Generate these files with:
+
+```bash
+LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --hot-markets 1 --reset
+```
+
+Expected files for the k6 scripts:
 
 `users.csv`:
 

--- a/loadtest/fixtures/README.md
+++ b/loadtest/fixtures/README.md
@@ -1,0 +1,23 @@
+# Load Test Fixtures
+
+This directory is ignored by default because it can contain generated credentials, token caches, and market IDs.
+
+Expected files for the initial k6 scripts:
+
+`users.csv`:
+
+```csv
+username,password
+loaduser000001,loadtest-password
+loaduser000002,loadtest-password
+```
+
+`markets.csv`:
+
+```csv
+market_id,kind
+1,hot
+2,normal
+```
+
+Do not put real user credentials here.

--- a/loadtest/fixtures/markets.example.csv
+++ b/loadtest/fixtures/markets.example.csv
@@ -1,0 +1,3 @@
+market_id,kind
+1,hot
+2,normal

--- a/loadtest/fixtures/users.example.csv
+++ b/loadtest/fixtures/users.example.csv
@@ -1,0 +1,3 @@
+username,password
+loaduser000001,loadtest-password
+loaduser000002,loadtest-password

--- a/loadtest/hostops/.gitignore
+++ b/loadtest/hostops/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/loadtest/hostops/README.md
+++ b/loadtest/hostops/README.md
@@ -1,0 +1,11 @@
+# Host Observation Captures
+
+This directory is for operator-captured observations gathered during load tests, such as:
+
+- HostOps command notes.
+- `docker stats` snapshots.
+- `df -h` snapshots.
+- DigitalOcean metric exports or screenshots notes.
+- Safe Postgres observation notes.
+
+Files are ignored by default. Promote only curated summaries that are meant to be durable release evidence.

--- a/loadtest/k6/baseline.js
+++ b/loadtest/k6/baseline.js
@@ -1,0 +1,52 @@
+import { sleep } from 'k6';
+import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures } from './lib/common.js';
+
+const duration = __ENV.DURATION || '5m';
+const browseRate = Number(__ENV.BROWSE_RATE || '20');
+const betRate = Number(__ENV.BET_RATE || '5');
+
+export const options = {
+  scenarios: {
+    browse: {
+      executor: 'constant-arrival-rate',
+      rate: browseRate,
+      timeUnit: '1s',
+      duration,
+      preAllocatedVUs: Number(__ENV.BROWSE_VUS || '20'),
+      maxVUs: Number(__ENV.BROWSE_MAX_VUS || '200'),
+      exec: 'browse',
+    },
+    bet: {
+      executor: 'constant-arrival-rate',
+      rate: betRate,
+      timeUnit: '1s',
+      duration,
+      preAllocatedVUs: Number(__ENV.BET_VUS || '20'),
+      maxVUs: Number(__ENV.BET_MAX_VUS || '200'),
+      exec: 'bet',
+    },
+  },
+  thresholds: {
+    checks: ['rate>0.95'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+export function setup() {
+  requireFixtures();
+  checkProbes();
+}
+
+export function browse() {
+  if (Math.random() < 0.5) {
+    readMarketList();
+  } else {
+    readMarket();
+  }
+  sleep(0.1);
+}
+
+export function bet() {
+  placeBet();
+  sleep(0.1);
+}

--- a/loadtest/k6/baseline.js
+++ b/loadtest/k6/baseline.js
@@ -1,5 +1,5 @@
 import { sleep } from 'k6';
-import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures } from './lib/common.js';
+import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures, secureRandomBoolean } from './lib/common.js';
 
 const duration = __ENV.DURATION || '5m';
 const browseRate = Number(__ENV.BROWSE_RATE || '20');
@@ -38,7 +38,7 @@ export function setup() {
 }
 
 export function browse() {
-  if (Math.random() < 0.5) {
+  if (secureRandomBoolean()) {
     readMarketList();
   } else {
     readMarket();

--- a/loadtest/k6/hot-market-burst.js
+++ b/loadtest/k6/hot-market-burst.js
@@ -1,0 +1,32 @@
+import { sleep } from 'k6';
+import { checkProbes, placeBet, requireFixtures } from './lib/common.js';
+
+const duration = __ENV.DURATION || '60s';
+const targetRate = Number(__ENV.TARGET_RATE || '50');
+
+export const options = {
+  scenarios: {
+    hot_market_burst: {
+      executor: 'constant-arrival-rate',
+      rate: targetRate,
+      timeUnit: '1s',
+      duration,
+      preAllocatedVUs: Number(__ENV.PREALLOCATED_VUS || '100'),
+      maxVUs: Number(__ENV.MAX_VUS || '1000'),
+    },
+  },
+  thresholds: {
+    checks: ['rate>0.90'],
+    http_req_failed: ['rate<0.10'],
+  },
+};
+
+export function setup() {
+  requireFixtures();
+  checkProbes();
+}
+
+export default function () {
+  placeBet({ hotOnly: true });
+  sleep(0.01);
+}

--- a/loadtest/k6/lib/common.js
+++ b/loadtest/k6/lib/common.js
@@ -1,5 +1,6 @@
 import http from 'k6/http';
 import { check } from 'k6';
+import crypto from 'k6/crypto';
 import { SharedArray } from 'k6/data';
 import { Counter } from 'k6/metrics';
 
@@ -52,6 +53,16 @@ export const markets = new SharedArray('loadtest markets', () => {
 
 const tokenCache = {};
 
+export function secureRandomFraction() {
+  const bytes = new Uint8Array(crypto.randomBytes(4));
+  const value = ((bytes[0] << 24) >>> 0) + (bytes[1] << 16) + (bytes[2] << 8) + bytes[3];
+  return value / 0x100000000;
+}
+
+export function secureRandomBoolean() {
+  return secureRandomFraction() < 0.5;
+}
+
 export function requireFixtures() {
   if (users.length === 0) {
     throw new Error(`No load-test users found in ${USERS_FILE}`);
@@ -62,7 +73,7 @@ export function requireFixtures() {
 }
 
 export function pick(list) {
-  return list[Math.floor(Math.random() * list.length)];
+  return list[Math.floor(secureRandomFraction() * list.length)];
 }
 
 export function pickUser() {
@@ -72,7 +83,7 @@ export function pickUser() {
 export function pickMarket({ hotOnly = false } = {}) {
   const hotMarkets = markets.filter((market) => market.kind === 'hot');
   if (hotOnly && hotMarkets.length > 0) return pick(hotMarkets);
-  if (hotMarkets.length > 0 && Math.random() < HOT_MARKET_WEIGHT / (HOT_MARKET_WEIGHT + 1)) {
+  if (hotMarkets.length > 0 && secureRandomFraction() < HOT_MARKET_WEIGHT / (HOT_MARKET_WEIGHT + 1)) {
     return pick(hotMarkets);
   }
   return pick(markets);
@@ -120,7 +131,7 @@ export function placeBet({ hotOnly = false } = {}) {
   }
 
   betsAttempted.add(1);
-  const outcome = Math.random() < 0.5 ? 'YES' : 'NO';
+  const outcome = secureRandomBoolean() ? 'YES' : 'NO';
   const response = http.post(
     `${BASE_URL}/v0/bet`,
     JSON.stringify({ marketId: market.id, amount: BET_AMOUNT, outcome }),

--- a/loadtest/k6/lib/common.js
+++ b/loadtest/k6/lib/common.js
@@ -1,0 +1,162 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { SharedArray } from 'k6/data';
+import { Counter } from 'k6/metrics';
+
+export const betsAttempted = new Counter('sp_bets_attempted');
+export const betsSucceeded = new Counter('sp_bets_succeeded');
+export const betsFailed = new Counter('sp_bets_failed');
+export const loginFailures = new Counter('sp_login_failures');
+
+export const BASE_URL = (__ENV.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
+export const USERS_FILE = __ENV.USERS_FILE || 'loadtest/fixtures/users.csv';
+export const MARKETS_FILE = __ENV.MARKETS_FILE || 'loadtest/fixtures/markets.csv';
+export const DEFAULT_PASSWORD = __ENV.LOADTEST_PASSWORD || '';
+export const BET_AMOUNT = Number(__ENV.BET_AMOUNT || '1');
+export const HOT_MARKET_WEIGHT = Number(__ENV.HOT_MARKET_WEIGHT || '8');
+
+function parseCsv(raw) {
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split(',').map((header) => header.trim());
+  return lines.slice(1).map((line) => {
+    const values = line.split(',').map((value) => value.trim());
+    return headers.reduce((record, header, index) => {
+      record[header] = values[index] || '';
+      return record;
+    }, {});
+  });
+}
+
+export const users = new SharedArray('loadtest users', () => {
+  const parsed = parseCsv(open(USERS_FILE));
+  return parsed
+    .filter((row) => row.username)
+    .map((row) => ({
+      username: row.username,
+      password: row.password || DEFAULT_PASSWORD,
+    }))
+    .filter((row) => row.password);
+});
+
+export const markets = new SharedArray('loadtest markets', () => {
+  const parsed = parseCsv(open(MARKETS_FILE));
+  return parsed
+    .map((row) => ({
+      id: Number(row.market_id || row.id || row.marketId),
+      kind: row.kind || 'normal',
+    }))
+    .filter((row) => Number.isFinite(row.id) && row.id > 0);
+});
+
+const tokenCache = {};
+
+export function requireFixtures() {
+  if (users.length === 0) {
+    throw new Error(`No load-test users found in ${USERS_FILE}`);
+  }
+  if (markets.length === 0) {
+    throw new Error(`No load-test markets found in ${MARKETS_FILE}`);
+  }
+}
+
+export function pick(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+export function pickUser() {
+  return pick(users);
+}
+
+export function pickMarket({ hotOnly = false } = {}) {
+  const hotMarkets = markets.filter((market) => market.kind === 'hot');
+  if (hotOnly && hotMarkets.length > 0) return pick(hotMarkets);
+  if (hotMarkets.length > 0 && Math.random() < HOT_MARKET_WEIGHT / (HOT_MARKET_WEIGHT + 1)) {
+    return pick(hotMarkets);
+  }
+  return pick(markets);
+}
+
+export function authHeaders(token) {
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  };
+}
+
+export function login(user) {
+  if (tokenCache[user.username]) return tokenCache[user.username];
+
+  const response = http.post(
+    `${BASE_URL}/v0/login`,
+    JSON.stringify({ username: user.username, password: user.password }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  const ok = check(response, {
+    'login returned 200': (r) => r.status === 200,
+    'login returned token': (r) => Boolean(r.json('result.token')),
+  });
+  if (!ok) {
+    loginFailures.add(1);
+    return '';
+  }
+
+  const token = response.json('result.token');
+  tokenCache[user.username] = token;
+  return token;
+}
+
+export function placeBet({ hotOnly = false } = {}) {
+  const user = pickUser();
+  const market = pickMarket({ hotOnly });
+  const token = login(user);
+  if (!token) {
+    betsFailed.add(1);
+    return;
+  }
+
+  betsAttempted.add(1);
+  const outcome = Math.random() < 0.5 ? 'YES' : 'NO';
+  const response = http.post(
+    `${BASE_URL}/v0/bet`,
+    JSON.stringify({ marketId: market.id, amount: BET_AMOUNT, outcome }),
+    authHeaders(token),
+  );
+
+  const ok = check(response, {
+    'bet returned 201': (r) => r.status === 201,
+  });
+  if (ok) {
+    betsSucceeded.add(1);
+  } else {
+    betsFailed.add(1);
+  }
+}
+
+export function readMarket() {
+	const market = pickMarket();
+	const response = http.get(`${BASE_URL}/v0/markets/${market.id}`);
+	check(response, {
+		'market detail returned 200': (r) => r.status === 200,
+	});
+}
+
+export function readMarketList() {
+	const response = http.get(`${BASE_URL}/v0/markets`);
+	check(response, {
+		'market list returned 200': (r) => r.status === 200,
+	});
+}
+
+export function checkProbes() {
+  for (const path of ['/health', '/readyz', '/ops/status']) {
+    const response = http.get(`${BASE_URL}${path}`);
+    check(response, {
+      [`${path} returned 200`]: (r) => r.status === 200,
+    });
+  }
+}

--- a/loadtest/k6/smoke.js
+++ b/loadtest/k6/smoke.js
@@ -1,0 +1,23 @@
+import { sleep } from 'k6';
+import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures } from './lib/common.js';
+
+export const options = {
+  vus: Number(__ENV.VUS || '1'),
+  iterations: Number(__ENV.ITERATIONS || '3'),
+  thresholds: {
+    checks: ['rate>0.95'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+export function setup() {
+  requireFixtures();
+  checkProbes();
+}
+
+export default function () {
+  readMarketList();
+  readMarket();
+  placeBet();
+  sleep(1);
+}

--- a/loadtest/k6/soak.js
+++ b/loadtest/k6/soak.js
@@ -1,5 +1,5 @@
 import { sleep } from 'k6';
-import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures } from './lib/common.js';
+import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures, secureRandomFraction } from './lib/common.js';
 
 const duration = __ENV.DURATION || '30m';
 const rate = Number(__ENV.RATE || '10');
@@ -27,7 +27,7 @@ export function setup() {
 }
 
 export default function () {
-  const roll = Math.random();
+  const roll = secureRandomFraction();
   if (roll < 0.35) {
     readMarketList();
   } else if (roll < 0.7) {

--- a/loadtest/k6/soak.js
+++ b/loadtest/k6/soak.js
@@ -1,0 +1,39 @@
+import { sleep } from 'k6';
+import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures } from './lib/common.js';
+
+const duration = __ENV.DURATION || '30m';
+const rate = Number(__ENV.RATE || '10');
+
+export const options = {
+  scenarios: {
+    soak: {
+      executor: 'constant-arrival-rate',
+      rate,
+      timeUnit: '1s',
+      duration,
+      preAllocatedVUs: Number(__ENV.PREALLOCATED_VUS || '50'),
+      maxVUs: Number(__ENV.MAX_VUS || '500'),
+    },
+  },
+  thresholds: {
+    checks: ['rate>0.95'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+export function setup() {
+  requireFixtures();
+  checkProbes();
+}
+
+export default function () {
+  const roll = Math.random();
+  if (roll < 0.35) {
+    readMarketList();
+  } else if (roll < 0.7) {
+    readMarket();
+  } else {
+    placeBet();
+  }
+  sleep(0.25);
+}

--- a/loadtest/results/.gitignore
+++ b/loadtest/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/loadtest.sh
+++ b/scripts/loadtest.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[ -z "${CALLED_FROM_SOCIALPREDICT:-}" ] && { echo "Not called from SocialPredict"; exit 42; }
+
+print_loadtest_help() {
+  cat <<'EOF'
+Usage: ./SocialPredict load COMMAND [OPTIONS]
+
+Commands:
+  seed    Create/reset guarded load-test users, moderators, markets, and fixture CSVs
+  help    Show this help
+
+Examples:
+  LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --hot-markets 1 --reset
+  LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 50000 --moderators 100 --markets 1000 --hot-markets 10 --reset
+EOF
+}
+
+print_loadtest_seed_help() {
+  cat <<'EOF'
+Usage: ./SocialPredict load seed [OPTIONS]
+
+Create or reset load-test fixtures through the normal database.
+
+Safety:
+  This command refuses to run unless LOAD_TEST_ENABLED=true.
+  This command refuses APP_ENV=production unless LOAD_TEST_ALLOW_PRODUCTION=true.
+  Generated fixture CSVs are written to loadtest/fixtures/ and are gitignored.
+
+Created/updated data:
+  loaduser000001...       REGULAR users with must_change_password=false
+  loadmod000001...        MODERATOR users with active moderator status
+  Load Test Market ...    published markets owned by load-test moderators
+
+Defaults:
+  password: loadtest-password
+  users: 10
+  moderators: 2
+  markets: 5
+  hot markets: 1
+  user prefix: loaduser
+  moderator prefix: loadmod
+  user balance: 1000000
+
+Options:
+  --users N              Number of REGULAR test users, 1-50000
+  --moderators N         Number of MODERATOR test users, 1-10000
+  --markets N            Number of published fixture markets, 1-50000
+  --hot-markets N        Number of fixture markets marked hot in markets.csv
+  --password VALUE       Password for every load-test user
+  --user-prefix VALUE    Prefix for regular users, e.g. loaduser
+  --moderator-prefix VALUE
+                          Prefix for moderators, e.g. loadmod
+  --user-balance N       Starting balance for each load-test user
+  --resolution-days N    Days until generated markets resolve, 1-3650
+  --bcrypt-cost N        Password hash cost, 4-31; defaults low for bulk fixtures
+  --reset                Remove existing prefixed fixture users, markets, and bets first
+  --help                 Show this help
+
+Examples:
+  LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --reset
+  LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 50000 --moderators 100 --markets 1000 --hot-markets 10 --reset
+EOF
+}
+
+require_integer() {
+  local label="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    print_error "${label} must be a non-negative integer."
+    exit 1
+  fi
+}
+
+run_loadtest_seed() {
+  local users="10"
+  local moderators="2"
+  local markets="5"
+  local hot_markets="1"
+  local password="loadtest-password"
+  local user_prefix="loaduser"
+  local moderator_prefix="loadmod"
+  local user_balance=""
+  local resolution_days="30"
+  local bcrypt_cost=""
+  local reset="false"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --users)
+        shift
+        users="${1:-}"
+        ;;
+      --moderators)
+        shift
+        moderators="${1:-}"
+        ;;
+      --markets)
+        shift
+        markets="${1:-}"
+        ;;
+      --hot-markets)
+        shift
+        hot_markets="${1:-}"
+        ;;
+      --password)
+        shift
+        password="${1:-}"
+        ;;
+      --user-prefix)
+        shift
+        user_prefix="${1:-}"
+        ;;
+      --moderator-prefix)
+        shift
+        moderator_prefix="${1:-}"
+        ;;
+      --user-balance)
+        shift
+        user_balance="${1:-}"
+        ;;
+      --resolution-days)
+        shift
+        resolution_days="${1:-}"
+        ;;
+      --bcrypt-cost)
+        shift
+        bcrypt_cost="${1:-}"
+        ;;
+      --reset)
+        reset="true"
+        ;;
+      --help|-h|help)
+        print_loadtest_seed_help
+        return 0
+        ;;
+      *)
+        print_error "Unknown load seed option: $1"
+        print_loadtest_seed_help
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  require_integer "--users" "${users}"
+  require_integer "--moderators" "${moderators}"
+  require_integer "--markets" "${markets}"
+  require_integer "--hot-markets" "${hot_markets}"
+  require_integer "--resolution-days" "${resolution_days}"
+  if [ -n "${user_balance}" ]; then
+    require_integer "--user-balance" "${user_balance}"
+  fi
+  if [ -n "${bcrypt_cost}" ]; then
+    require_integer "--bcrypt-cost" "${bcrypt_cost}"
+  fi
+
+  if [ "${LOAD_TEST_ENABLED:-false}" != "true" ]; then
+    print_error "Refusing to run load seed unless LOAD_TEST_ENABLED=true is set."
+    exit 1
+  fi
+
+  if ! docker ps --format '{{.Names}}' | grep -qx "${BACKEND_CONTAINER_NAME}"; then
+    print_error "Backend container '${BACKEND_CONTAINER_NAME}' is not running. Start the app first with './SocialPredict up'."
+    exit 1
+  fi
+
+  local network_name
+  network_name="$(docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' "${BACKEND_CONTAINER_NAME}" | head -n 1)"
+  if [ -z "${network_name}" ]; then
+    print_error "Could not determine Docker network for ${BACKEND_CONTAINER_NAME}."
+    exit 1
+  fi
+
+  local platform_args=()
+  if [ -n "${FORCE_PLATFORM:-}" ]; then
+    platform_args=(--platform "${FORCE_PLATFORM}")
+  fi
+
+  local optional_env=()
+  if [ -n "${user_balance}" ]; then
+    optional_env+=(-e "LOAD_TEST_USER_BALANCE=${user_balance}")
+  fi
+  if [ -n "${bcrypt_cost}" ]; then
+    optional_env+=(-e "LOAD_TEST_BCRYPT_COST=${bcrypt_cost}")
+  fi
+
+  print_status "Seeding load-test fixtures through Docker network '${network_name}' ..."
+
+  docker run --rm \
+    "${platform_args[@]}" \
+    --network "${network_name}" \
+    -v "socialpredict_loadtest_go_mod:/go/pkg/mod" \
+    -v "socialpredict_loadtest_go_build:/root/.cache/go-build" \
+    -v "${SCRIPT_DIR}:/workspace" \
+    -w /workspace/backend \
+    -e "APP_ENV=${APP_ENV}" \
+    -e "DB_HOST=db" \
+    -e "DB_PORT=5432" \
+    -e "POSTGRES_USER=${POSTGRES_USER}" \
+    -e "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+    -e "POSTGRES_DATABASE=${POSTGRES_DATABASE}" \
+    -e "DB_REQUIRE_TLS=${DB_REQUIRE_TLS:-false}" \
+    -e "DB_SSLMODE=${DB_SSLMODE:-disable}" \
+    -e "LOAD_TEST_ENABLED=${LOAD_TEST_ENABLED:-false}" \
+    -e "LOAD_TEST_ALLOW_PRODUCTION=${LOAD_TEST_ALLOW_PRODUCTION:-false}" \
+    -e "LOAD_TEST_RESET=${reset}" \
+    -e "LOAD_TEST_USER_COUNT=${users}" \
+    -e "LOAD_TEST_MODERATOR_COUNT=${moderators}" \
+    -e "LOAD_TEST_MARKET_COUNT=${markets}" \
+    -e "LOAD_TEST_HOT_MARKET_COUNT=${hot_markets}" \
+    -e "LOAD_TEST_PASSWORD=${password}" \
+    -e "LOAD_TEST_USER_PREFIX=${user_prefix}" \
+    -e "LOAD_TEST_MODERATOR_PREFIX=${moderator_prefix}" \
+    -e "LOAD_TEST_FIXTURE_DIR=/workspace/loadtest/fixtures" \
+    -e "LOAD_TEST_RESOLUTION_DAYS=${resolution_days}" \
+    "${optional_env[@]}" \
+    golang:1.25-alpine \
+    sh -lc "export PATH=/usr/local/go/bin:/go/bin:\$PATH; go run ./cmd/loadtestseed"
+}
+
+command="${1:-help}"
+case "${command}" in
+  seed)
+    shift
+    run_loadtest_seed "$@"
+    ;;
+  --help|-h|help)
+    print_loadtest_help
+    ;;
+  *)
+    print_error "Unknown load command: ${command}"
+    print_loadtest_help
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Adds FEATURE/04 production notes for staging-safe load testing, hot-market betting simulations, and release dossier evidence.
- Adds the portable `loadtest/` harness with k6 smoke/baseline/hot-market/soak scenarios and dossier summarization.
- Adds guarded fixture seeding via `./SocialPredict load seed`, generating fake users, approved moderators, published markets, and gitignored fixture CSVs.
- Keeps betting traffic on normal `/v0/login` + `/v0/bet` behavior; no god token or DigitalOcean credential is used for k6 API traffic.

## Safety
- `LOAD_TEST_ENABLED=true` is required for seeding.
- `APP_ENV=production` is refused unless `LOAD_TEST_ALLOW_PRODUCTION=true` is explicitly set.
- `--reset` removes only prefixed load-test users, moderator users, markets, and related bets.
- Generated `loadtest/fixtures/*.csv` and `loadtest/results/*` files remain gitignored.

## Validation
- `bash -n SocialPredict scripts/loadtest.sh`
- `git diff --check`
- `cd backend && go test ./cmd/loadtestseed`
- `cd backend && go test ./...`
- `node --check loadtest/dossier/summarize.mjs`
- `node --check loadtest/k6/*.js loadtest/k6/lib/*.js`
- `LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 2 --moderators 1 --markets 2 --hot-markets 1 --reset`
- `./loadtest/cli/loadtest check`
- `./loadtest/cli/loadtest run smoke --base-url http://localhost:8080`
