### PR TITLE
Add remote fixture pull for load tests

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -114,7 +114,8 @@ cp loadtest/fixtures/markets.example.csv loadtest/fixtures/markets.csv
 Run a smoke scenario:
 
 ```bash
-./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
+./loadtest/cli/loadtest fixtures pull staging
+./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ```
 
 Generate a release dossier from the k6 summary output:

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -9,9 +9,10 @@ Seed fixture CSVs with `./SocialPredict load seed`, or provide files under `load
 ```bash
 LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --reset
 ./loadtest/cli/loadtest check
-./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
-./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --duration 5m --browse-rate 20 --bet-rate 5
-./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 100 --duration 60s
+./loadtest/cli/loadtest fixtures pull staging
+./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
+./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --duration 5m --browse-rate 20 --bet-rate 5
+./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 100 --duration 60s
 ./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --metadata loadtest/dossier/metadata.example.json --out loadtest/dossier/runs/<run>.json
 ```
 
@@ -20,3 +21,25 @@ LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --mar
 k6 logs in with normal fake SocialPredict users from `users.csv` and uses normal bearer tokens for `/v0/bet`.
 
 No DigitalOcean credentials or betting god token are used by this CLI.
+
+## Remote Fixture Pull
+
+After running `./SocialPredict load seed` on a remote staging host, pull the generated fixture CSVs back to your load-generator machine:
+
+```bash
+./loadtest/cli/loadtest fixtures pull staging
+```
+
+The staging defaults are `root@kconfs.com`, `~/.keys/socialpredict/staging/id_ed25519`, and `/opt/socialpredict/loadtest/fixtures`.
+
+Override values when needed:
+
+```bash
+./loadtest/cli/loadtest fixtures pull staging \
+  --host root@45.55.227.1 \
+  --key ~/.keys/socialpredict/staging/id_ed25519 \
+  --remote-path /opt/socialpredict/loadtest/fixtures \
+  --local-path loadtest/fixtures
+```
+
+Public staging/prod Nginx publishes API routes under `/api`, so use `--api-prefix /api` when running against `https://kconfs.com` or `https://brierfoxforecast.com`. Direct backend targets such as `http://localhost:8080` should omit the prefix.

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -229,6 +229,7 @@ run_cmd() {
   fi
 
   echo "Running ${scenario} against ${base_url}"
+  echo "API prefix: ${api_prefix:-<none>}"
   (
     cd "$REPO_DIR"
     BASE_URL="$base_url" \

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -11,13 +11,15 @@ Usage: ./loadtest/cli/loadtest COMMAND [OPTIONS]
 
 Commands:
   check                  Check local load-test prerequisites
+  fixtures pull <env>    Pull generated fixture CSVs from a remote host
   run <scenario>         Run k6 scenario: smoke, baseline, hot-market-burst, soak
   dossier                Generate release dossier JSON from a k6 summary
   help                   Show this help
 
 Run examples:
   ./loadtest/cli/loadtest check
-  ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com
+  ./loadtest/cli/loadtest fixtures pull staging
+  ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
   ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 100 --duration 60s
   ./loadtest/cli/loadtest dossier --summary loadtest/results/smoke-20260528T120000Z-summary.json --out loadtest/dossier/runs/smoke.json
 
@@ -73,6 +75,108 @@ check_cmd() {
   echo "Load-test prerequisites look ready."
 }
 
+fixture_host_for_env() {
+  case "$1" in
+    staging)
+      echo "root@kconfs.com"
+      ;;
+    mo|prod|production)
+      echo "root@brierfoxforecast.com"
+      ;;
+    *)
+      echo "root@$1"
+      ;;
+  esac
+}
+
+fixtures_pull_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest fixtures pull <env> [OPTIONS]
+
+Pull generated load-test fixture CSVs from a remote SocialPredict host.
+
+Defaults:
+  staging host:    root@kconfs.com
+  mo/prod host:    root@brierfoxforecast.com
+  key path:        ~/.keys/socialpredict/<env>/id_ed25519
+  remote path:     /opt/socialpredict/loadtest/fixtures
+  local path:      loadtest/fixtures
+  files:           users.csv, markets.csv
+
+Options:
+  --host VALUE          SSH host, e.g. root@45.55.227.1 or root@kconfs.com
+  --key VALUE           SSH private key path
+  --port VALUE          SSH port; default 22
+  --remote-path VALUE   Remote fixture directory
+  --local-path VALUE    Local fixture directory
+  --help                Show this help
+
+Examples:
+  ./loadtest/cli/loadtest fixtures pull staging
+  ./loadtest/cli/loadtest fixtures pull staging --host root@45.55.227.1
+HELP
+}
+
+fixtures_pull_cmd() {
+  case "${1:-}" in
+    --help|-h|help)
+      fixtures_pull_help
+      exit 0
+      ;;
+  esac
+
+  if [ "$#" -lt 1 ]; then
+    echo "fixtures pull requires <env>." >&2
+    fixtures_pull_help
+    exit 1
+  fi
+
+  local env_name="$1"
+  shift
+  local host
+  host="$(fixture_host_for_env "$env_name")"
+  local key="${HOME}/.keys/socialpredict/${env_name}/id_ed25519"
+  local port="22"
+  local remote_path="/opt/socialpredict/loadtest/fixtures"
+  local local_path="${LOADTEST_DIR}/fixtures"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --host) host="$2"; shift 2 ;;
+      --key) key="$2"; shift 2 ;;
+      --port) port="$2"; shift 2 ;;
+      --remote-path) remote_path="$2"; shift 2 ;;
+      --local-path) local_path="$2"; shift 2 ;;
+      --help|-h) fixtures_pull_help; exit 0 ;;
+      *) echo "Unknown fixtures pull option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  require_command scp
+  if [ ! -f "$key" ]; then
+    echo "Missing SSH key: $key" >&2
+    exit 1
+  fi
+
+  mkdir -p "$local_path"
+  echo "Pulling load-test fixtures from ${host}:${remote_path}"
+  scp -P "$port" -i "$key" "${host}:${remote_path}/users.csv" "${local_path}/users.csv"
+  scp -P "$port" -i "$key" "${host}:${remote_path}/markets.csv" "${local_path}/markets.csv"
+  echo "Fixtures pulled:"
+  echo "  ${local_path}/users.csv"
+  echo "  ${local_path}/markets.csv"
+}
+
+fixtures_cmd() {
+  local subcommand="${1:-help}"
+  shift || true
+  case "$subcommand" in
+    pull) fixtures_pull_cmd "$@" ;;
+    --help|-h|help) fixtures_pull_help ;;
+    *) echo "Unknown fixtures command: $subcommand" >&2; fixtures_pull_help; exit 1 ;;
+  esac
+}
+
 run_cmd() {
   if [ "$#" -lt 1 ]; then
     echo "Missing scenario." >&2
@@ -82,6 +186,7 @@ run_cmd() {
   local scenario="$1"
   shift
   local base_url="${BASE_URL:-http://localhost:8080}"
+  local api_prefix="${API_PREFIX:-}"
   local users_file="${USERS_FILE:-${LOADTEST_DIR}/fixtures/users.csv}"
   local markets_file="${MARKETS_FILE:-${LOADTEST_DIR}/fixtures/markets.csv}"
   local duration="${DURATION:-}"
@@ -93,6 +198,7 @@ run_cmd() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --base-url) base_url="$2"; shift 2 ;;
+      --api-prefix) api_prefix="$2"; shift 2 ;;
       --users-file) users_file="$2"; shift 2 ;;
       --markets-file) markets_file="$2"; shift 2 ;;
       --duration) duration="$2"; shift 2 ;;
@@ -126,6 +232,7 @@ run_cmd() {
   (
     cd "$REPO_DIR"
     BASE_URL="$base_url" \
+    API_PREFIX="$api_prefix" \
     USERS_FILE="$users_file" \
     MARKETS_FILE="$markets_file" \
     DURATION="$duration" \
@@ -167,6 +274,7 @@ command="${1:-help}"
 shift || true
 case "$command" in
   check) check_cmd "$@" ;;
+  fixtures) fixtures_cmd "$@" ;;
   run) run_cmd "$@" ;;
   dossier) dossier_cmd "$@" ;;
   help|--help|-h) print_help ;;

--- a/loadtest/k6/lib/common.js
+++ b/loadtest/k6/lib/common.js
@@ -10,6 +10,7 @@ export const betsFailed = new Counter('sp_bets_failed');
 export const loginFailures = new Counter('sp_login_failures');
 
 export const BASE_URL = (__ENV.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
+export const API_PREFIX = normalizeApiPrefix(__ENV.API_PREFIX || '');
 export const USERS_FILE = __ENV.USERS_FILE || 'loadtest/fixtures/users.csv';
 export const MARKETS_FILE = __ENV.MARKETS_FILE || 'loadtest/fixtures/markets.csv';
 export const DEFAULT_PASSWORD = __ENV.LOADTEST_PASSWORD || '';
@@ -52,6 +53,16 @@ export const markets = new SharedArray('loadtest markets', () => {
 });
 
 const tokenCache = {};
+
+function normalizeApiPrefix(prefix) {
+  const trimmed = String(prefix || '').trim();
+  if (!trimmed || trimmed === '/') return '';
+  return trimmed.startsWith('/') ? trimmed.replace(/\/$/, '') : `/${trimmed.replace(/\/$/, '')}`;
+}
+
+function apiUrl(path) {
+  return `${BASE_URL}${API_PREFIX}${path}`;
+}
 
 export function secureRandomFraction() {
   const bytes = new Uint8Array(crypto.randomBytes(4));
@@ -102,7 +113,7 @@ export function login(user) {
   if (tokenCache[user.username]) return tokenCache[user.username];
 
   const response = http.post(
-    `${BASE_URL}/v0/login`,
+    apiUrl('/v0/login'),
     JSON.stringify({ username: user.username, password: user.password }),
     { headers: { 'Content-Type': 'application/json' } },
   );
@@ -133,7 +144,7 @@ export function placeBet({ hotOnly = false } = {}) {
   betsAttempted.add(1);
   const outcome = secureRandomBoolean() ? 'YES' : 'NO';
   const response = http.post(
-    `${BASE_URL}/v0/bet`,
+    apiUrl('/v0/bet'),
     JSON.stringify({ marketId: market.id, amount: BET_AMOUNT, outcome }),
     authHeaders(token),
   );
@@ -150,14 +161,14 @@ export function placeBet({ hotOnly = false } = {}) {
 
 export function readMarket() {
 	const market = pickMarket();
-	const response = http.get(`${BASE_URL}/v0/markets/${market.id}`);
+	const response = http.get(apiUrl(`/v0/markets/${market.id}`));
 	check(response, {
 		'market detail returned 200': (r) => r.status === 200,
 	});
 }
 
 export function readMarketList() {
-	const response = http.get(`${BASE_URL}/v0/markets`);
+	const response = http.get(apiUrl('/v0/markets'));
 	check(response, {
 		'market list returned 200': (r) => r.status === 200,
 	});

--- a/loadtest/k6/lib/common.js
+++ b/loadtest/k6/lib/common.js
@@ -8,6 +8,7 @@ export const betsAttempted = new Counter('sp_bets_attempted');
 export const betsSucceeded = new Counter('sp_bets_succeeded');
 export const betsFailed = new Counter('sp_bets_failed');
 export const loginFailures = new Counter('sp_login_failures');
+export const marketReadFailures = new Counter('sp_market_read_failures');
 
 export const BASE_URL = (__ENV.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
 export const API_PREFIX = normalizeApiPrefix(__ENV.API_PREFIX || '');
@@ -16,6 +17,9 @@ export const MARKETS_FILE = __ENV.MARKETS_FILE || 'loadtest/fixtures/markets.csv
 export const DEFAULT_PASSWORD = __ENV.LOADTEST_PASSWORD || '';
 export const BET_AMOUNT = Number(__ENV.BET_AMOUNT || '1');
 export const HOT_MARKET_WEIGHT = Number(__ENV.HOT_MARKET_WEIGHT || '8');
+export const FAILURE_LOG_LIMIT = Number(__ENV.FAILURE_LOG_LIMIT || '10');
+
+let failureLogCount = 0;
 
 function parseCsv(raw) {
   const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
@@ -62,6 +66,33 @@ function normalizeApiPrefix(prefix) {
 
 function apiUrl(path) {
   return `${BASE_URL}${API_PREFIX}${path}`;
+}
+
+function responseSnippet(response) {
+  if (!response || !response.body) return '';
+  return String(response.body).replace(/\s+/g, ' ').slice(0, 240);
+}
+
+function recordFailure(kind, response, context = {}) {
+  const status = response ? String(response.status) : 'unknown';
+  const tags = { kind, status };
+  if (context.reason) tags.reason = context.reason;
+  if (kind === 'login') {
+    loginFailures.add(1, tags);
+  } else if (kind === 'bet') {
+    betsFailed.add(1, tags);
+  } else if (kind === 'market_read') {
+    marketReadFailures.add(1, tags);
+  }
+
+  if (failureLogCount >= FAILURE_LOG_LIMIT) return;
+  failureLogCount += 1;
+
+  const details = Object.entries(context)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .map(([key, value]) => `${key}=${value}`)
+    .join(' ');
+  console.warn(`[loadtest] ${kind} failed status=${status} ${details} body="${responseSnippet(response)}"`);
 }
 
 export function secureRandomFraction() {
@@ -123,7 +154,7 @@ export function login(user) {
     'login returned token': (r) => Boolean(r.json('result.token')),
   });
   if (!ok) {
-    loginFailures.add(1);
+    recordFailure('login', response, { user: user.username, url: apiUrl('/v0/login') });
     return '';
   }
 
@@ -137,7 +168,7 @@ export function placeBet({ hotOnly = false } = {}) {
   const market = pickMarket({ hotOnly });
   const token = login(user);
   if (!token) {
-    betsFailed.add(1);
+    betsFailed.add(1, { reason: 'login_failed' });
     return;
   }
 
@@ -155,23 +186,29 @@ export function placeBet({ hotOnly = false } = {}) {
   if (ok) {
     betsSucceeded.add(1);
   } else {
-    betsFailed.add(1);
+    recordFailure('bet', response, { marketId: market.id, outcome, url: apiUrl('/v0/bet') });
   }
 }
 
 export function readMarket() {
 	const market = pickMarket();
 	const response = http.get(apiUrl(`/v0/markets/${market.id}`));
-	check(response, {
+	const ok = check(response, {
 		'market detail returned 200': (r) => r.status === 200,
 	});
+	if (!ok) {
+		recordFailure('market_read', response, { marketId: market.id, url: apiUrl(`/v0/markets/${market.id}`) });
+	}
 }
 
 export function readMarketList() {
 	const response = http.get(apiUrl('/v0/markets'));
-	check(response, {
+	const ok = check(response, {
 		'market list returned 200': (r) => r.status === 200,
 	});
+	if (!ok) {
+		recordFailure('market_read', response, { url: apiUrl('/v0/markets') });
+	}
 }
 
 export function checkProbes() {


### PR DESCRIPTION
## Summary
- Adds `./loadtest/cli/loadtest fixtures pull <env>` to copy generated `users.csv` and `markets.csv` from remote SocialPredict hosts.
- Adds staging defaults for `root@kconfs.com`, `~/.keys/socialpredict/staging/id_ed25519`, and `/opt/socialpredict/loadtest/fixtures`.
- Adds `--api-prefix` to k6 runs so public Nginx deployments can use `/api` while direct backend targets keep no prefix.
- Documents the staging fixture pull and public API prefix flow.

## Validation
- `bash -n loadtest/cli/loadtest`
- `node --check loadtest/k6/*.js loadtest/k6/lib/*.js`
- `git diff --check`
- `./loadtest/cli/loadtest fixtures pull staging`
- `./loadtest/cli/loadtest check`
- `./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api`