### PR TITLE
Add runtime-configurable rate limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,4 +52,12 @@ SECURITY_FRAME_ANCESTORS="'none'"
 SHARE_DEFAULT_IMAGE_URL=''
 SHARE_SITE_NAME='SocialPredict'
 
+# Runtime rate limits are ops/security posture, not game setup.
+# secure-default profile:
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+
 TRAEFIK_CONTAINER_NAME=socialpredict-traefik-container

--- a/README/INFRA/README-INFRA-PRODUCTION.md
+++ b/README/INFRA/README-INFRA-PRODUCTION.md
@@ -94,19 +94,20 @@ provider-appropriate TLS mode, for example `DB_REQUIRE_TLS=true` with
 
 `./SocialPredict install` also writes runtime rate-limit values into `.env`.
 These values are operations/security policy, not game setup. The
-OpenPredictionMarkets production Ansible deploy now sets
-`RATE_LIMIT_PROFILE=secure-default` while invoking the installer. Production-like
-manual installs also default to the conservative `secure-default` profile unless
-the operator explicitly passes a different profile:
+OpenPredictionMarkets production Ansible deploy sources the non-secret overlay
+at `deploy/env/.env.mo` before invoking the installer. Production-like manual
+installs also default to the conservative `secure-default` profile unless the
+operator explicitly passes a different profile:
 
 ```bash
 ./SocialPredict install -e production -d brierfoxforecast.com -m ops@example.com
 ./SocialPredict install -e production -d brierfoxforecast.com -m ops@example.com -r custom
 ```
 
-The default production profile writes:
+The production/model-office overlay contains:
 
 ```text
+RATE_LIMIT_PROFILE=env-file
 RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
 RATE_LIMIT_LOGIN_BURST=3
 RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
@@ -114,11 +115,15 @@ RATE_LIMIT_GENERAL_BURST=10
 RATE_LIMIT_CLEANUP_INTERVAL=5m
 ```
 
+`RATE_LIMIT_PROFILE=env-file` is consumed during install. The generated host
+`.env` stores the concrete `RATE_LIMIT_*` values.
+
 Do not use the staging/load-test profile for production unless the operator has
 fresh capacity evidence for that host size and deployment topology.
 
-The Ansible workflow accepts the optional `PRODUCTION_RATE_LIMIT_PROFILE` secret
-if an operator intentionally needs to override the default production profile.
+The Ansible workflow accepts the optional `PRODUCTION_RATE_LIMIT_ENV_FILE`
+secret if an operator intentionally needs to source a different non-secret
+overlay path.
 
 The `ansible_playbooks` repository may also contain an `ADMIN_PASSWORD` secret,
 but the current production workflow does not pass it into the Ansible command.

--- a/README/INFRA/README-INFRA-PRODUCTION.md
+++ b/README/INFRA/README-INFRA-PRODUCTION.md
@@ -93,9 +93,11 @@ provider-appropriate TLS mode, for example `DB_REQUIRE_TLS=true` with
 `DB_SSLMODE=verify-full` when certificate validation is configured.
 
 `./SocialPredict install` also writes runtime rate-limit values into `.env`.
-These values are operations/security policy, not game setup. Production-like
-installs default to the conservative `secure-default` profile unless the
-operator or Ansible workflow explicitly passes a different profile:
+These values are operations/security policy, not game setup. The
+OpenPredictionMarkets production Ansible deploy now sets
+`RATE_LIMIT_PROFILE=secure-default` while invoking the installer. Production-like
+manual installs also default to the conservative `secure-default` profile unless
+the operator explicitly passes a different profile:
 
 ```bash
 ./SocialPredict install -e production -d brierfoxforecast.com -m ops@example.com
@@ -114,6 +116,9 @@ RATE_LIMIT_CLEANUP_INTERVAL=5m
 
 Do not use the staging/load-test profile for production unless the operator has
 fresh capacity evidence for that host size and deployment topology.
+
+The Ansible workflow accepts the optional `PRODUCTION_RATE_LIMIT_PROFILE` secret
+if an operator intentionally needs to override the default production profile.
 
 The `ansible_playbooks` repository may also contain an `ADMIN_PASSWORD` secret,
 but the current production workflow does not pass it into the Ansible command.

--- a/README/INFRA/README-INFRA-PRODUCTION.md
+++ b/README/INFRA/README-INFRA-PRODUCTION.md
@@ -92,6 +92,29 @@ packaged local compose database. For an external production database, set a
 provider-appropriate TLS mode, for example `DB_REQUIRE_TLS=true` with
 `DB_SSLMODE=verify-full` when certificate validation is configured.
 
+`./SocialPredict install` also writes runtime rate-limit values into `.env`.
+These values are operations/security policy, not game setup. Production-like
+installs default to the conservative `secure-default` profile unless the
+operator or Ansible workflow explicitly passes a different profile:
+
+```bash
+./SocialPredict install -e production -d brierfoxforecast.com -m ops@example.com
+./SocialPredict install -e production -d brierfoxforecast.com -m ops@example.com -r custom
+```
+
+The default production profile writes:
+
+```text
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+Do not use the staging/load-test profile for production unless the operator has
+fresh capacity evidence for that host size and deployment topology.
+
 The `ansible_playbooks` repository may also contain an `ADMIN_PASSWORD` secret,
 but the current production workflow does not pass it into the Ansible command.
 It is only relevant if the workflow or a manual Ansible run supplies an

--- a/README/INFRA/README-INFRA-STAGING.md
+++ b/README/INFRA/README-INFRA-STAGING.md
@@ -84,17 +84,21 @@ performs this high-level flow:
    /opt/socialpredict/SocialPredict install -e production -d "$STAGING_DOMAIN" -m "$STAGING_EMAIL"
    ```
 
-   The installer also owns runtime rate-limit values in `.env`. If staging is
-   being used for load-test evidence on the current 512 MiB / 1 vCPU
-   DigitalOcean droplet, the Ansible command should select the staging profile:
+   The installer also owns runtime rate-limit values in `.env`. For
+   OpenPredictionMarkets staging, the `ansible_playbooks` deploy now sets
+   `RATE_LIMIT_PROFILE=small-droplet-staging` while invoking the installer so
+   the current 512 MiB / 1 vCPU DigitalOcean droplet uses the measurement
+   profile after this SocialPredict runtime support is deployed.
+
+   Equivalent manual command:
 
    ```bash
    /opt/socialpredict/SocialPredict install -e production -d "$STAGING_DOMAIN" -m "$STAGING_EMAIL" -r small-droplet-staging
    ```
 
-   Equivalently, the Ansible workflow can export
-   `RATE_LIMIT_PROFILE=small-droplet-staging` before invoking the installer.
-   Without an explicit profile, production-like installs use
+   The Ansible workflow also accepts the optional
+   `STAGING_RATE_LIMIT_PROFILE` secret if an operator needs to override that
+   default. Without an explicit profile, production-like installs use
    `secure-default`.
 
 6. Builds staging backend and frontend Docker images on the host.

--- a/README/INFRA/README-INFRA-STAGING.md
+++ b/README/INFRA/README-INFRA-STAGING.md
@@ -85,21 +85,24 @@ performs this high-level flow:
    ```
 
    The installer also owns runtime rate-limit values in `.env`. For
-   OpenPredictionMarkets staging, the `ansible_playbooks` deploy now sets
-   `RATE_LIMIT_PROFILE=small-droplet-staging` while invoking the installer so
-   the current 512 MiB / 1 vCPU DigitalOcean droplet uses the measurement
-   profile after this SocialPredict runtime support is deployed.
+   OpenPredictionMarkets staging, the `ansible_playbooks` deploy sources the
+   non-secret overlay at `deploy/env/.env.staging` before invoking the installer.
+   That overlay is intentionally high so one Mac/k6 source IP can hammer staging
+   without the per-IP limiter masking app/database/host capacity evidence.
 
    Equivalent manual command:
 
    ```bash
-   /opt/socialpredict/SocialPredict install -e production -d "$STAGING_DOMAIN" -m "$STAGING_EMAIL" -r small-droplet-staging
+   set -a
+   . /opt/socialpredict/deploy/env/.env.staging
+   set +a
+   /opt/socialpredict/SocialPredict install -e production -d "$STAGING_DOMAIN" -m "$STAGING_EMAIL"
    ```
 
    The Ansible workflow also accepts the optional
-   `STAGING_RATE_LIMIT_PROFILE` secret if an operator needs to override that
-   default. Without an explicit profile, production-like installs use
-   `secure-default`.
+   `STAGING_RATE_LIMIT_ENV_FILE` secret if an operator needs to source a
+   different non-secret overlay path. Without an overlay or explicit profile,
+   production-like installs use `secure-default`.
 
 6. Builds staging backend and frontend Docker images on the host.
 7. Writes staging image names into `/opt/socialpredict/.env`.
@@ -220,21 +223,25 @@ RATE_LIMIT_GENERAL_BURST=10
 RATE_LIMIT_CLEANUP_INTERVAL=5m
 ```
 
-The current `small-droplet-staging` profile for the 512 MiB / 1 vCPU staging
-Droplet writes:
+The current OpenPredictionMarkets `.env.staging` overlay for temporary
+single-source load testing contains:
 
 ```text
-RATE_LIMIT_LOGIN_RATE_PER_SECOND=5
-RATE_LIMIT_LOGIN_BURST=20
-RATE_LIMIT_GENERAL_RATE_PER_SECOND=25
-RATE_LIMIT_GENERAL_BURST=50
+RATE_LIMIT_PROFILE=env-file
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=50
+RATE_LIMIT_LOGIN_BURST=100
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=500
+RATE_LIMIT_GENERAL_BURST=1000
 RATE_LIMIT_CLEANUP_INTERVAL=5m
 ```
 
-These are starting values for measurement, not a production promise. If k6,
-DigitalOcean metrics, `/readyz`, or backend logs show CPU saturation, memory
-pressure, database contention, or `RATE_LIMITED`/`LOGIN_RATE_LIMITED` responses,
-record the evidence and tune the profile or host size deliberately.
+`RATE_LIMIT_PROFILE=env-file` is consumed during install. The generated host
+`.env` stores the concrete `RATE_LIMIT_*` values.
+
+These values are for staging capacity measurement from one source IP, not a
+production promise. If k6, DigitalOcean metrics, `/readyz`, or backend logs show
+CPU saturation, memory pressure, database contention, or app failures, record
+the evidence and tune the overlay or host size deliberately.
 
 `STAGING_PRIVATE_KEY` must be the private SSH key whose public key is already in
 the staging VPS user's `~/.ssh/authorized_keys`. `STAGING_PASSWORD` is used as

--- a/README/INFRA/README-INFRA-STAGING.md
+++ b/README/INFRA/README-INFRA-STAGING.md
@@ -84,6 +84,19 @@ performs this high-level flow:
    /opt/socialpredict/SocialPredict install -e production -d "$STAGING_DOMAIN" -m "$STAGING_EMAIL"
    ```
 
+   The installer also owns runtime rate-limit values in `.env`. If staging is
+   being used for load-test evidence on the current 512 MiB / 1 vCPU
+   DigitalOcean droplet, the Ansible command should select the staging profile:
+
+   ```bash
+   /opt/socialpredict/SocialPredict install -e production -d "$STAGING_DOMAIN" -m "$STAGING_EMAIL" -r small-droplet-staging
+   ```
+
+   Equivalently, the Ansible workflow can export
+   `RATE_LIMIT_PROFILE=small-droplet-staging` before invoking the installer.
+   Without an explicit profile, production-like installs use
+   `secure-default`.
+
 6. Builds staging backend and frontend Docker images on the host.
 7. Writes staging image names into `/opt/socialpredict/.env`.
 8. Sets `DB_REQUIRE_TLS=false` for the staging local database topology.
@@ -189,6 +202,35 @@ STAGING_PORT=22
 STAGING_USER=root
 STAGING_DOMAIN=kconfs.com
 ```
+
+Runtime rate limits are not GitHub secrets. They are written into the host
+`.env` by `./SocialPredict install`.
+
+The current `secure-default` profile writes:
+
+```text
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+The current `small-droplet-staging` profile for the 512 MiB / 1 vCPU staging
+Droplet writes:
+
+```text
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=5
+RATE_LIMIT_LOGIN_BURST=20
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=25
+RATE_LIMIT_GENERAL_BURST=50
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+These are starting values for measurement, not a production promise. If k6,
+DigitalOcean metrics, `/readyz`, or backend logs show CPU saturation, memory
+pressure, database contention, or `RATE_LIMITED`/`LOGIN_RATE_LIMITED` responses,
+record the evidence and tune the profile or host size deliberately.
 
 `STAGING_PRIVATE_KEY` must be the private SSH key whose public key is already in
 the staging VPS user's `~/.ssh/authorized_keys`. `STAGING_PASSWORD` is used as

--- a/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
+++ b/README/PRODUCTION-NOTES/FEATURES/04/04-load-testing.md
@@ -123,6 +123,12 @@ The betting path is the first critical write path because it touches authenticat
 
 The first implementation should prefer `k6` for API load generation because it supports scenario-based request-rate testing, JSON result output, and scripting realistic HTTP flows from a local Mac or separate load-generator host.
 
+Runtime rate limits are now tracked separately in
+[`../05/05-runtime-rate-limit-policy.md`](../05/05-runtime-rate-limit-policy.md).
+When a load test fails, the dossier should distinguish app/database/host
+pressure from explicit `RATE_LIMITED` or `LOGIN_RATE_LIMITED` responses before
+using the result as capacity evidence.
+
 k6 is not an in-server test runner for this feature. It is the external traffic generator. For end-to-end evidence, k6 should call the public staging URL, such as `https://kconfs.com`, through the same DNS, TLS, reverse proxy, backend, and Postgres path a real user would use.
 
 Valid runner locations:

--- a/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
@@ -1,6 +1,6 @@
 # 05 Runtime Rate Limit Policy
 
-Status: proposed
+Status: implemented baseline
 Date: 2026-05-29
 
 ## Purpose
@@ -53,7 +53,7 @@ They should not be owned by:
 
 ## Proposed Runtime Environment Variables
 
-Add environment-driven configuration with safe defaults matching current behavior when unset:
+The backend reads environment-driven configuration with safe defaults matching current behavior when unset:
 
 ```bash
 RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
@@ -69,11 +69,11 @@ Existing behavior should remain the fallback:
 - general API: one request per second, burst 10
 - cleanup interval: 5 minutes
 
-The implementation should parse these values during backend startup and pass them into `security.RateLimitConfig` before constructing runtime middleware.
+The implementation parses these values during backend startup and passes them into `security.RateLimitConfig` before constructing runtime middleware. Invalid configured values fail startup so an operator does not accidentally run with an unintended security posture.
 
 ## Install-Time Policy
 
-`./SocialPredict install` should set rate-limit values for production-like installs.
+`./SocialPredict install` sets rate-limit values for production-like installs.
 
 The install flow should not ask users to understand Go token-bucket internals. It should present a small number of profiles, then write explicit `.env` values.
 
@@ -92,7 +92,7 @@ custom
   Operator supplies explicit login/general rate and burst values.
 ```
 
-The production install path should default to `secure-default` unless the operator explicitly chooses a staging/load-test profile.
+The production install path defaults to `secure-default` unless the operator explicitly chooses a staging/load-test profile.
 
 Development installs can keep secure defaults. Developers who need local load testing can override `.env` manually.
 
@@ -126,13 +126,13 @@ For public staging and production URLs, k6 should use:
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ```
 
-For lower-than-one-request-per-second scenarios, the loadtest CLI should support k6 `timeUnit` values. k6 `constant-arrival-rate.rate` must be an integer, so this is invalid:
+For lower-than-one-request-per-second scenarios, the loadtest CLI supports k6 `timeUnit` values. k6 `constant-arrival-rate.rate` must be an integer, so this is invalid:
 
 ```bash
 --bet-rate 0.05
 ```
 
-The desired expression should be supported as:
+The desired expression is supported as:
 
 ```bash
 --bet-rate 1 --bet-time-unit 20s

--- a/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
@@ -1,0 +1,172 @@
+# 05 Runtime Rate Limit Policy
+
+Status: proposed
+Date: 2026-05-29
+
+## Purpose
+
+SocialPredict needs runtime-configurable rate limits so staging, production, and load-test environments can be tuned without changing game rules or rebuilding code.
+
+This is not game setup. It should not live in `backend/setup/setup.yaml`, because rate limits are security and operations policy, not market mechanics or economics.
+
+The first measured target is the current staging DigitalOcean baseline:
+
+- Droplet class: regular CPU
+- Memory: 512 MiB
+- vCPU: 1
+- Transfer: 500 GiB
+- SSD: 10 GiB
+- Cost: about $0.00595/hr, $4/mo
+- Current staging domain: `kconfs.com`
+
+This feature should let operators record what this small machine can safely handle before larger instance sizing, database separation, Redis/distributed rate limiting, or proxy-level rate limiting are introduced.
+
+## Current Problem
+
+The first k6 baseline against `kconfs.com` failed before it reached meaningful database or betting capacity pressure. The backend returned stable security failures:
+
+- `LOGIN_RATE_LIMITED`
+- `RATE_LIMITED`
+
+That means the current test primarily validated the application rate limiter rather than the market, bet, database, or reverse-proxy capacity.
+
+The current defaults remain appropriate as secure defaults, but they are too low for controlled staging load tests from a single load-generator IP.
+
+## Ownership Boundary
+
+Rate limits are runtime security configuration.
+
+They should be owned by:
+
+- `.env` values generated or updated by `./SocialPredict install`
+- backend runtime startup configuration
+- infrastructure/deployment documentation
+- release dossier evidence for measured environments
+
+They should not be owned by:
+
+- `backend/setup/setup.yaml`
+- game-mode setup
+- market economics
+- frontend-only configuration
+- k6 scripts as hard-coded assumptions
+
+## Proposed Runtime Environment Variables
+
+Add environment-driven configuration with safe defaults matching current behavior when unset:
+
+```bash
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+Existing behavior should remain the fallback:
+
+- login: one request every 10 seconds, burst 3
+- general API: one request per second, burst 10
+- cleanup interval: 5 minutes
+
+The implementation should parse these values during backend startup and pass them into `security.RateLimitConfig` before constructing runtime middleware.
+
+## Install-Time Policy
+
+`./SocialPredict install` should set rate-limit values for production-like installs.
+
+The install flow should not ask users to understand Go token-bucket internals. It should present a small number of profiles, then write explicit `.env` values.
+
+Candidate profiles:
+
+```text
+secure-default
+  Best for unknown public deployments and development.
+  Keeps current conservative defaults.
+
+small-droplet-staging
+  Intended for the current $4/mo 512 MiB / 1 vCPU DigitalOcean droplet.
+  Values are provisional and must be verified by load-test evidence.
+
+custom
+  Operator supplies explicit login/general rate and burst values.
+```
+
+The production install path should default to `secure-default` unless the operator explicitly chooses a staging/load-test profile.
+
+Development installs can keep secure defaults. Developers who need local load testing can override `.env` manually.
+
+## Initial Small-Droplet Staging Candidate
+
+The first candidate values for the current `kconfs.com` staging machine should be conservative enough to avoid masking resource pressure but high enough to stop rate limiting from dominating low-volume k6 tests.
+
+Start with:
+
+```bash
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=5
+RATE_LIMIT_LOGIN_BURST=20
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=25
+RATE_LIMIT_GENERAL_BURST=50
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+These are not production capacity claims. They are a starting point for measurement on the $4/mo droplet.
+
+If this profile still rate-limits before CPU, memory, DB, or application latency becomes the bottleneck, raise it incrementally and record each run in the release dossier.
+
+If this profile causes resource pressure before the desired request volume, record the machine limit rather than hiding it with a larger droplet.
+
+## Load-Test Interaction
+
+k6 should continue to run from outside the app/database droplet.
+
+For public staging and production URLs, k6 should use:
+
+```bash
+./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
+```
+
+For lower-than-one-request-per-second scenarios, the loadtest CLI should support k6 `timeUnit` values. k6 `constant-arrival-rate.rate` must be an integer, so this is invalid:
+
+```bash
+--bet-rate 0.05
+```
+
+The desired expression should be supported as:
+
+```bash
+--bet-rate 1 --bet-time-unit 20s
+--browse-rate 1 --browse-time-unit 5s
+```
+
+This lets operators run tiny tests without abusing fractional rates.
+
+## Release Dossier Evidence
+
+Every capacity-oriented run should record:
+
+- git SHA or release tag
+- environment and domain
+- DigitalOcean droplet size
+- rate-limit profile and exact values
+- k6 scenario, rate, time unit, duration, and user/market fixture counts
+- p50, p95, p99 latency
+- throughput and error rate
+- `RATE_LIMITED` and `LOGIN_RATE_LIMITED` counts
+- CPU, memory, disk, and network observations
+- whether the run hit rate limits, application errors, DB pressure, or host pressure first
+
+For the current $4/mo droplet, the dossier should explicitly say that findings apply to the 512 MiB / 1 vCPU / 10 GiB SSD tier only.
+
+## Non-Goals
+
+This feature should not immediately add:
+
+- Redis-backed distributed rate limiting
+- proxy-owned rate limiting
+- per-user paid-tier quotas
+- abuse-detection policy
+- autoscaling
+- larger droplet recommendations without evidence
+
+Those may be future work after the first release dossier identifies the actual bottleneck.

--- a/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
@@ -88,6 +88,10 @@ small-droplet-staging
   Intended for the current $4/mo 512 MiB / 1 vCPU DigitalOcean droplet.
   Values are provisional and must be verified by load-test evidence.
 
+env-file
+  Non-interactive deployment mode.
+  Uses RATE_LIMIT_* values sourced from a non-secret deploy env overlay.
+
 custom
   Operator supplies explicit login/general rate and burst values.
 ```
@@ -96,25 +100,32 @@ The production install path defaults to `secure-default` unless the operator exp
 
 Development installs can keep secure defaults. Developers who need local load testing can override `.env` manually.
 
-## Initial Small-Droplet Staging Candidate
+## OpenPredictionMarkets Staging Overlay
 
-The first candidate values for the current `kconfs.com` staging machine should be conservative enough to avoid masking resource pressure but high enough to stop rate limiting from dominating low-volume k6 tests.
+OpenPredictionMarkets staging uses `deploy/env/.env.staging` as a non-secret
+overlay before running `./SocialPredict install`. It is intentionally high
+because single-source k6 testing from one Mac or one load-generator host would
+otherwise trip the per-IP limiter before the app, database, or host is stressed.
 
-Start with:
+Current staging overlay:
 
 ```bash
-RATE_LIMIT_LOGIN_RATE_PER_SECOND=5
-RATE_LIMIT_LOGIN_BURST=20
-RATE_LIMIT_GENERAL_RATE_PER_SECOND=25
-RATE_LIMIT_GENERAL_BURST=50
+RATE_LIMIT_PROFILE=env-file
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=50
+RATE_LIMIT_LOGIN_BURST=100
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=500
+RATE_LIMIT_GENERAL_BURST=1000
 RATE_LIMIT_CLEANUP_INTERVAL=5m
 ```
 
 These are not production capacity claims. They are a starting point for measurement on the $4/mo droplet.
 
-If this profile still rate-limits before CPU, memory, DB, or application latency becomes the bottleneck, raise it incrementally and record each run in the release dossier.
+If this overlay still rate-limits before CPU, memory, DB, or application latency becomes the bottleneck, raise it incrementally and record each run in the release dossier.
 
-If this profile causes resource pressure before the desired request volume, record the machine limit rather than hiding it with a larger droplet.
+If this overlay causes resource pressure before the desired request volume, record the machine limit rather than hiding it with a larger droplet.
+
+OpenPredictionMarkets production/model-office uses `deploy/env/.env.mo`, which
+keeps the conservative `secure-default` values.
 
 ## Load-Test Interaction
 

--- a/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
@@ -33,9 +33,13 @@ The install UI should prefer profiles over raw fields:
 
 - `secure-default`
 - `small-droplet-staging`
+- `env-file`
 - `custom`
 
-For `custom`, the installer prompts for explicit values. For profiles, the installer writes the resolved values so the operator can audit and change `.env` later.
+For `custom`, the installer prompts for explicit values. For `env-file`, the
+installer requires `RATE_LIMIT_*` values to already be present in the shell
+environment. For profiles, the installer writes the resolved values so the
+operator can audit and change `.env` later.
 
 Non-interactive production installs can pass the profile with:
 
@@ -44,6 +48,10 @@ Non-interactive production installs can pass the profile with:
 ```
 
 or by setting `RATE_LIMIT_PROFILE` before invoking the installer.
+
+OpenPredictionMarkets Ansible uses non-secret overlays under `deploy/env/`
+instead of committing full generated host `.env` files. The overlays only carry
+rate-limit posture. The host still runs from `/opt/socialpredict/.env`.
 
 ## Current Measurement Target
 

--- a/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
@@ -1,0 +1,70 @@
+# Runtime Rate Limit Policy Design
+
+Status: proposed
+Date: 2026-05-29
+
+## Design Position
+
+Rate limits are runtime security controls. They should be configured beside deployment/runtime settings and should be visible in operational evidence.
+
+They are not game rules. Moving them into `setup.yaml` would couple infrastructure security posture to market mechanics and would make production tuning look like a product/game-mode change.
+
+## Configuration Shape
+
+The backend already constructs `security.RateLimitConfig` during server startup. The proposed implementation should add a small env parser before that construction and preserve existing defaults when env values are unset or invalid.
+
+Recommended names:
+
+```bash
+RATE_LIMIT_LOGIN_RATE_PER_SECOND
+RATE_LIMIT_LOGIN_BURST
+RATE_LIMIT_GENERAL_RATE_PER_SECOND
+RATE_LIMIT_GENERAL_BURST
+RATE_LIMIT_CLEANUP_INTERVAL
+```
+
+Use decimal parsing for rates so values such as `0.1` remain possible. Use integer parsing for burst. Use Go duration parsing for cleanup interval.
+
+## Install Integration
+
+`./SocialPredict install` should write explicit `.env` values for production-like installs.
+
+The install UI should prefer profiles over raw fields:
+
+- `secure-default`
+- `small-droplet-staging`
+- `custom`
+
+For `custom`, the installer can prompt for explicit values. For profiles, the installer should write the resolved values so the operator can audit and change `.env` later.
+
+## Current Measurement Target
+
+The first staging target is intentionally small:
+
+```text
+DigitalOcean regular CPU
+512 MiB memory
+1 vCPU
+500 GiB transfer
+10 GiB SSD
+$4/mo
+```
+
+The design goal is not to promise high traffic on this instance. The goal is to make the limit measurable and to avoid confusing rate-limit failures with actual application/database capacity failures.
+
+## Safety
+
+Defaults must stay conservative.
+
+A production install should not silently choose permissive load-test settings. Operators should explicitly choose the staging/load-test profile or custom values.
+
+Load-test-specific values should be documented as staging evidence inputs, not as universal production recommendations.
+
+## Future Re-Entry Points
+
+Revisit this design if evidence shows:
+
+- one app replica is not enough and rate limits need shared/distributed state
+- Traefik or another ingress should enforce coarse rate limits before the app
+- auth/login rate limits need separate trusted automation behavior
+- customer-facing plans require per-user or per-organization quotas

--- a/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
@@ -1,6 +1,6 @@
 # Runtime Rate Limit Policy Design
 
-Status: proposed
+Status: implemented baseline
 Date: 2026-05-29
 
 ## Design Position
@@ -11,9 +11,9 @@ They are not game rules. Moving them into `setup.yaml` would couple infrastructu
 
 ## Configuration Shape
 
-The backend already constructs `security.RateLimitConfig` during server startup. The proposed implementation should add a small env parser before that construction and preserve existing defaults when env values are unset or invalid.
+The backend constructs `security.RateLimitConfig` during runtime startup. The baseline implementation now parses explicit environment values before server wiring and preserves existing defaults when values are unset. Invalid configured values fail startup rather than silently weakening or misrepresenting the runtime posture.
 
-Recommended names:
+Environment names:
 
 ```bash
 RATE_LIMIT_LOGIN_RATE_PER_SECOND
@@ -27,7 +27,7 @@ Use decimal parsing for rates so values such as `0.1` remain possible. Use integ
 
 ## Install Integration
 
-`./SocialPredict install` should write explicit `.env` values for production-like installs.
+`./SocialPredict install` writes explicit `.env` values for development, localhost, and production-like installs.
 
 The install UI should prefer profiles over raw fields:
 
@@ -35,7 +35,15 @@ The install UI should prefer profiles over raw fields:
 - `small-droplet-staging`
 - `custom`
 
-For `custom`, the installer can prompt for explicit values. For profiles, the installer should write the resolved values so the operator can audit and change `.env` later.
+For `custom`, the installer prompts for explicit values. For profiles, the installer writes the resolved values so the operator can audit and change `.env` later.
+
+Non-interactive production installs can pass the profile with:
+
+```bash
+./SocialPredict install -e production -d example.com -m ops@example.com -r small-droplet-staging
+```
+
+or by setting `RATE_LIMIT_PROFILE` before invoking the installer.
 
 ## Current Measurement Target
 
@@ -51,6 +59,8 @@ $4/mo
 ```
 
 The design goal is not to promise high traffic on this instance. The goal is to make the limit measurable and to avoid confusing rate-limit failures with actual application/database capacity failures.
+
+The current compose files do not intentionally constrain backend CPU with Docker `cpus`, `mem_limit`, or `deploy.resources` settings. On the current one-vCPU droplet, host CPU observations should therefore be treated as real capacity signals unless a future host-level or compose-level limit is added.
 
 ## Safety
 

--- a/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
@@ -54,11 +54,17 @@ Service ownership: release dossier and operations.
 Checklist:
 
 - [ ] Deploy env-configurable rate limits to `kconfs.com`.
-- [ ] Set the `small-droplet-staging` profile on the current 512 MiB / 1 vCPU droplet.
+- [x] Land Ansible deploy support for selecting the `small-droplet-staging` profile on the current 512 MiB / 1 vCPU droplet.
 - [ ] Run smoke after deployment.
 - [ ] Run a low baseline test.
 - [ ] Increment rates until the first clear bottleneck appears.
 - [ ] Record rate-limit settings and DigitalOcean host observations in the release dossier.
+
+Ansible note: `openpredictionmarkets/ansible_playbooks` now defaults staging to
+`RATE_LIMIT_PROFILE=small-droplet-staging` and production/model-office to
+`RATE_LIMIT_PROFILE=secure-default`, with optional
+`STAGING_RATE_LIMIT_PROFILE` and `PRODUCTION_RATE_LIMIT_PROFILE` secret
+overrides.
 
 ## 05. Documentation
 

--- a/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
@@ -24,6 +24,7 @@ Checklist:
 - [x] Add install profile selection for production-like installs.
 - [x] Keep `secure-default` as the safe default.
 - [x] Add `small-droplet-staging` profile for the current $4/mo DigitalOcean target.
+- [x] Add `env-file` profile support for non-secret deploy env overlays.
 - [x] Add `custom` prompts for explicit values.
 - [x] Write resolved values into `.env`.
 - [x] Document how to change values after install.
@@ -54,17 +55,16 @@ Service ownership: release dossier and operations.
 Checklist:
 
 - [ ] Deploy env-configurable rate limits to `kconfs.com`.
-- [x] Land Ansible deploy support for selecting the `small-droplet-staging` profile on the current 512 MiB / 1 vCPU droplet.
+- [x] Land Ansible deploy support for sourcing environment-specific rate-limit overlays.
 - [ ] Run smoke after deployment.
 - [ ] Run a low baseline test.
 - [ ] Increment rates until the first clear bottleneck appears.
 - [ ] Record rate-limit settings and DigitalOcean host observations in the release dossier.
 
-Ansible note: `openpredictionmarkets/ansible_playbooks` now defaults staging to
-`RATE_LIMIT_PROFILE=small-droplet-staging` and production/model-office to
-`RATE_LIMIT_PROFILE=secure-default`, with optional
-`STAGING_RATE_LIMIT_PROFILE` and `PRODUCTION_RATE_LIMIT_PROFILE` secret
-overrides.
+Ansible note: `openpredictionmarkets/ansible_playbooks` sources
+`deploy/env/.env.staging` for staging and `deploy/env/.env.mo` for
+production/model-office. Optional `STAGING_RATE_LIMIT_ENV_FILE` and
+`PRODUCTION_RATE_LIMIT_ENV_FILE` secrets can point to different overlay paths.
 
 ## 05. Documentation
 

--- a/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
@@ -1,0 +1,70 @@
+# Runtime Rate Limit Policy Plan
+
+Status: proposed
+Date: 2026-05-29
+
+## 01. Backend Env Parsing
+
+Service ownership: backend runtime and security middleware.
+
+Checklist:
+
+- [ ] Add env parsing for login/general rate and burst values.
+- [ ] Preserve current defaults when env values are unset.
+- [ ] Reject or safely fall back on invalid values with clear startup logging.
+- [ ] Unit test default behavior and env override behavior.
+- [ ] Confirm `TRUST_PROXY_HEADERS` behavior remains unchanged.
+
+## 02. Installer Profiles
+
+Service ownership: `./SocialPredict install` and deployment documentation.
+
+Checklist:
+
+- [ ] Add install profile selection for production-like installs.
+- [ ] Keep `secure-default` as the safe default.
+- [ ] Add `small-droplet-staging` profile for the current $4/mo DigitalOcean target.
+- [ ] Add `custom` prompts for explicit values.
+- [ ] Write resolved values into `.env`.
+- [ ] Document how to change values after install.
+
+## 03. Loadtest CLI Low-Rate Support
+
+Service ownership: `loadtest/cli` and k6 scenario configuration.
+
+Checklist:
+
+- [ ] Add `--browse-time-unit` for baseline browse scenario.
+- [ ] Add `--bet-time-unit` for baseline bet scenario.
+- [ ] Add equivalent time-unit options where useful for hot-market and soak scenarios.
+- [ ] Document that k6 rates are integers and sub-1/sec traffic should use larger time units.
+- [ ] Validate a tiny public staging run without fractional-rate parse errors.
+
+## 04. Staging Evidence Pass
+
+Service ownership: release dossier and operations.
+
+Checklist:
+
+- [ ] Deploy env-configurable rate limits to `kconfs.com`.
+- [ ] Set the `small-droplet-staging` profile on the current 512 MiB / 1 vCPU droplet.
+- [ ] Run smoke after deployment.
+- [ ] Run a low baseline test.
+- [ ] Increment rates until the first clear bottleneck appears.
+- [ ] Record rate-limit settings and DigitalOcean host observations in the release dossier.
+
+## 05. Documentation
+
+Checklist:
+
+- [ ] Update infra docs with the rate-limit env vars.
+- [ ] Update loadtest docs with the staging profile and time-unit examples.
+- [ ] Update release dossier schema/metadata guidance to include rate-limit settings.
+- [ ] Cross-link from FEATURE/04 load testing notes.
+
+## Exit Criteria
+
+- Operators can choose conservative defaults or staging/load-test limits during install.
+- Backend runtime applies env-configured rate limits without code changes.
+- k6 low-rate tests can run without fractional-rate errors.
+- Release dossier evidence can distinguish rate-limit bottlenecks from app/database/host bottlenecks.

--- a/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
@@ -1,6 +1,6 @@
 # Runtime Rate Limit Policy Plan
 
-Status: proposed
+Status: implemented baseline; staging evidence remains pending
 Date: 2026-05-29
 
 ## 01. Backend Env Parsing
@@ -9,11 +9,11 @@ Service ownership: backend runtime and security middleware.
 
 Checklist:
 
-- [ ] Add env parsing for login/general rate and burst values.
-- [ ] Preserve current defaults when env values are unset.
-- [ ] Reject or safely fall back on invalid values with clear startup logging.
-- [ ] Unit test default behavior and env override behavior.
-- [ ] Confirm `TRUST_PROXY_HEADERS` behavior remains unchanged.
+- [x] Add env parsing for login/general rate and burst values.
+- [x] Preserve current defaults when env values are unset.
+- [x] Reject invalid values during security config startup.
+- [x] Unit test default behavior and env override behavior.
+- [x] Confirm `TRUST_PROXY_HEADERS` behavior remains unchanged.
 
 ## 02. Installer Profiles
 
@@ -21,12 +21,12 @@ Service ownership: `./SocialPredict install` and deployment documentation.
 
 Checklist:
 
-- [ ] Add install profile selection for production-like installs.
-- [ ] Keep `secure-default` as the safe default.
-- [ ] Add `small-droplet-staging` profile for the current $4/mo DigitalOcean target.
-- [ ] Add `custom` prompts for explicit values.
-- [ ] Write resolved values into `.env`.
-- [ ] Document how to change values after install.
+- [x] Add install profile selection for production-like installs.
+- [x] Keep `secure-default` as the safe default.
+- [x] Add `small-droplet-staging` profile for the current $4/mo DigitalOcean target.
+- [x] Add `custom` prompts for explicit values.
+- [x] Write resolved values into `.env`.
+- [x] Document how to change values after install.
 
 ## 03. Loadtest CLI Low-Rate Support
 
@@ -34,11 +34,18 @@ Service ownership: `loadtest/cli` and k6 scenario configuration.
 
 Checklist:
 
-- [ ] Add `--browse-time-unit` for baseline browse scenario.
-- [ ] Add `--bet-time-unit` for baseline bet scenario.
-- [ ] Add equivalent time-unit options where useful for hot-market and soak scenarios.
-- [ ] Document that k6 rates are integers and sub-1/sec traffic should use larger time units.
-- [ ] Validate a tiny public staging run without fractional-rate parse errors.
+- [x] Add `--browse-time-unit` for baseline browse scenario.
+- [x] Add `--bet-time-unit` for baseline bet scenario.
+- [x] Add equivalent time-unit options where useful for hot-market and soak scenarios.
+- [x] Document that k6 rates are integers and sub-1/sec traffic should use larger time units.
+- [ ] Validate a tiny public staging run with fresh fixtures and no threshold failures.
+
+Implementation note: a local 2026-05-29 k6 baseline run using
+`--browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s`
+initialized successfully and no longer hit the k6 fractional-rate parser error.
+It still failed thresholds against public staging because the local fixture CSVs
+were stale relative to the deployed staging database, so final staging evidence
+remains pending.
 
 ## 04. Staging Evidence Pass
 
@@ -57,10 +64,10 @@ Checklist:
 
 Checklist:
 
-- [ ] Update infra docs with the rate-limit env vars.
-- [ ] Update loadtest docs with the staging profile and time-unit examples.
-- [ ] Update release dossier schema/metadata guidance to include rate-limit settings.
-- [ ] Cross-link from FEATURE/04 load testing notes.
+- [x] Update infra docs with the rate-limit env vars.
+- [x] Update loadtest docs with the staging profile and time-unit examples.
+- [x] Update release dossier schema/metadata guidance to include rate-limit settings.
+- [x] Cross-link from FEATURE/04 load testing notes.
 
 ## Exit Criteria
 

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -78,6 +78,7 @@ Current feature specs:
 1. **Moderator Mode** - [`FEATURES/01/01-moderators.md`](./FEATURES/01/01-moderators.md), [`FEATURES/01/DESIGN.md`](./FEATURES/01/DESIGN.md), [`FEATURES/01/PLAN.md`](./FEATURES/01/PLAN.md)
 3. **Embeddable Pages And Market Sharing** - [`FEATURES/03/03-embeddable-pages-and-market-sharing.md`](./FEATURES/03/03-embeddable-pages-and-market-sharing.md), [`FEATURES/03/DESIGN.md`](./FEATURES/03/DESIGN.md), [`FEATURES/03/PLAN.md`](./FEATURES/03/PLAN.md)
 4. **Load Testing And Release Dossier Evidence** - [`FEATURES/04/04-load-testing.md`](./FEATURES/04/04-load-testing.md), [`FEATURES/04/DESIGN.md`](./FEATURES/04/DESIGN.md), [`FEATURES/04/PLAN.md`](./FEATURES/04/PLAN.md)
+5. **Runtime Rate Limit Policy** - [`FEATURES/05/05-runtime-rate-limit-policy.md`](./FEATURES/05/05-runtime-rate-limit-policy.md), [`FEATURES/05/DESIGN.md`](./FEATURES/05/DESIGN.md), [`FEATURES/05/PLAN.md`](./FEATURES/05/PLAN.md)
 
 ## Implementation Priority
 

--- a/backend/internal/app/runtime/security.go
+++ b/backend/internal/app/runtime/security.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"socialpredict/security"
+
+	"golang.org/x/time/rate"
 )
 
 // CORSConfig describes the request-boundary CORS posture owned by runtime bootstrap.
@@ -27,6 +30,7 @@ type SecurityConfig struct {
 	CORS              CORSConfig
 	Headers           security.SecurityHeaders
 	Share             ShareConfig
+	RateLimit         security.RateLimitConfig
 }
 
 // ShareConfig describes public market sharing metadata owned by runtime config.
@@ -46,10 +50,16 @@ func LoadSecurityConfigFromEnv() (SecurityConfig, error) {
 	headers := security.DefaultSecurityHeaders()
 	headers.StrictTransportSecurity = strictTransportSecurityHeader()
 	applyFrameAncestors(&headers, getRuntimeListEnv("SECURITY_FRAME_ANCESTORS", "'none'"))
+	trustProxyHeaders := getRuntimeBoolEnv("TRUST_PROXY_HEADERS", false)
+	rateLimit, err := rateLimitConfigFromEnv()
+	if err != nil {
+		return SecurityConfig{}, err
+	}
+	rateLimit.TrustProxyHeaders = trustProxyHeaders
 
 	return SecurityConfig{
 		JWTSigningKey:     signingKey,
-		TrustProxyHeaders: getRuntimeBoolEnv("TRUST_PROXY_HEADERS", false),
+		TrustProxyHeaders: trustProxyHeaders,
 		CORS: CORSConfig{
 			Enabled:          getRuntimeBoolEnv("CORS_ENABLED", true),
 			AllowedOrigins:   getRuntimeListEnv("CORS_ALLOW_ORIGINS", "*"),
@@ -65,7 +75,31 @@ func LoadSecurityConfigFromEnv() (SecurityConfig, error) {
 			DefaultImageURL: strings.TrimSpace(os.Getenv("SHARE_DEFAULT_IMAGE_URL")),
 			SiteName:        getRuntimeStringEnv("SHARE_SITE_NAME", "SocialPredict"),
 		},
+		RateLimit: rateLimit,
 	}, nil
+}
+
+func rateLimitConfigFromEnv() (security.RateLimitConfig, error) {
+	config := security.DefaultRateLimitConfig()
+	var err error
+
+	if config.LoginRate, err = getRuntimeRateEnv("RATE_LIMIT_LOGIN_RATE_PER_SECOND", config.LoginRate); err != nil {
+		return security.RateLimitConfig{}, err
+	}
+	if config.LoginBurst, err = getRuntimePositiveIntEnv("RATE_LIMIT_LOGIN_BURST", config.LoginBurst); err != nil {
+		return security.RateLimitConfig{}, err
+	}
+	if config.GeneralRate, err = getRuntimeRateEnv("RATE_LIMIT_GENERAL_RATE_PER_SECOND", config.GeneralRate); err != nil {
+		return security.RateLimitConfig{}, err
+	}
+	if config.GeneralBurst, err = getRuntimePositiveIntEnv("RATE_LIMIT_GENERAL_BURST", config.GeneralBurst); err != nil {
+		return security.RateLimitConfig{}, err
+	}
+	if config.CleanupInterval, err = getRuntimePositiveDurationEnv("RATE_LIMIT_CLEANUP_INTERVAL", config.CleanupInterval); err != nil {
+		return security.RateLimitConfig{}, err
+	}
+
+	return config, nil
 }
 
 func applyFrameAncestors(headers *security.SecurityHeaders, ancestors []string) {
@@ -176,4 +210,40 @@ func getRuntimeIntEnv(key string, def int) int {
 		return def
 	}
 	return parsed
+}
+
+func getRuntimePositiveIntEnv(key string, def int) (int, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return def, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return 0, fmt.Errorf("security config: %s must be a positive integer", key)
+	}
+	return parsed, nil
+}
+
+func getRuntimeRateEnv(key string, def rate.Limit) (rate.Limit, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return def, nil
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil || parsed <= 0 {
+		return 0, fmt.Errorf("security config: %s must be a positive decimal requests-per-second value", key)
+	}
+	return rate.Limit(parsed), nil
+}
+
+func getRuntimePositiveDurationEnv(key string, def time.Duration) (time.Duration, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return def, nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil || parsed <= 0 {
+		return 0, fmt.Errorf("security config: %s must be a positive Go duration, e.g. 5m", key)
+	}
+	return parsed, nil
 }

--- a/backend/internal/app/runtime/security_test.go
+++ b/backend/internal/app/runtime/security_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadSecurityConfigFromEnvRequiresJWTSigningKey(t *testing.T) {
@@ -48,6 +49,21 @@ func TestLoadSecurityConfigFromEnvOwnsDefaults(t *testing.T) {
 	if config.Share.PublicBaseURL != "http://localhost" {
 		t.Fatalf("PublicBaseURL = %q", config.Share.PublicBaseURL)
 	}
+	if got := float64(config.RateLimit.LoginRate); got != 0.1 {
+		t.Fatalf("login rate = %v, want 0.1", got)
+	}
+	if config.RateLimit.LoginBurst != 3 {
+		t.Fatalf("login burst = %d, want 3", config.RateLimit.LoginBurst)
+	}
+	if got := float64(config.RateLimit.GeneralRate); got != 1 {
+		t.Fatalf("general rate = %v, want 1", got)
+	}
+	if config.RateLimit.GeneralBurst != 10 {
+		t.Fatalf("general burst = %d, want 10", config.RateLimit.GeneralBurst)
+	}
+	if config.RateLimit.CleanupInterval != 5*time.Minute {
+		t.Fatalf("cleanup interval = %v, want 5m", config.RateLimit.CleanupInterval)
+	}
 }
 
 func TestLoadSecurityConfigFromEnvOwnsProxyCORSAndHSTSOverrides(t *testing.T) {
@@ -92,5 +108,63 @@ func TestLoadSecurityConfigFromEnvOwnsProxyCORSAndHSTSOverrides(t *testing.T) {
 	}
 	if config.Share.PublicBaseURL != "https://kconfs.com" || config.Share.DefaultImageURL != "https://cdn.example/share.png" || config.Share.SiteName != "KConfs" {
 		t.Fatalf("unexpected share config: %+v", config.Share)
+	}
+}
+
+func TestLoadSecurityConfigFromEnvOwnsRateLimitOverrides(t *testing.T) {
+	t.Setenv("JWT_SIGNING_KEY", "test-secret-key")
+	t.Setenv("TRUST_PROXY_HEADERS", "true")
+	t.Setenv("RATE_LIMIT_LOGIN_RATE_PER_SECOND", "5")
+	t.Setenv("RATE_LIMIT_LOGIN_BURST", "20")
+	t.Setenv("RATE_LIMIT_GENERAL_RATE_PER_SECOND", "25.5")
+	t.Setenv("RATE_LIMIT_GENERAL_BURST", "50")
+	t.Setenv("RATE_LIMIT_CLEANUP_INTERVAL", "2m")
+
+	config, err := LoadSecurityConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadSecurityConfigFromEnv returned error: %v", err)
+	}
+	if got := float64(config.RateLimit.LoginRate); got != 5 {
+		t.Fatalf("login rate = %v, want 5", got)
+	}
+	if config.RateLimit.LoginBurst != 20 {
+		t.Fatalf("login burst = %d, want 20", config.RateLimit.LoginBurst)
+	}
+	if got := float64(config.RateLimit.GeneralRate); got != 25.5 {
+		t.Fatalf("general rate = %v, want 25.5", got)
+	}
+	if config.RateLimit.GeneralBurst != 50 {
+		t.Fatalf("general burst = %d, want 50", config.RateLimit.GeneralBurst)
+	}
+	if config.RateLimit.CleanupInterval != 2*time.Minute {
+		t.Fatalf("cleanup interval = %v, want 2m", config.RateLimit.CleanupInterval)
+	}
+	if !config.RateLimit.TrustProxyHeaders {
+		t.Fatalf("rate limit config should inherit trusted proxy setting")
+	}
+}
+
+func TestLoadSecurityConfigFromEnvRejectsInvalidRateLimitOverrides(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{name: "login rate", key: "RATE_LIMIT_LOGIN_RATE_PER_SECOND", val: "0"},
+		{name: "login burst", key: "RATE_LIMIT_LOGIN_BURST", val: "-1"},
+		{name: "general rate", key: "RATE_LIMIT_GENERAL_RATE_PER_SECOND", val: "many"},
+		{name: "general burst", key: "RATE_LIMIT_GENERAL_BURST", val: "0"},
+		{name: "cleanup interval", key: "RATE_LIMIT_CLEANUP_INTERVAL", val: "soon"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("JWT_SIGNING_KEY", "test-secret-key")
+			t.Setenv(tt.key, tt.val)
+
+			if _, err := LoadSecurityConfigFromEnv(); err == nil {
+				t.Fatalf("expected error for %s=%q", tt.key, tt.val)
+			}
+		})
 	}
 }

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -307,9 +307,7 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	// This defines all functions starting with /api/
 
 	// Apply security middleware to all routes
-	rateLimitConfig := security.DefaultRateLimitConfig()
-	rateLimitConfig.TrustProxyHeaders = securityConfig.TrustProxyHeaders
-	securityService := security.NewRuntimeSecurityService(rateLimitConfig, securityConfig.Headers)
+	securityService := security.NewRuntimeSecurityService(securityConfig.RateLimit, securityConfig.Headers)
 	securityMiddleware := securityService.SecurityMiddleware()
 	loginSecurityMiddleware := securityService.LoginSecurityMiddleware()
 	privateActionMiddleware := func(next http.Handler) http.Handler {

--- a/deploy/env/.env.mo
+++ b/deploy/env/.env.mo
@@ -1,0 +1,8 @@
+# Non-secret production/model-office rate-limit overlay for OpenPredictionMarkets.
+# Keep this conservative unless fresh capacity evidence supports a change.
+RATE_LIMIT_PROFILE=env-file
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+RATE_LIMIT_CLEANUP_INTERVAL=5m

--- a/deploy/env/.env.staging
+++ b/deploy/env/.env.staging
@@ -1,0 +1,9 @@
+# Non-secret staging rate-limit overlay for OpenPredictionMarkets.
+# This profile is intentionally high so one Mac/k6 source IP can hammer staging
+# without the per-IP limiter masking app/database/host capacity evidence.
+RATE_LIMIT_PROFILE=env-file
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=50
+RATE_LIMIT_LOGIN_BURST=100
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=500
+RATE_LIMIT_GENERAL_BURST=1000
+RATE_LIMIT_CLEANUP_INTERVAL=5m

--- a/deploy/env/README.md
+++ b/deploy/env/README.md
@@ -1,0 +1,12 @@
+# Deploy Env Overlays
+
+These files are non-secret environment overlays used by the OpenPredictionMarkets Ansible deployment before running `./SocialPredict install`.
+
+They are not replacements for the generated host `.env`. The install command reads the overlay values, validates/writes the rate-limit settings, and the host continues to run from `/opt/socialpredict/.env`.
+
+Files:
+
+- `.env.staging`: high per-IP rate limits for temporary single-source staging load tests from a Mac or one load-generator host.
+- `.env.mo`: conservative model-office/production rate limits.
+
+Do not add secrets to these files. Secrets belong in GitHub Actions secrets, HostOps local config, or the generated host `.env`.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -138,7 +138,9 @@ Generate a release dossier from the k6 summary output:
 ```
 
 For capacity evidence, copy `loadtest/dossier/metadata.example.json` and record
-the active `RATE_LIMIT_*` values under `rateLimitPolicy`. The summarizer also
+the active `RATE_LIMIT_*` values under `rateLimitPolicy`. For
+OpenPredictionMarkets staging, those values are expected to come from
+`deploy/env/.env.staging` during single-source load tests. The summarizer also
 copies k6 counters for `sp_rate_limited` and `sp_login_rate_limited` into the
 dossier so rate-limit failures can be separated from app, database, or host
 pressure.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -118,10 +118,29 @@ Run a smoke scenario:
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ```
 
+Run a low baseline without fractional k6 rates:
+
+```bash
+./loadtest/cli/loadtest run baseline \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --browse-rate 1 \
+  --browse-time-unit 5s \
+  --bet-rate 1 \
+  --bet-time-unit 20s
+```
+
 Generate a release dossier from the k6 summary output:
 
 ```bash
 ./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --out loadtest/dossier/runs/<run>.json
 ```
+
+For capacity evidence, copy `loadtest/dossier/metadata.example.json` and record
+the active `RATE_LIMIT_*` values under `rateLimitPolicy`. The summarizer also
+copies k6 counters for `sp_rate_limited` and `sp_login_rate_limited` into the
+dossier so rate-limit failures can be separated from app, database, or host
+pressure.
 
 Run from a Mac or a separate load-generator droplet for meaningful capacity evidence. Running k6 on the app/database droplet is only valid for tiny smoke checks.

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -11,7 +11,7 @@ LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --mar
 ./loadtest/cli/loadtest check
 ./loadtest/cli/loadtest fixtures pull staging
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
-./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --duration 5m --browse-rate 20 --bet-rate 5
+./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --duration 5m --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
 ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 100 --duration 60s
 ./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --metadata loadtest/dossier/metadata.example.json --out loadtest/dossier/runs/<run>.json
 ```
@@ -43,3 +43,18 @@ Override values when needed:
 ```
 
 Public staging/prod Nginx publishes API routes under `/api`, so use `--api-prefix /api` when running against `https://kconfs.com` or `https://brierfoxforecast.com`. Direct backend targets such as `http://localhost:8080` should omit the prefix.
+
+## Low-Rate Runs
+
+k6 `constant-arrival-rate` values must be positive integers. For sub-1/sec traffic, increase the time unit instead of passing a fractional rate:
+
+```bash
+./loadtest/cli/loadtest run baseline \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --browse-rate 1 \
+  --browse-time-unit 5s \
+  --bet-rate 1 \
+  --bet-time-unit 20s
+```

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -20,6 +20,7 @@ Run examples:
   ./loadtest/cli/loadtest check
   ./loadtest/cli/loadtest fixtures pull staging
   ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
+  ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
   ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 100 --duration 60s
   ./loadtest/cli/loadtest dossier --summary loadtest/results/smoke-20260528T120000Z-summary.json --out loadtest/dossier/runs/smoke.json
 
@@ -40,6 +41,18 @@ require_command() {
 
 iso_stamp() {
   date -u +%Y%m%dT%H%M%SZ
+}
+
+require_positive_integer_value() {
+  local label="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    return 0
+  fi
+  if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${label} must be a positive integer. For sub-1/sec rates, increase the time unit, e.g. --bet-rate 1 --bet-time-unit 20s." >&2
+    exit 1
+  fi
 }
 
 scenario_path() {
@@ -191,8 +204,13 @@ run_cmd() {
   local markets_file="${MARKETS_FILE:-${LOADTEST_DIR}/fixtures/markets.csv}"
   local duration="${DURATION:-}"
   local target_rate="${TARGET_RATE:-}"
+  local target_time_unit="${TARGET_TIME_UNIT:-}"
   local bet_rate="${BET_RATE:-}"
+  local bet_time_unit="${BET_TIME_UNIT:-}"
   local browse_rate="${BROWSE_RATE:-}"
+  local browse_time_unit="${BROWSE_TIME_UNIT:-}"
+  local rate="${RATE:-}"
+  local time_unit="${TIME_UNIT:-}"
   local out=""
 
   while [ "$#" -gt 0 ]; do
@@ -203,8 +221,13 @@ run_cmd() {
       --markets-file) markets_file="$2"; shift 2 ;;
       --duration) duration="$2"; shift 2 ;;
       --target-rate) target_rate="$2"; shift 2 ;;
+      --target-time-unit) target_time_unit="$2"; shift 2 ;;
       --bet-rate) bet_rate="$2"; shift 2 ;;
+      --bet-time-unit) bet_time_unit="$2"; shift 2 ;;
       --browse-rate) browse_rate="$2"; shift 2 ;;
+      --browse-time-unit) browse_time_unit="$2"; shift 2 ;;
+      --rate) rate="$2"; shift 2 ;;
+      --time-unit) time_unit="$2"; shift 2 ;;
       --out) out="$2"; shift 2 ;;
       --help|-h) print_help; exit 0 ;;
       *) echo "Unknown run option: $1" >&2; exit 1 ;;
@@ -222,6 +245,10 @@ run_cmd() {
     echo "Missing markets fixture: $markets_file" >&2
     exit 1
   fi
+  require_positive_integer_value "--target-rate" "$target_rate"
+  require_positive_integer_value "--bet-rate" "$bet_rate"
+  require_positive_integer_value "--browse-rate" "$browse_rate"
+  require_positive_integer_value "--rate" "$rate"
 
   mkdir -p "${LOADTEST_DIR}/results"
   if [ -z "$out" ]; then
@@ -238,8 +265,13 @@ run_cmd() {
     MARKETS_FILE="$markets_file" \
     DURATION="$duration" \
     TARGET_RATE="$target_rate" \
+    TARGET_TIME_UNIT="$target_time_unit" \
     BET_RATE="$bet_rate" \
+    BET_TIME_UNIT="$bet_time_unit" \
     BROWSE_RATE="$browse_rate" \
+    BROWSE_TIME_UNIT="$browse_time_unit" \
+    RATE="$rate" \
+    TIME_UNIT="$time_unit" \
     k6 run --summary-export "$out" "$script"
   )
   echo "Summary: $out"

--- a/loadtest/dossier/metadata.example.json
+++ b/loadtest/dossier/metadata.example.json
@@ -18,6 +18,14 @@
     "targetBetRatePerSecond": 0,
     "readWriteMix": "smoke"
   },
+  "rateLimitPolicy": {
+    "profile": "secure-default",
+    "loginRatePerSecond": 0.1,
+    "loginBurst": 3,
+    "generalRatePerSecond": 1,
+    "generalBurst": 10,
+    "cleanupInterval": "5m"
+  },
   "infrastructureObservations": {
     "appCpuPeakPercent": null,
     "memoryPeakPercent": null,

--- a/loadtest/dossier/schema.example.json
+++ b/loadtest/dossier/schema.example.json
@@ -34,11 +34,12 @@
     "loginRateLimited": 0
   },
   "rateLimitPolicy": {
-    "profile": "small-droplet-staging",
-    "loginRatePerSecond": 5,
-    "loginBurst": 20,
-    "generalRatePerSecond": 25,
-    "generalBurst": 50,
+    "profile": "env-file",
+    "source": "deploy/env/.env.staging",
+    "loginRatePerSecond": 50,
+    "loginBurst": 100,
+    "generalRatePerSecond": 500,
+    "generalBurst": 1000,
     "cleanupInterval": "5m"
   },
   "infrastructureObservations": {

--- a/loadtest/dossier/schema.example.json
+++ b/loadtest/dossier/schema.example.json
@@ -29,7 +29,17 @@
     "httpReqDurationP99Ms": 0,
     "betsAttempted": 0,
     "betsSucceeded": 0,
-    "betsFailed": 0
+    "betsFailed": 0,
+    "rateLimited": 0,
+    "loginRateLimited": 0
+  },
+  "rateLimitPolicy": {
+    "profile": "small-droplet-staging",
+    "loginRatePerSecond": 5,
+    "loginBurst": 20,
+    "generalRatePerSecond": 25,
+    "generalBurst": 50,
+    "cleanupInterval": "5m"
   },
   "infrastructureObservations": {
     "appCpuPeakPercent": null,

--- a/loadtest/dossier/summarize.mjs
+++ b/loadtest/dossier/summarize.mjs
@@ -24,7 +24,9 @@ function readJSON(file) {
 }
 
 function metric(summary, name, value, fallback = 0) {
-  return summary.metrics?.[name]?.values?.[value] ?? fallback;
+  const metricValue = summary.metrics?.[name];
+  if (!metricValue) return fallback;
+  return metricValue[value] ?? metricValue.values?.[value] ?? fallback;
 }
 
 function count(summary, name) {
@@ -32,11 +34,12 @@ function count(summary, name) {
 }
 
 function rate(summary, name) {
-  return metric(summary, name, 'rate', 0);
+  return metric(summary, name, 'rate', metric(summary, name, 'value', 0));
 }
 
 function percentile(summary, name, p) {
-  return metric(summary, name, `p(${p})`, 0);
+  const fallback = p === 50 ? metric(summary, name, 'med', 0) : 0;
+  return metric(summary, name, `p(${p})`, fallback);
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -72,7 +75,10 @@ const dossier = {
     betsSucceeded: count(summary, 'sp_bets_succeeded'),
     betsFailed: count(summary, 'sp_bets_failed'),
     loginFailures: count(summary, 'sp_login_failures'),
+    rateLimited: count(summary, 'sp_rate_limited'),
+    loginRateLimited: count(summary, 'sp_login_rate_limited'),
   },
+  rateLimitPolicy: metadata.rateLimitPolicy || {},
   infrastructureObservations: metadata.infrastructureObservations || {},
   decision: args.decision || metadata.decision || 'inconclusive',
   knownRisks: metadata.knownRisks || [],

--- a/loadtest/k6/baseline.js
+++ b/loadtest/k6/baseline.js
@@ -3,14 +3,16 @@ import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures, sec
 
 const duration = __ENV.DURATION || '5m';
 const browseRate = Number(__ENV.BROWSE_RATE || '20');
+const browseTimeUnit = __ENV.BROWSE_TIME_UNIT || '1s';
 const betRate = Number(__ENV.BET_RATE || '5');
+const betTimeUnit = __ENV.BET_TIME_UNIT || '1s';
 
 export const options = {
   scenarios: {
     browse: {
       executor: 'constant-arrival-rate',
       rate: browseRate,
-      timeUnit: '1s',
+      timeUnit: browseTimeUnit,
       duration,
       preAllocatedVUs: Number(__ENV.BROWSE_VUS || '20'),
       maxVUs: Number(__ENV.BROWSE_MAX_VUS || '200'),
@@ -19,7 +21,7 @@ export const options = {
     bet: {
       executor: 'constant-arrival-rate',
       rate: betRate,
-      timeUnit: '1s',
+      timeUnit: betTimeUnit,
       duration,
       preAllocatedVUs: Number(__ENV.BET_VUS || '20'),
       maxVUs: Number(__ENV.BET_MAX_VUS || '200'),

--- a/loadtest/k6/hot-market-burst.js
+++ b/loadtest/k6/hot-market-burst.js
@@ -3,13 +3,14 @@ import { checkProbes, placeBet, requireFixtures } from './lib/common.js';
 
 const duration = __ENV.DURATION || '60s';
 const targetRate = Number(__ENV.TARGET_RATE || '50');
+const targetTimeUnit = __ENV.TARGET_TIME_UNIT || '1s';
 
 export const options = {
   scenarios: {
     hot_market_burst: {
       executor: 'constant-arrival-rate',
       rate: targetRate,
-      timeUnit: '1s',
+      timeUnit: targetTimeUnit,
       duration,
       preAllocatedVUs: Number(__ENV.PREALLOCATED_VUS || '100'),
       maxVUs: Number(__ENV.MAX_VUS || '1000'),

--- a/loadtest/k6/lib/common.js
+++ b/loadtest/k6/lib/common.js
@@ -9,6 +9,8 @@ export const betsSucceeded = new Counter('sp_bets_succeeded');
 export const betsFailed = new Counter('sp_bets_failed');
 export const loginFailures = new Counter('sp_login_failures');
 export const marketReadFailures = new Counter('sp_market_read_failures');
+export const rateLimited = new Counter('sp_rate_limited');
+export const loginRateLimited = new Counter('sp_login_rate_limited');
 
 export const BASE_URL = (__ENV.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
 export const API_PREFIX = normalizeApiPrefix(__ENV.API_PREFIX || '');
@@ -73,10 +75,25 @@ function responseSnippet(response) {
   return String(response.body).replace(/\s+/g, ' ').slice(0, 240);
 }
 
+function responseReason(response) {
+  if (!response || !response.body) return '';
+  try {
+    return response.json('reason') || '';
+  } catch {
+    return '';
+  }
+}
+
 function recordFailure(kind, response, context = {}) {
   const status = response ? String(response.status) : 'unknown';
+  const reason = context.reason || responseReason(response);
   const tags = { kind, status };
-  if (context.reason) tags.reason = context.reason;
+  if (reason) tags.reason = reason;
+  if (reason === 'RATE_LIMITED') {
+    rateLimited.add(1, tags);
+  } else if (reason === 'LOGIN_RATE_LIMITED') {
+    loginRateLimited.add(1, tags);
+  }
   if (kind === 'login') {
     loginFailures.add(1, tags);
   } else if (kind === 'bet') {
@@ -88,7 +105,7 @@ function recordFailure(kind, response, context = {}) {
   if (failureLogCount >= FAILURE_LOG_LIMIT) return;
   failureLogCount += 1;
 
-  const details = Object.entries(context)
+  const details = Object.entries({ ...context, reason })
     .filter(([, value]) => value !== undefined && value !== '')
     .map(([key, value]) => `${key}=${value}`)
     .join(' ');

--- a/loadtest/k6/soak.js
+++ b/loadtest/k6/soak.js
@@ -3,13 +3,14 @@ import { checkProbes, placeBet, readMarket, readMarketList, requireFixtures, sec
 
 const duration = __ENV.DURATION || '30m';
 const rate = Number(__ENV.RATE || '10');
+const timeUnit = __ENV.TIME_UNIT || '1s';
 
 export const options = {
   scenarios: {
     soak: {
       executor: 'constant-arrival-rate',
       rate,
-      timeUnit: '1s',
+      timeUnit,
       duration,
       preAllocatedVUs: Number(__ENV.PREALLOCATED_VUS || '50'),
       maxVUs: Number(__ENV.MAX_VUS || '500'),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -143,6 +143,76 @@ set_env_value() {
   fi
 }
 
+apply_rate_limit_values() {
+  local login_rate="$1"
+  local login_burst="$2"
+  local general_rate="$3"
+  local general_burst="$4"
+  local cleanup_interval="$5"
+
+  set_env_value "RATE_LIMIT_LOGIN_RATE_PER_SECOND" "${login_rate}"
+  set_env_value "RATE_LIMIT_LOGIN_BURST" "${login_burst}"
+  set_env_value "RATE_LIMIT_GENERAL_RATE_PER_SECOND" "${general_rate}"
+  set_env_value "RATE_LIMIT_GENERAL_BURST" "${general_burst}"
+  set_env_value "RATE_LIMIT_CLEANUP_INTERVAL" "${cleanup_interval}"
+}
+
+apply_rate_limit_profile() {
+  local profile="${1:-secure-default}"
+
+  case "${profile}" in
+    secure-default)
+      apply_rate_limit_values "0.1" "3" "1" "10" "5m"
+      ;;
+    small-droplet-staging)
+      apply_rate_limit_values "5" "20" "25" "50" "5m"
+      ;;
+    custom)
+      local login_rate
+      local login_burst
+      local general_rate
+      local general_burst
+      local cleanup_interval
+      read -r -p "Login rate limit, requests per second? " login_rate
+      read -r -p "Login rate limit burst? " login_burst
+      read -r -p "General API rate limit, requests per second? " general_rate
+      read -r -p "General API rate limit burst? " general_burst
+      read -r -p "Rate limiter cleanup interval, e.g. 5m? " cleanup_interval
+      apply_rate_limit_values "${login_rate}" "${login_burst}" "${general_rate}" "${general_burst}" "${cleanup_interval}"
+      ;;
+    *)
+      print_error "Unknown rate-limit profile '${profile}'. Use secure-default, small-droplet-staging, or custom."
+      exit 1
+      ;;
+  esac
+
+  echo "Setting Rate Limit Profile: ${profile}"
+}
+
+select_rate_limit_profile() {
+  local profile="${RATE_LIMIT_PROFILE:-}"
+  if [ -n "${profile}" ]; then
+    apply_rate_limit_profile "${profile}"
+    return
+  fi
+
+  echo "### Select Rate Limit Profile:"
+  echo "1) secure-default - conservative public defaults"
+  echo "2) small-droplet-staging - initial load-test profile for 512 MiB / 1 vCPU DigitalOcean staging"
+  echo "3) custom - enter explicit values"
+  read -r -p "Please enter your choice [1]: " profile_choice
+
+  case "${profile_choice:-1}" in
+    1) apply_rate_limit_profile "secure-default" ;;
+    2) apply_rate_limit_profile "small-droplet-staging" ;;
+    3) apply_rate_limit_profile "custom" ;;
+    *)
+      print_error "Invalid rate-limit profile choice '${profile_choice}'."
+      exit 1
+      ;;
+  esac
+}
+
 # Check if Docker Image exists on the system
 check_image() {
   local image_name=$1
@@ -203,6 +273,8 @@ build_dev() {
   "${SED_INPLACE[@]}" "s|^BACKEND_IMAGE_NAME=.*|BACKEND_IMAGE_NAME=${BACKEND_IMAGE_NAME}|" "${SCRIPT_DIR}/.env"
   "${SED_INPLACE[@]}" "s|^FRONTEND_IMAGE_NAME=.*|FRONTEND_IMAGE_NAME=${FRONTEND_IMAGE_NAME}|" "${SCRIPT_DIR}/.env"
 
+  apply_rate_limit_profile "secure-default"
+
   ensure_jwt_signing_key
 
   print_status "Searching for Docker Images ..."
@@ -257,6 +329,8 @@ services:
 EOF
   echo "Wrote docker-compose.override.yml to pin platform = ${FORCE_PLATFORM:-linux/amd64}"
 
+  apply_rate_limit_profile "secure-default"
+
   ensure_jwt_signing_key
 
   docker compose \
@@ -300,6 +374,8 @@ build_production() {
   envsubst < "$template" > "$file"
 
   echo "Setting EMAIL to: $email_answer"
+
+  select_rate_limit_profile
 
   # Update Database User Password:
   # The packaged production compose topology uses local Docker Postgres.
@@ -354,6 +430,8 @@ build_production_args() {
   envsubst < "$template" > "$file"
 
   echo "Setting EMAIL to: $2"
+
+  apply_rate_limit_profile "${3:-${RATE_LIMIT_PROFILE:-secure-default}}"
 
   # Update Database User Password:
   # The packaged production compose topology uses local Docker Postgres.
@@ -432,7 +510,8 @@ if [ "$#" -eq 0 ]; then
     esac
   done
 else
-  while getopts ":e:d:m:" opt; do
+  rate_limit_profile="${RATE_LIMIT_PROFILE:-secure-default}"
+  while getopts ":e:d:m:r:" opt; do
     case $opt in
       e)
         if [ "$OPTARG" != "development" ] && [ "$OPTARG" != "localhost" ] && [ "$OPTARG" != "production" ]; then
@@ -448,6 +527,9 @@ else
         ;;
       m)
         email="$OPTARG"
+        ;;
+      r)
+        rate_limit_profile="$OPTARG"
         ;;
       \?)
         echo "Invalid option: -$OPTARG"
@@ -472,6 +554,6 @@ else
   elif [ "$env" == "localhost" ]; then
     build_local
   elif [ "$env" == "production" ]; then
-    build_production_args "$domain" "$email"
+    build_production_args "$domain" "$email" "$rate_limit_profile"
   fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -157,6 +157,30 @@ apply_rate_limit_values() {
   set_env_value "RATE_LIMIT_CLEANUP_INTERVAL" "${cleanup_interval}"
 }
 
+require_rate_limit_env_value() {
+  local key="$1"
+  local value="${!key:-}"
+  if [ -z "${value}" ]; then
+    print_error "RATE_LIMIT_PROFILE=env-file requires ${key} to be set by the sourced env overlay."
+    exit 1
+  fi
+}
+
+apply_rate_limit_env_file_values() {
+  require_rate_limit_env_value "RATE_LIMIT_LOGIN_RATE_PER_SECOND"
+  require_rate_limit_env_value "RATE_LIMIT_LOGIN_BURST"
+  require_rate_limit_env_value "RATE_LIMIT_GENERAL_RATE_PER_SECOND"
+  require_rate_limit_env_value "RATE_LIMIT_GENERAL_BURST"
+  require_rate_limit_env_value "RATE_LIMIT_CLEANUP_INTERVAL"
+
+  apply_rate_limit_values \
+    "${RATE_LIMIT_LOGIN_RATE_PER_SECOND}" \
+    "${RATE_LIMIT_LOGIN_BURST}" \
+    "${RATE_LIMIT_GENERAL_RATE_PER_SECOND}" \
+    "${RATE_LIMIT_GENERAL_BURST}" \
+    "${RATE_LIMIT_CLEANUP_INTERVAL}"
+}
+
 apply_rate_limit_profile() {
   local profile="${1:-secure-default}"
 
@@ -166,6 +190,9 @@ apply_rate_limit_profile() {
       ;;
     small-droplet-staging)
       apply_rate_limit_values "5" "20" "25" "50" "5m"
+      ;;
+    env-file)
+      apply_rate_limit_env_file_values
       ;;
     custom)
       local login_rate
@@ -181,7 +208,7 @@ apply_rate_limit_profile() {
       apply_rate_limit_values "${login_rate}" "${login_burst}" "${general_rate}" "${general_burst}" "${cleanup_interval}"
       ;;
     *)
-      print_error "Unknown rate-limit profile '${profile}'. Use secure-default, small-droplet-staging, or custom."
+      print_error "Unknown rate-limit profile '${profile}'. Use secure-default, small-droplet-staging, env-file, or custom."
       exit 1
       ;;
   esac
@@ -199,13 +226,15 @@ select_rate_limit_profile() {
   echo "### Select Rate Limit Profile:"
   echo "1) secure-default - conservative public defaults"
   echo "2) small-droplet-staging - initial load-test profile for 512 MiB / 1 vCPU DigitalOcean staging"
-  echo "3) custom - enter explicit values"
+  echo "3) env-file - use RATE_LIMIT_* values from the current shell environment"
+  echo "4) custom - enter explicit values"
   read -r -p "Please enter your choice [1]: " profile_choice
 
   case "${profile_choice:-1}" in
     1) apply_rate_limit_profile "secure-default" ;;
     2) apply_rate_limit_profile "small-droplet-staging" ;;
-    3) apply_rate_limit_profile "custom" ;;
+    3) apply_rate_limit_profile "env-file" ;;
+    4) apply_rate_limit_profile "custom" ;;
     *)
       print_error "Invalid rate-limit profile choice '${profile_choice}'."
       exit 1


### PR DESCRIPTION
## Summary
- Implements runtime-configurable backend rate limits through `RATE_LIMIT_*` environment variables while preserving the existing conservative defaults when unset.
- Adds `./SocialPredict install` rate-limit profiles: `secure-default`, `small-droplet-staging`, `env-file`, and `custom`, with non-interactive `-r` / `RATE_LIMIT_PROFILE` support.
- Adds non-secret deploy overlays under `deploy/env/`: `.env.staging` for temporary high single-source staging load tests, and `.env.mo` for conservative model-office/production limits.
- Updates k6/loadtest tooling so sub-1/sec scenarios use integer rates plus `timeUnit`, and rejects fractional rates with an actionable message.
- Adds release-dossier metadata/results fields for active rate-limit policy plus `RATE_LIMITED` and `LOGIN_RATE_LIMITED` counters.
- Refreshes infra and feature docs to clarify that rate limits are runtime/security posture, not `setup.yaml` game rules.

## Rate-Limit Posture
- Default / `secure-default` / `deploy/env/.env.mo`: login `0.1/sec` burst `3`; general `1/sec` burst `10`; cleanup `5m`.
- Staging single-source test overlay / `deploy/env/.env.staging`: login `50/sec` burst `100`; general `500/sec` burst `1000`; cleanup `5m`.
- The staging overlay is intentionally permissive for Mac/k6 hammer tests from one source IP; it is not a production recommendation.

## Notes
- The current compose files do not intentionally constrain backend CPU with Docker CPU/memory resource limits, so observed user CPU on the 1 vCPU droplet should be treated as real capacity signal unless future host/compose limits are added.
- Matching Ansible follow-up PR: https://github.com/openpredictionmarkets/ansible_playbooks/pull/7
- Final staging evidence still requires merging/deploying this SocialPredict PR, reseeding/pulling fresh fixtures, and rerunning smoke/baseline.

## Validation
- `cd backend && go test ./...`
- `bash -n scripts/install.sh loadtest/cli/loadtest`
- `node --check loadtest/dossier/summarize.mjs`
- `node --check loadtest/k6/*.js loadtest/k6/lib/*.js`
- `git diff --check`
- Confirmed fractional k6 rates now fail early with the CLI guidance to use `--bet-rate 1 --bet-time-unit 20s`.
- Tried a tiny public staging baseline with integer rates/time units; it parsed correctly but failed thresholds because local fixture CSVs were stale against the deployed staging DB (`AUTHORIZATION_DENIED` / `MARKET_NOT_FOUND`). Final staging evidence remains pending after reseeding/pulling fresh fixtures.
