### PR TITLE
Add loadtest remote seed and host checks

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -7,6 +7,7 @@ The boundary is intentionally portable. If the harness later needs independent v
 ## Directory Map
 
 - `cli/`: wrapper commands for running scenarios and generating dossier summaries.
+- `cli/OPERATING.md`: step-by-step operator/LLM runbook for staging load tests.
 - `k6/`: k6 API load-test scenarios.
 - `fixtures/`: generated or operator-provided users, credentials, and market IDs. Ignored by default.
 - `results/`: raw k6 outputs. Ignored by default.
@@ -114,6 +115,12 @@ cp loadtest/fixtures/markets.example.csv loadtest/fixtures/markets.csv
 Run a smoke scenario:
 
 ```bash
+./loadtest/cli/loadtest fixtures seed staging \
+  --users 100 \
+  --moderators 5 \
+  --markets 20 \
+  --hot-markets 2 \
+  --reset
 ./loadtest/cli/loadtest fixtures pull staging
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ```

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -138,6 +138,18 @@ Run a low baseline without fractional k6 rates:
   --bet-time-unit 20s
 ```
 
+Run a hot-market burst with setup-time pre-authentication so the measured
+scenario focuses on concentrated betting throughput:
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --target-rate 50 \
+  --preauth-users 100
+```
+
 Generate a release dossier from the k6 summary output:
 
 ```bash

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -124,6 +124,27 @@ Smoke should pass before any baseline or burst test.
 
 7. Increase load gradually and record results in the release dossier.
 
+## Hot-Market Burst Sequence
+
+After smoke and a low baseline pass, isolate concentrated betting pressure with
+`hot-market-burst`. This scenario pre-authenticates users during k6 setup and
+reuses bearer tokens during the measured betting window, so it is intended to
+measure betting throughput rather than login churn.
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --target-rate 50 \
+  --preauth-users 100
+```
+
+If `LOGIN_RATE_LIMITED` appears in this scenario, either increase
+`--preauth-users` only after confirming the staging login limit, or reseed/pull
+fresh fixtures and rerun. Do not interpret login-limit failures as pure betting
+capacity failures.
+
 ## Important Interpretation Notes
 
 - The app rate limiter is per client identity/IP, not a global server cap.

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -1,0 +1,134 @@
+# Load Test CLI Operating Runbook
+
+This runbook is written for a human operator or an LLM agent that needs to reproduce the OpenPredictionMarkets staging load-test sequence safely.
+
+## Local Prerequisites
+
+Install local tools on the load generator machine:
+
+```bash
+brew install k6 node
+```
+
+Verify:
+
+```bash
+./loadtest/cli/loadtest check
+```
+
+## SSH Setup
+
+The CLI uses SSH for remote host operations. For OpenPredictionMarkets staging, the expected local key is:
+
+```text
+~/.keys/socialpredict/staging/id_ed25519
+```
+
+The corresponding public key must already be present in the staging host user's `~/.ssh/authorized_keys`.
+
+Default staging SSH target:
+
+```text
+root@kconfs.com
+```
+
+Default staging repo path:
+
+```text
+/opt/socialpredict
+```
+
+Override those when needed with:
+
+```bash
+--host root@45.55.227.1
+--key ~/.keys/socialpredict/staging/id_ed25519
+--port 22
+--repo-path /opt/socialpredict
+```
+
+## Command Sequence For Staging
+
+1. Confirm public readiness:
+
+```bash
+curl -s https://kconfs.com/readyz
+```
+
+Expected body:
+
+```text
+ready
+```
+
+2. Confirm staging rate limits:
+
+```bash
+./loadtest/cli/loadtest host rate-limits staging
+```
+
+Expected current staging values for single-source load testing:
+
+```text
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=50
+RATE_LIMIT_LOGIN_BURST=100
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=500
+RATE_LIMIT_GENERAL_BURST=1000
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+3. Seed remote staging fixtures:
+
+```bash
+./loadtest/cli/loadtest fixtures seed staging \
+  --users 100 \
+  --moderators 5 \
+  --markets 20 \
+  --hot-markets 2 \
+  --reset
+```
+
+This runs `./SocialPredict load seed` on the remote host with:
+
+```text
+LOAD_TEST_ENABLED=true
+LOAD_TEST_ALLOW_PRODUCTION=true
+```
+
+`--reset` removes only load-test-prefixed fixture data before recreating fixtures.
+
+4. Pull fresh fixture CSVs to the local load generator:
+
+```bash
+./loadtest/cli/loadtest fixtures pull staging
+```
+
+5. Run smoke:
+
+```bash
+./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
+```
+
+Smoke should pass before any baseline or burst test.
+
+6. Run a cautious baseline:
+
+```bash
+./loadtest/cli/loadtest run baseline \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --browse-rate 5 \
+  --bet-rate 2
+```
+
+7. Increase load gradually and record results in the release dossier.
+
+## Important Interpretation Notes
+
+- The app rate limiter is per client identity/IP, not a global server cap.
+- Single-source k6 from a Mac needs higher per-IP staging limits than normal production traffic.
+- Model-office/production should keep conservative limits to discourage automation by any one client identity.
+- Do not run heavy k6 tests on the app/database droplet itself; use a Mac or separate load-generator host.
+- If smoke fails with `AUTHORIZATION_DENIED` or `MARKET_NOT_FOUND`, reseed remote staging and pull fresh fixtures again.
+- If tests fail with `RATE_LIMITED` or `LOGIN_RATE_LIMITED`, confirm staging is using the high `.env.staging` rate-limit overlay.

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -9,6 +9,8 @@ Seed fixture CSVs with `./SocialPredict load seed`, or provide files under `load
 ```bash
 LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --reset
 ./loadtest/cli/loadtest check
+./loadtest/cli/loadtest host rate-limits staging
+./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
 ./loadtest/cli/loadtest fixtures pull staging
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --duration 5m --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
@@ -22,19 +24,61 @@ k6 logs in with normal fake SocialPredict users from `users.csv` and uses normal
 
 No DigitalOcean credentials or betting god token are used by this CLI.
 
-## Remote Fixture Pull
+## Operator Runbook
 
-After running `./SocialPredict load seed` on a remote staging host, pull the generated fixture CSVs back to your load-generator machine:
+For a step-by-step staging sequence, including SSH key expectations and what an
+LLM agent should run in order, see [`OPERATING.md`](./OPERATING.md).
+
+## Remote Host Checks
+
+Show the active remote `RATE_LIMIT_*` values:
 
 ```bash
+./loadtest/cli/loadtest host rate-limits staging
+```
+
+Override the SSH target when needed:
+
+```bash
+./loadtest/cli/loadtest host rate-limits staging \
+  --host root@45.55.227.1 \
+  --key ~/.keys/socialpredict/staging/id_ed25519 \
+  --repo-path /opt/socialpredict
+```
+
+## Remote Fixture Seed And Pull
+
+Seed staging over SSH, then pull the generated fixture CSVs back to your
+load-generator machine:
+
+```bash
+./loadtest/cli/loadtest fixtures seed staging \
+  --users 100 \
+  --moderators 5 \
+  --markets 20 \
+  --hot-markets 2 \
+  --reset
+
 ./loadtest/cli/loadtest fixtures pull staging
 ```
 
-The staging defaults are `root@kconfs.com`, `~/.keys/socialpredict/staging/id_ed25519`, and `/opt/socialpredict/loadtest/fixtures`.
+The staging defaults are `root@kconfs.com`,
+`~/.keys/socialpredict/staging/id_ed25519`, `/opt/socialpredict`, and
+`/opt/socialpredict/loadtest/fixtures`.
 
 Override values when needed:
 
 ```bash
+./loadtest/cli/loadtest fixtures seed staging \
+  --host root@45.55.227.1 \
+  --key ~/.keys/socialpredict/staging/id_ed25519 \
+  --repo-path /opt/socialpredict \
+  --users 100 \
+  --moderators 5 \
+  --markets 20 \
+  --hot-markets 2 \
+  --reset
+
 ./loadtest/cli/loadtest fixtures pull staging \
   --host root@45.55.227.1 \
   --key ~/.keys/socialpredict/staging/id_ed25519 \

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -14,7 +14,7 @@ LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --mar
 ./loadtest/cli/loadtest fixtures pull staging
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --duration 5m --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
-./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 100 --duration 60s
+./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 50 --duration 60s --preauth-users 100
 ./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --metadata loadtest/dossier/metadata.example.json --out loadtest/dossier/runs/<run>.json
 ```
 
@@ -87,6 +87,21 @@ Override values when needed:
 ```
 
 Public staging/prod Nginx publishes API routes under `/api`, so use `--api-prefix /api` when running against `https://kconfs.com` or `https://brierfoxforecast.com`. Direct backend targets such as `http://localhost:8080` should omit the prefix.
+
+## Hot-Market Burst
+
+`hot-market-burst` pre-authenticates users during k6 `setup()` and then reuses
+those bearer tokens during the measured betting scenario. This keeps high-rate
+hot-market tests focused on betting throughput instead of measuring login churn.
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --target-rate 50 \
+  --preauth-users 100
+```
 
 ## Low-Rate Runs
 

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -11,13 +11,17 @@ Usage: ./loadtest/cli/loadtest COMMAND [OPTIONS]
 
 Commands:
   check                  Check local load-test prerequisites
+  fixtures seed <env>    Seed load-test fixtures on a remote host over SSH
   fixtures pull <env>    Pull generated fixture CSVs from a remote host
+  host rate-limits <env> Show remote RATE_LIMIT_* values over SSH
   run <scenario>         Run k6 scenario: smoke, baseline, hot-market-burst, soak
   dossier                Generate release dossier JSON from a k6 summary
   help                   Show this help
 
 Run examples:
   ./loadtest/cli/loadtest check
+  ./loadtest/cli/loadtest host rate-limits staging
+  ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
   ./loadtest/cli/loadtest fixtures pull staging
   ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
   ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
@@ -51,6 +55,18 @@ require_positive_integer_value() {
   fi
   if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
     echo "${label} must be a positive integer. For sub-1/sec rates, increase the time unit, e.g. --bet-rate 1 --bet-time-unit 20s." >&2
+    exit 1
+  fi
+}
+
+require_nonnegative_integer_value() {
+  local label="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    return 0
+  fi
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "${label} must be a non-negative integer." >&2
     exit 1
   fi
 }
@@ -100,6 +116,154 @@ fixture_host_for_env() {
       echo "root@$1"
       ;;
   esac
+}
+
+shell_quote() {
+  printf "%q" "$1"
+}
+
+fixtures_seed_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest fixtures seed <env> [OPTIONS]
+
+Seed load-test fixtures on a remote SocialPredict host over SSH.
+
+Defaults:
+  staging host:    root@kconfs.com
+  mo/prod host:    root@brierfoxforecast.com
+  key path:        ~/.keys/socialpredict/<env>/id_ed25519
+  SSH port:        22
+  remote repo:     /opt/socialpredict
+
+Seed defaults mirror './SocialPredict load seed':
+  users:           10
+  moderators:      2
+  markets:         5
+  hot markets:     1
+  password:        loadtest-password
+  user prefix:     loaduser
+  moderator prefix: loadmod
+  user balance:    1000000
+
+Options:
+  --host VALUE              SSH host, e.g. root@45.55.227.1 or root@kconfs.com
+  --key VALUE               SSH private key path
+  --port VALUE              SSH port; default 22
+  --repo-path VALUE         Remote SocialPredict repo path; default /opt/socialpredict
+  --users N                 Number of REGULAR test users
+  --moderators N            Number of MODERATOR test users
+  --markets N               Number of published fixture markets
+  --hot-markets N           Number of fixture markets marked hot in markets.csv
+  --password VALUE          Password for every load-test user
+  --user-prefix VALUE       Prefix for regular users
+  --moderator-prefix VALUE  Prefix for moderators
+  --user-balance N          Starting balance for each load-test user
+  --resolution-days N       Days until generated markets resolve
+  --bcrypt-cost N           Password hash cost
+  --reset                   Remove existing prefixed fixture users, markets, and bets first
+  --help                    Show this help
+
+Examples:
+  ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
+  ./loadtest/cli/loadtest fixtures seed staging --host root@45.55.227.1 --key ~/.keys/socialpredict/staging/id_ed25519 --reset
+HELP
+}
+
+fixtures_seed_cmd() {
+  case "${1:-}" in
+    --help|-h|help)
+      fixtures_seed_help
+      exit 0
+      ;;
+  esac
+
+  if [ "$#" -lt 1 ]; then
+    echo "fixtures seed requires <env>." >&2
+    fixtures_seed_help
+    exit 1
+  fi
+
+  local env_name="$1"
+  shift
+  local host
+  host="$(fixture_host_for_env "$env_name")"
+  local key="${HOME}/.keys/socialpredict/${env_name}/id_ed25519"
+  local port="22"
+  local repo_path="/opt/socialpredict"
+  local users="10"
+  local moderators="2"
+  local markets="5"
+  local hot_markets="1"
+  local password="loadtest-password"
+  local user_prefix="loaduser"
+  local moderator_prefix="loadmod"
+  local user_balance=""
+  local resolution_days=""
+  local bcrypt_cost=""
+  local reset="false"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --host) host="$2"; shift 2 ;;
+      --key) key="$2"; shift 2 ;;
+      --port) port="$2"; shift 2 ;;
+      --repo-path) repo_path="$2"; shift 2 ;;
+      --users) users="$2"; shift 2 ;;
+      --moderators) moderators="$2"; shift 2 ;;
+      --markets) markets="$2"; shift 2 ;;
+      --hot-markets) hot_markets="$2"; shift 2 ;;
+      --password) password="$2"; shift 2 ;;
+      --user-prefix) user_prefix="$2"; shift 2 ;;
+      --moderator-prefix) moderator_prefix="$2"; shift 2 ;;
+      --user-balance) user_balance="$2"; shift 2 ;;
+      --resolution-days) resolution_days="$2"; shift 2 ;;
+      --bcrypt-cost) bcrypt_cost="$2"; shift 2 ;;
+      --reset) reset="true"; shift ;;
+      --help|-h) fixtures_seed_help; exit 0 ;;
+      *) echo "Unknown fixtures seed option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  require_command ssh
+  if [ ! -f "$key" ]; then
+    echo "Missing SSH key: $key" >&2
+    exit 1
+  fi
+
+  require_positive_integer_value "--users" "$users"
+  require_positive_integer_value "--moderators" "$moderators"
+  require_positive_integer_value "--markets" "$markets"
+  require_nonnegative_integer_value "--hot-markets" "$hot_markets"
+  require_positive_integer_value "--user-balance" "$user_balance"
+  require_positive_integer_value "--resolution-days" "$resolution_days"
+  require_positive_integer_value "--bcrypt-cost" "$bcrypt_cost"
+
+  local seed_args=(
+    ./SocialPredict load seed
+    --users "$users"
+    --moderators "$moderators"
+    --markets "$markets"
+    --hot-markets "$hot_markets"
+    --password "$password"
+    --user-prefix "$user_prefix"
+    --moderator-prefix "$moderator_prefix"
+  )
+  if [ -n "$user_balance" ]; then seed_args+=(--user-balance "$user_balance"); fi
+  if [ -n "$resolution_days" ]; then seed_args+=(--resolution-days "$resolution_days"); fi
+  if [ -n "$bcrypt_cost" ]; then seed_args+=(--bcrypt-cost "$bcrypt_cost"); fi
+  if [ "$reset" = "true" ]; then seed_args+=(--reset); fi
+
+  local quoted_seed_cmd=""
+  local arg
+  for arg in "${seed_args[@]}"; do
+    quoted_seed_cmd+=" $(shell_quote "$arg")"
+  done
+
+  local remote_script
+  remote_script="cd $(shell_quote "$repo_path") && LOAD_TEST_ENABLED=true LOAD_TEST_ALLOW_PRODUCTION=true${quoted_seed_cmd}"
+
+  echo "Seeding load-test fixtures on ${host}:${repo_path}"
+  ssh -p "$port" -i "$key" "$host" "$remote_script"
 }
 
 fixtures_pull_help() {
@@ -180,13 +344,126 @@ fixtures_pull_cmd() {
   echo "  ${local_path}/markets.csv"
 }
 
+fixtures_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest fixtures <seed|pull> <env> [OPTIONS]
+
+Commands:
+  seed <env>   Seed load-test fixtures on a remote host over SSH
+  pull <env>   Pull generated fixture CSVs from a remote host
+
+Examples:
+  ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
+  ./loadtest/cli/loadtest fixtures pull staging
+
+Run command-specific help:
+  ./loadtest/cli/loadtest fixtures seed --help
+  ./loadtest/cli/loadtest fixtures pull --help
+HELP
+}
+
 fixtures_cmd() {
   local subcommand="${1:-help}"
   shift || true
   case "$subcommand" in
+    seed) fixtures_seed_cmd "$@" ;;
     pull) fixtures_pull_cmd "$@" ;;
-    --help|-h|help) fixtures_pull_help ;;
-    *) echo "Unknown fixtures command: $subcommand" >&2; fixtures_pull_help; exit 1 ;;
+    --help|-h|help) fixtures_help ;;
+    *) echo "Unknown fixtures command: $subcommand" >&2; fixtures_help; exit 1 ;;
+  esac
+}
+
+host_rate_limits_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest host rate-limits <env> [OPTIONS]
+
+Show remote RATE_LIMIT_* values from a SocialPredict host .env file over SSH.
+
+Defaults:
+  staging host:    root@kconfs.com
+  mo/prod host:    root@brierfoxforecast.com
+  key path:        ~/.keys/socialpredict/<env>/id_ed25519
+  SSH port:        22
+  remote repo:     /opt/socialpredict
+
+Options:
+  --host VALUE       SSH host, e.g. root@45.55.227.1 or root@kconfs.com
+  --key VALUE        SSH private key path
+  --port VALUE       SSH port; default 22
+  --repo-path VALUE  Remote SocialPredict repo path; default /opt/socialpredict
+  --help             Show this help
+
+Examples:
+  ./loadtest/cli/loadtest host rate-limits staging
+  ./loadtest/cli/loadtest host rate-limits staging --host root@45.55.227.1
+HELP
+}
+
+host_rate_limits_cmd() {
+  case "${1:-}" in
+    --help|-h|help)
+      host_rate_limits_help
+      exit 0
+      ;;
+  esac
+
+  if [ "$#" -lt 1 ]; then
+    echo "host rate-limits requires <env>." >&2
+    host_rate_limits_help
+    exit 1
+  fi
+
+  local env_name="$1"
+  shift
+  local host
+  host="$(fixture_host_for_env "$env_name")"
+  local key="${HOME}/.keys/socialpredict/${env_name}/id_ed25519"
+  local port="22"
+  local repo_path="/opt/socialpredict"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --host) host="$2"; shift 2 ;;
+      --key) key="$2"; shift 2 ;;
+      --port) port="$2"; shift 2 ;;
+      --repo-path) repo_path="$2"; shift 2 ;;
+      --help|-h) host_rate_limits_help; exit 0 ;;
+      *) echo "Unknown host rate-limits option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  require_command ssh
+  if [ ! -f "$key" ]; then
+    echo "Missing SSH key: $key" >&2
+    exit 1
+  fi
+
+  local remote_script
+  remote_script="cd $(shell_quote "$repo_path") && grep \"^RATE_LIMIT_\" .env"
+
+  echo "Reading remote rate limits from ${host}:${repo_path}/.env"
+  ssh -p "$port" -i "$key" "$host" "$remote_script"
+}
+
+host_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest host <rate-limits> <env> [OPTIONS]
+
+Commands:
+  rate-limits <env>  Show remote RATE_LIMIT_* values over SSH
+
+Examples:
+  ./loadtest/cli/loadtest host rate-limits staging
+HELP
+}
+
+host_cmd() {
+  local subcommand="${1:-help}"
+  shift || true
+  case "$subcommand" in
+    rate-limits) host_rate_limits_cmd "$@" ;;
+    --help|-h|help) host_help ;;
+    *) echo "Unknown host command: $subcommand" >&2; host_help; exit 1 ;;
   esac
 }
 
@@ -308,6 +585,7 @@ shift || true
 case "$command" in
   check) check_cmd "$@" ;;
   fixtures) fixtures_cmd "$@" ;;
+  host) host_cmd "$@" ;;
   run) run_cmd "$@" ;;
   dossier) dossier_cmd "$@" ;;
   help|--help|-h) print_help ;;

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -25,7 +25,7 @@ Run examples:
   ./loadtest/cli/loadtest fixtures pull staging
   ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
   ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
-  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 100 --duration 60s
+  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 50 --duration 60s --preauth-users 100
   ./loadtest/cli/loadtest dossier --summary loadtest/results/smoke-20260528T120000Z-summary.json --out loadtest/dossier/runs/smoke.json
 
 Fixture defaults:
@@ -482,6 +482,7 @@ run_cmd() {
   local duration="${DURATION:-}"
   local target_rate="${TARGET_RATE:-}"
   local target_time_unit="${TARGET_TIME_UNIT:-}"
+  local preauth_users="${PREAUTH_USERS:-}"
   local bet_rate="${BET_RATE:-}"
   local bet_time_unit="${BET_TIME_UNIT:-}"
   local browse_rate="${BROWSE_RATE:-}"
@@ -499,6 +500,7 @@ run_cmd() {
       --duration) duration="$2"; shift 2 ;;
       --target-rate) target_rate="$2"; shift 2 ;;
       --target-time-unit) target_time_unit="$2"; shift 2 ;;
+      --preauth-users) preauth_users="$2"; shift 2 ;;
       --bet-rate) bet_rate="$2"; shift 2 ;;
       --bet-time-unit) bet_time_unit="$2"; shift 2 ;;
       --browse-rate) browse_rate="$2"; shift 2 ;;
@@ -523,6 +525,7 @@ run_cmd() {
     exit 1
   fi
   require_positive_integer_value "--target-rate" "$target_rate"
+  require_positive_integer_value "--preauth-users" "$preauth_users"
   require_positive_integer_value "--bet-rate" "$bet_rate"
   require_positive_integer_value "--browse-rate" "$browse_rate"
   require_positive_integer_value "--rate" "$rate"
@@ -543,6 +546,7 @@ run_cmd() {
     DURATION="$duration" \
     TARGET_RATE="$target_rate" \
     TARGET_TIME_UNIT="$target_time_unit" \
+    PREAUTH_USERS="$preauth_users" \
     BET_RATE="$bet_rate" \
     BET_TIME_UNIT="$bet_time_unit" \
     BROWSE_RATE="$browse_rate" \

--- a/loadtest/k6/hot-market-burst.js
+++ b/loadtest/k6/hot-market-burst.js
@@ -1,9 +1,10 @@
 import { sleep } from 'k6';
-import { checkProbes, placeBet, requireFixtures } from './lib/common.js';
+import { checkProbes, placeBet, preAuthenticateUsers, requireFixtures } from './lib/common.js';
 
 const duration = __ENV.DURATION || '60s';
 const targetRate = Number(__ENV.TARGET_RATE || '50');
 const targetTimeUnit = __ENV.TARGET_TIME_UNIT || '1s';
+const preauthUsers = Number(__ENV.PREAUTH_USERS || '100');
 
 export const options = {
   scenarios: {
@@ -25,9 +26,12 @@ export const options = {
 export function setup() {
   requireFixtures();
   checkProbes();
+  return {
+    authenticatedUsers: preAuthenticateUsers(preauthUsers),
+  };
 }
 
-export default function () {
-  placeBet({ hotOnly: true });
+export default function (data) {
+  placeBet({ hotOnly: true, authenticatedUsers: data.authenticatedUsers });
   sleep(0.01);
 }

--- a/loadtest/k6/lib/common.js
+++ b/loadtest/k6/lib/common.js
@@ -20,6 +20,7 @@ export const DEFAULT_PASSWORD = __ENV.LOADTEST_PASSWORD || '';
 export const BET_AMOUNT = Number(__ENV.BET_AMOUNT || '1');
 export const HOT_MARKET_WEIGHT = Number(__ENV.HOT_MARKET_WEIGHT || '8');
 export const FAILURE_LOG_LIMIT = Number(__ENV.FAILURE_LOG_LIMIT || '10');
+export const PREAUTH_USERS = Number(__ENV.PREAUTH_USERS || '100');
 
 let failureLogCount = 0;
 
@@ -180,10 +181,33 @@ export function login(user) {
   return token;
 }
 
-export function placeBet({ hotOnly = false } = {}) {
-  const user = pickUser();
+export function preAuthenticateUsers(limit = PREAUTH_USERS) {
+  const count = Math.min(Math.max(Number(limit) || 0, 0), users.length);
+  const authenticatedUsers = [];
+  for (const user of users.slice(0, count)) {
+    const token = login(user);
+    if (token) {
+      authenticatedUsers.push({ username: user.username, token });
+    }
+  }
+  if (authenticatedUsers.length === 0) {
+    throw new Error('No users could be pre-authenticated for load testing');
+  }
+  return authenticatedUsers;
+}
+
+export function pickAuthenticatedUser(authenticatedUsers) {
+  if (!authenticatedUsers || authenticatedUsers.length === 0) {
+    return null;
+  }
+  return pick(authenticatedUsers);
+}
+
+export function placeBet({ hotOnly = false, authenticatedUsers = null } = {}) {
+  const authenticatedUser = pickAuthenticatedUser(authenticatedUsers);
+  const user = authenticatedUser || pickUser();
   const market = pickMarket({ hotOnly });
-  const token = login(user);
+  const token = authenticatedUser ? authenticatedUser.token : login(user);
   if (!token) {
     betsFailed.add(1, { reason: 'login_failed' });
     return;


### PR DESCRIPTION
## Summary
- Adds `./loadtest/cli/loadtest fixtures seed <env>` to seed remote SocialPredict load-test fixtures over SSH.
- Adds `./loadtest/cli/loadtest host rate-limits <env>` to inspect remote `RATE_LIMIT_*` values over SSH.
- Adds `loadtest/cli/OPERATING.md`, an operator/LLM runbook with SSH key setup and the sequential staging workflow.
- Updates `hot-market-burst` to pre-authenticate users during k6 `setup()` and reuse bearer tokens during the measured betting scenario.
- Updates loadtest docs with remote seed, pull, smoke, pre-auth hot-market burst, and staging rate-limit check examples.

## Validation
- `bash -n loadtest/cli/loadtest`
- `node --check loadtest/k6/lib/common.js loadtest/k6/hot-market-burst.js`
- `./loadtest/cli/loadtest fixtures seed --help`
- `./loadtest/cli/loadtest fixtures --help`
- `./loadtest/cli/loadtest host rate-limits --help`
- `./loadtest/cli/loadtest host rate-limits staging`
- `./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --duration 5s --target-rate 1 --preauth-users 2 --out /tmp/socialpredict-hot-preauth-smoke.json`
- `git diff --check`

## Live checks
`./loadtest/cli/loadtest host rate-limits staging` returned:

```text
RATE_LIMIT_LOGIN_RATE_PER_SECOND=50
RATE_LIMIT_LOGIN_BURST=100
RATE_LIMIT_GENERAL_RATE_PER_SECOND=500
RATE_LIMIT_GENERAL_BURST=1000
RATE_LIMIT_CLEANUP_INTERVAL=5m
```

The low-rate pre-auth hot-market smoke passed with `0%` HTTP failures and all bets succeeded.
