### PR TITLE
chore: add load-test host telemetry and cleanup wrappers

### DIFF
--- a/HostOps
+++ b/HostOps
@@ -33,6 +33,8 @@ Commands:
   env list                        List local environments under ~/.keys/socialpredict
   host ssh <env>                  Open SSH session to environment host
   host env get <env> <KEY>        Read remote .env key
+  host disk <env>                 Show host disk and Docker usage
+  host cleanup <env>              Run remote ./SocialPredict cleanup docker
   host logs <env> <service>       (Planned) Tail remote service logs
   deploy <env>                    (Planned) Orchestrate remote ./SocialPredict deploy
   tf <plan|apply|destroy> <env>   (Planned) Terraform wrapper
@@ -42,6 +44,8 @@ Current implementation:
   - env list is implemented
   - host ssh is implemented
   - host env get is implemented
+  - host disk is implemented
+  - host cleanup is implemented
   - all other commands are scaffold placeholders
 
 Environment directories:
@@ -92,6 +96,9 @@ Examples:
   ./HostOps env list
   ./HostOps host ssh staging
   ./HostOps host env get staging ADMIN_PASSWORD
+  ./HostOps host disk staging
+  ./HostOps host cleanup staging
+  ./HostOps host cleanup staging --all-images
 
 Example:
   # ~/.keys/socialpredict/staging/hostops.env
@@ -337,6 +344,86 @@ grep -E "^${REQUESTED_KEY}=" "$env_file" || {
 REMOTE
 }
 
+host_disk() {
+  local env="$1"
+
+  resolve_env_connection "$env"
+
+  ssh -i "$HOSTOPS_RESOLVED_KEY" \
+    -o BatchMode=yes \
+    -p "$HOSTOPS_RESOLVED_PORT" \
+    "${HOSTOPS_RESOLVED_USER}@${HOSTOPS_RESOLVED_HOST}" \
+    "REPO_PATH='$HOSTOPS_RESOLVED_REPO_PATH' bash -s" <<'REMOTE'
+set -euo pipefail
+echo "Host disk usage:"
+df -h /
+echo
+echo "Docker disk usage:"
+docker system df || true
+echo
+echo "Running containers:"
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" || true
+echo
+echo "Docker volumes:"
+docker volume ls || true
+REMOTE
+}
+
+host_cleanup() {
+  local env="$1"
+  shift || true
+
+  local cleanup_args=()
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --all-images|--volumes)
+        cleanup_args+=("$1")
+        ;;
+      --help|-h)
+        cat <<'EOF'
+Usage: ./HostOps host cleanup <env> [OPTIONS]
+
+Run remote './SocialPredict cleanup docker' on the selected host.
+
+Options:
+  --all-images   Remove all unused images, not just dangling images
+  --volumes      Also prune unused Docker volumes; use carefully on data hosts
+  --help         Show this help
+
+Examples:
+  ./HostOps host cleanup staging
+  ./HostOps host cleanup staging --all-images
+  ./HostOps host cleanup staging --all-images --volumes
+
+Boundary:
+  HostOps only connects to the host and invokes ./SocialPredict. The Docker
+  cleanup behavior remains owned by ./SocialPredict.
+EOF
+        return 0
+        ;;
+      *)
+        print_error "Unknown host cleanup option: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  resolve_env_connection "$env"
+
+  local quoted_cleanup_args=""
+  local arg
+  for arg in "${cleanup_args[@]}"; do
+    quoted_cleanup_args+=" $(printf "%q" "$arg")"
+  done
+
+  ssh -i "$HOSTOPS_RESOLVED_KEY" \
+    -o BatchMode=yes \
+    -p "$HOSTOPS_RESOLVED_PORT" \
+    "${HOSTOPS_RESOLVED_USER}@${HOSTOPS_RESOLVED_HOST}" \
+    "cd $(printf "%q" "$HOSTOPS_RESOLVED_REPO_PATH") && ./SocialPredict cleanup docker${quoted_cleanup_args}"
+}
+
 main() {
   local cmd="${1:-help}"
 
@@ -386,6 +473,27 @@ main() {
               exit 1
               ;;
           esac
+          ;;
+        disk)
+          local env="${3:-}"
+          if [[ -z "$env" ]]; then
+            print_error "Usage: ./HostOps host disk <env>"
+            exit 1
+          fi
+          host_disk "$env"
+          ;;
+        cleanup)
+          local env="${3:-}"
+          if [[ "$env" == "--help" || "$env" == "-h" || "$env" == "help" ]]; then
+            host_cleanup "help" --help
+            exit 0
+          fi
+          if [[ -z "$env" ]]; then
+            print_error "Usage: ./HostOps host cleanup <env> [--all-images] [--volumes]"
+            exit 1
+          fi
+          shift 3
+          host_cleanup "$env" "$@"
           ;;
         get|logs|run)
           require_planned

--- a/README/INFRA/README-INFRA-HOSTOPS.md
+++ b/README/INFRA/README-INFRA-HOSTOPS.md
@@ -235,6 +235,41 @@ Example:
 ./HostOps host env get staging ADMIN_PASSWORD
 ```
 
+`./HostOps host disk <env>`:
+
+- Needs the same SSH keys as `host ssh`
+- Shows `df -h /`, `docker system df`, running containers, and Docker volumes
+- Does not delete anything
+- Use before and after cleanup to capture disk state
+
+Example:
+
+```bash
+./HostOps host disk staging
+```
+
+`./HostOps host cleanup <env>`:
+
+- Needs the same SSH keys as `host ssh`
+- Needs remote repo path via `HOSTOPS_REPO_PATH` or `HOSTOPS_<ENV>_REPO_PATH`, default `/opt/socialpredict`
+- Calls remote `./SocialPredict cleanup docker`
+- Does not reimplement Docker cleanup in HostOps
+- By default removes stopped containers, dangling images, and Docker build cache, but does not prune volumes
+- Optional `--all-images` removes all unused images
+- Optional `--volumes` prunes unused volumes and should only be used when data retention is understood
+
+Examples:
+
+```bash
+./HostOps host cleanup staging
+./HostOps host cleanup staging --all-images
+./HostOps host cleanup staging --all-images --volumes
+```
+
+Weekly cleanup automation should use the same boundary: the workflow or
+orchestrator may connect to the host, but it should invoke
+`./SocialPredict cleanup docker` rather than embedding raw Docker prune logic.
+
 `./HostOps host logs <env> <service>` (planned):
 
 - Needs the same SSH keys as `host ssh`

--- a/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
@@ -11,12 +11,12 @@ This is not game setup. It should not live in `backend/setup/setup.yaml`, becaus
 
 The first measured target is the current staging DigitalOcean baseline:
 
-- Droplet class: regular CPU
-- Memory: 512 MiB
+- Droplet class: Basic regular CPU
+- Memory: 1 GiB
 - vCPU: 1
-- Transfer: 500 GiB
-- SSD: 10 GiB
-- Cost: about $0.00595/hr, $4/mo
+- Transfer: 1,000 GiB
+- SSD: 25 GiB
+- Cost: about $0.00893/hr, $6/mo in the 2026-05-29 pricing snapshot
 - Current staging domain: `kconfs.com`
 
 This feature should let operators record what this small machine can safely handle before larger instance sizing, database separation, Redis/distributed rate limiting, or proxy-level rate limiting are introduced.
@@ -85,7 +85,7 @@ secure-default
   Keeps current conservative defaults.
 
 small-droplet-staging
-  Intended for the current $4/mo 512 MiB / 1 vCPU DigitalOcean droplet.
+  Intended for the current $6/mo 1 GiB / 1 vCPU DigitalOcean droplet.
   Values are provisional and must be verified by load-test evidence.
 
 env-file
@@ -118,7 +118,7 @@ RATE_LIMIT_GENERAL_BURST=1000
 RATE_LIMIT_CLEANUP_INTERVAL=5m
 ```
 
-These are not production capacity claims. They are a starting point for measurement on the $4/mo droplet.
+These are not production capacity claims. They are a starting point for measurement on the current `$6/mo` Basic `1 vCPU / 1 GiB / 25 GiB` staging droplet.
 
 If this overlay still rate-limits before CPU, memory, DB, or application latency becomes the bottleneck, raise it incrementally and record each run in the release dossier.
 
@@ -167,7 +167,7 @@ Every capacity-oriented run should record:
 - CPU, memory, disk, and network observations
 - whether the run hit rate limits, application errors, DB pressure, or host pressure first
 
-For the current $4/mo droplet, the dossier should explicitly say that findings apply to the 512 MiB / 1 vCPU / 10 GiB SSD tier only.
+For the current staging droplet, the dossier should explicitly say that findings apply to the Basic `1 GiB / 1 vCPU / 25 GiB SSD` tier only. Earlier 512 MiB assumptions are not valid evidence for the measured runs.
 
 ## Non-Goals
 

--- a/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
@@ -58,17 +58,17 @@ rate-limit posture. The host still runs from `/opt/socialpredict/.env`.
 The first staging target is intentionally small:
 
 ```text
-DigitalOcean regular CPU
-512 MiB memory
+DigitalOcean Basic regular CPU
+1 GiB memory
 1 vCPU
-500 GiB transfer
-10 GiB SSD
-$4/mo
+1,000 GiB transfer
+25 GiB SSD
+$6/mo in the 2026-05-29 pricing snapshot
 ```
 
 The design goal is not to promise high traffic on this instance. The goal is to make the limit measurable and to avoid confusing rate-limit failures with actual application/database capacity failures.
 
-The current compose files do not intentionally constrain backend CPU with Docker `cpus`, `mem_limit`, or `deploy.resources` settings. On the current one-vCPU droplet, host CPU observations should therefore be treated as real capacity signals unless a future host-level or compose-level limit is added.
+The current compose files do not intentionally constrain backend CPU with Docker `cpus`, `mem_limit`, or `deploy.resources` settings. On the current one-vCPU droplet, Docker sees the same `1` CPU and about `957 MiB` RAM that the host exposes. Host CPU and memory observations should therefore be treated as real capacity signals unless a future host-level or compose-level limit is added.
 
 ## Safety
 

--- a/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/PLAN.md
@@ -23,7 +23,7 @@ Checklist:
 
 - [x] Add install profile selection for production-like installs.
 - [x] Keep `secure-default` as the safe default.
-- [x] Add `small-droplet-staging` profile for the current $4/mo DigitalOcean target.
+- [x] Add `small-droplet-staging` profile for the current Basic `1 vCPU / 1 GiB / 25 GiB` DigitalOcean staging target.
 - [x] Add `env-file` profile support for non-secret deploy env overlays.
 - [x] Add `custom` prompts for explicit values.
 - [x] Write resolved values into `.env`.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -186,6 +186,18 @@ Attach the host summary JSON to a generated dossier when available:
   --out loadtest/dossier/runs/<run>.json
 ```
 
+Generated dossier JSON also includes `rateLimitEquivalents`, which converts the
+measured successful bet rate into equivalent normal-limit client identities:
+
+```text
+ceil(successful_bets_per_second / normal_general_rate_per_second)
+```
+
+For the current `secure-default`/model-office policy, the normal sustained
+general API limit is `1` request/second per client identity with burst `10`.
+These are client identity/IP equivalents for the current limiter, not guaranteed
+unique human users if many users share one NAT or proxy identity.
+
 For capacity evidence, copy `loadtest/dossier/metadata.example.json` and record
 the active `RATE_LIMIT_*` values under `rateLimitPolicy`. For
 OpenPredictionMarkets staging, those values are expected to come from

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -150,6 +150,23 @@ scenario focuses on concentrated betting throughput:
   --preauth-users 100
 ```
 
+Capture host CPU, RAM, disk, and Docker stats during a run:
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --target-rate 50 \
+  --preauth-users 100 \
+  --monitor-env staging \
+  --monitor-interval 5
+```
+
+The monitor writes a CSV under `loadtest/hostops/` by default. This is ignored
+by git and should be promoted into a curated dossier only after the run is
+interpreted.
+
 Generate a release dossier from the k6 summary output:
 
 ```bash

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -167,10 +167,23 @@ The monitor writes a CSV under `loadtest/hostops/` by default. This is ignored
 by git and should be promoted into a curated dossier only after the run is
 interpreted.
 
+The CLI also writes a sibling host summary JSON and prints the key after-run
+stats, including CPU, RAM, disk usage, disk IO, network IO, Docker aggregate
+CPU/RAM, and backend/Postgres/Traefik CPU slices.
+
 Generate a release dossier from the k6 summary output:
 
 ```bash
 ./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --out loadtest/dossier/runs/<run>.json
+```
+
+Attach the host summary JSON to a generated dossier when available:
+
+```bash
+./loadtest/cli/loadtest dossier \
+  --summary loadtest/results/<summary>.json \
+  --host-summary loadtest/hostops/<run>-host-summary.json \
+  --out loadtest/dossier/runs/<run>.json
 ```
 
 For capacity evidence, copy `loadtest/dossier/metadata.example.json` and record

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -171,6 +171,19 @@ The CLI also writes a sibling host summary JSON and prints the key after-run
 stats, including CPU, RAM, disk usage, disk IO, network IO, Docker aggregate
 CPU/RAM, and backend/Postgres/Traefik CPU slices.
 
+When `--monitor-env` is used, the CLI also captures a static host profile JSON
+before the run. That profile records the control variables for interpreting
+capacity evidence: OS/kernel, CPU count/model, RAM/swap, root disk size, Docker
+server/storage/cgroup settings, Docker-visible CPU/RAM, and whether running
+containers have explicit CPU or memory limits.
+
+Interpretation:
+
+- `cpu_user_pct`, `cpu_system_pct`, and `cpu_idle_pct` are whole-machine host CPU samples from `/proc/stat`.
+- `docker_cpu_pct_sum` is the sum of `docker stats` CPU percentages across containers.
+- On a `1 vCPU` host, Docker CPU near `100%` plus host idle near `0%` means the containers are effectively consuming the whole machine.
+- If the host profile shows zero explicit container CPU/memory limits, there is no Docker Compose cap to raise; more headroom requires a larger host, fewer services on the host, or architectural changes.
+
 Generate a release dossier from the k6 summary output:
 
 ```bash

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -213,8 +213,8 @@ one bet/second. If modeling one bet every ten seconds per identity, use
 
 ## Small-Droplet Max-Capacity Ladder
 
-For the current smallest staging Droplet, use a gradual hot-market ladder and
-capture host telemetry on every run:
+For the current Basic `1 vCPU / 1 GiB RAM / 25 GiB Disk` staging Droplet, use a
+gradual hot-market ladder and capture host telemetry on every run:
 
 ```bash
 ./loadtest/cli/loadtest run hot-market-burst \

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -149,8 +149,9 @@ Smoke should pass before any baseline or burst test.
 ```
 
 This writes a CSV under `loadtest/hostops/` with CPU, RAM, disk, and Docker
-stats sampled from the remote host over SSH. Use that CSV alongside the k6
-summary when producing a release dossier.
+stats sampled from the remote host over SSH. The CLI also writes a sibling
+host summary JSON and prints the after-run maxima/minima. Use that summary
+alongside the k6 summary when producing a release dossier.
 
 8. Increase load gradually and record results in the release dossier.
 
@@ -199,6 +200,16 @@ capture host telemetry on every run:
   --preauth-users 100 \
   --monitor-env staging \
   --monitor-interval 5
+```
+
+After the run, create a dossier that includes both the k6 result and the host
+summary:
+
+```bash
+./loadtest/cli/loadtest dossier \
+  --summary loadtest/results/<summary>.json \
+  --host-summary loadtest/hostops/<run>-host-summary.json \
+  --out loadtest/dossier/runs/<run>.json
 ```
 
 Suggested sequence after smoke passes:

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -61,6 +61,19 @@ Expected body:
 ready
 ```
 
+Optional: inspect and clean staging disk before capacity runs:
+
+```bash
+./HostOps host disk staging
+./HostOps host cleanup staging
+./HostOps host cleanup staging --all-images
+./HostOps host disk staging
+```
+
+Do not use `--volumes` during routine cleanup unless you have confirmed the
+volumes are unused and safe to delete. The cleanup wrapper calls remote
+`./SocialPredict cleanup docker`; HostOps does not own Docker runtime behavior.
+
 2. Confirm staging rate limits:
 
 ```bash
@@ -122,7 +135,24 @@ Smoke should pass before any baseline or burst test.
   --bet-rate 2
 ```
 
-7. Increase load gradually and record results in the release dossier.
+7. Attach host telemetry when increasing load:
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --target-rate 50 \
+  --preauth-users 100 \
+  --monitor-env staging \
+  --monitor-interval 5
+```
+
+This writes a CSV under `loadtest/hostops/` with CPU, RAM, disk, and Docker
+stats sampled from the remote host over SSH. Use that CSV alongside the k6
+summary when producing a release dossier.
+
+8. Increase load gradually and record results in the release dossier.
 
 ## Hot-Market Burst Sequence
 
@@ -153,3 +183,31 @@ capacity failures.
 - Do not run heavy k6 tests on the app/database droplet itself; use a Mac or separate load-generator host.
 - If smoke fails with `AUTHORIZATION_DENIED` or `MARKET_NOT_FOUND`, reseed remote staging and pull fresh fixtures again.
 - If tests fail with `RATE_LIMITED` or `LOGIN_RATE_LIMITED`, confirm staging is using the high `.env.staging` rate-limit overlay.
+- If host telemetry shows available memory dropping below roughly `150 MiB`, p95 latency above `1s`, dropped iterations, or sustained error rates, stop increasing the target rate and capture that run as a capacity boundary.
+
+## Small-Droplet Max-Capacity Ladder
+
+For the current smallest staging Droplet, use a gradual hot-market ladder and
+capture host telemetry on every run:
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --target-rate 50 \
+  --preauth-users 100 \
+  --monitor-env staging \
+  --monitor-interval 5
+```
+
+Suggested sequence after smoke passes:
+
+- `50` bets/sec for `1m`
+- `75` bets/sec for `1m`
+- `100` bets/sec for `1m`
+- `125` bets/sec for `1m`
+- repeat the highest passing rate for `5m`
+
+Stop the ladder when any run shows errors, dropped iterations, p95 latency over
+the chosen service target, or host telemetry shows sustained memory pressure.

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -149,9 +149,13 @@ Smoke should pass before any baseline or burst test.
 ```
 
 This writes a CSV under `loadtest/hostops/` with CPU, RAM, disk, and Docker
-stats sampled from the remote host over SSH. The CLI also writes a sibling
-host summary JSON and prints the after-run maxima/minima. Use that summary
-alongside the k6 summary when producing a release dossier.
+stats sampled from the remote host over SSH. The CLI also writes sibling host
+profile and host summary JSON files and prints the after-run maxima/minima. Use
+that summary alongside the k6 summary when producing a release dossier.
+
+The host profile is the test-control record. It captures OS/kernel, CPU count,
+memory, root disk, Docker server/storage/cgroup settings, Docker-visible CPU and
+RAM, and whether containers have explicit CPU or memory limits.
 
 8. Increase load gradually and record results in the release dossier.
 
@@ -204,6 +208,8 @@ one bet/second. If modeling one bet every ten seconds per identity, use
 - If smoke fails with `AUTHORIZATION_DENIED` or `MARKET_NOT_FOUND`, reseed remote staging and pull fresh fixtures again.
 - If tests fail with `RATE_LIMITED` or `LOGIN_RATE_LIMITED`, confirm staging is using the high `.env.staging` rate-limit overlay.
 - If host telemetry shows available memory dropping below roughly `150 MiB`, p95 latency above `1s`, dropped iterations, or sustained error rates, stop increasing the target rate and capture that run as a capacity boundary.
+- If `docker_cpu_pct_sum` is near `100%` on a `1 vCPU` host while host CPU idle is near `0%`, Docker is not the bottleneck boundary; the whole host is CPU saturated.
+- If the host profile shows no explicit container CPU/memory limits, there is no Docker Compose resource cap to raise for more local headroom.
 
 ## Small-Droplet Max-Capacity Ladder
 

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -176,6 +176,25 @@ If `LOGIN_RATE_LIMITED` appears in this scenario, either increase
 fresh fixtures and rerun. Do not interpret login-limit failures as pure betting
 capacity failures.
 
+## Normal-Rate-Limit Equivalent
+
+OpenPredictionMarkets staging uses much higher per-IP limits than normal so a
+single Mac can generate useful capacity pressure. The normal/model-office
+general API limit is currently `1` request/second per client identity with burst
+`10`; login is `0.1` request/second with burst `3`.
+
+The dossier converts measured successful betting throughput into normal-limit
+client-identity equivalents with:
+
+```text
+ceil(successful_bets_per_second / normal_general_rate_per_second)
+```
+
+Example: a run that sustains `65.78` successful bets/second corresponds to
+`ceil(65.78 / 1) = 66` normal-limit client identities if each identity places
+one bet/second. If modeling one bet every ten seconds per identity, use
+`ceil(65.78 / 0.1) = 658`.
+
 ## Important Interpretation Notes
 
 - The app rate limiter is per client identity/IP, not a global server cap.

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -10,11 +10,13 @@ Seed fixture CSVs with `./SocialPredict load seed`, or provide files under `load
 LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --reset
 ./loadtest/cli/loadtest check
 ./loadtest/cli/loadtest host rate-limits staging
+./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
 ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
 ./loadtest/cli/loadtest fixtures pull staging
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --duration 5m --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
 ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 50 --duration 60s --preauth-users 100
+./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 50 --duration 60s --preauth-users 100 --monitor-env staging
 ./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --metadata loadtest/dossier/metadata.example.json --out loadtest/dossier/runs/<run>.json
 ```
 
@@ -45,6 +47,29 @@ Override the SSH target when needed:
   --key ~/.keys/socialpredict/staging/id_ed25519 \
   --repo-path /opt/socialpredict
 ```
+
+Capture CPU, RAM, disk, and Docker stats as CSV while you run a test:
+
+```bash
+./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
+```
+
+Or attach monitoring directly to a k6 run:
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url https://kconfs.com \
+  --api-prefix /api \
+  --duration 1m \
+  --target-rate 50 \
+  --preauth-users 100 \
+  --monitor-env staging \
+  --monitor-interval 5
+```
+
+The CSV is written to `loadtest/hostops/` by default. It includes host load,
+CPU user/system/idle percentages, memory, swap, root disk usage, summed Docker
+CPU/memory, and backend/Postgres/Traefik CPU slices.
 
 ## Remote Fixture Seed And Pull
 

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -11,13 +11,14 @@ LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --mar
 ./loadtest/cli/loadtest check
 ./loadtest/cli/loadtest host rate-limits staging
 ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
+./loadtest/cli/loadtest host summarize loadtest/hostops/<run>-host.csv
 ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
 ./loadtest/cli/loadtest fixtures pull staging
 ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
 ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --duration 5m --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
 ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 50 --duration 60s --preauth-users 100
 ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --api-prefix /api --target-rate 50 --duration 60s --preauth-users 100 --monitor-env staging
-./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --metadata loadtest/dossier/metadata.example.json --out loadtest/dossier/runs/<run>.json
+./loadtest/cli/loadtest dossier --summary loadtest/results/<summary>.json --host-summary loadtest/hostops/<run>-host-summary.json --metadata loadtest/dossier/metadata.example.json --out loadtest/dossier/runs/<run>.json
 ```
 
 ## Authentication
@@ -68,8 +69,19 @@ Or attach monitoring directly to a k6 run:
 ```
 
 The CSV is written to `loadtest/hostops/` by default. It includes host load,
-CPU user/system/idle percentages, memory, swap, root disk usage, summed Docker
-CPU/memory, and backend/Postgres/Traefik CPU slices.
+CPU user/system/idle percentages, memory, swap, root disk usage, disk read/write
+rates, network receive/transmit rates, summed Docker CPU/memory, and
+backend/Postgres/Traefik CPU slices.
+
+Summarize a telemetry CSV after the fact:
+
+```bash
+./loadtest/cli/loadtest host summarize loadtest/hostops/<run>-host.csv
+```
+
+When `--monitor-env` is attached to a k6 run, the CLI automatically writes a
+sibling `<run>-host-summary.json` and prints the same summary after the k6
+output.
 
 ## Remote Fixture Seed And Pull
 

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -10,6 +10,7 @@ Seed fixture CSVs with `./SocialPredict load seed`, or provide files under `load
 LOAD_TEST_ENABLED=true ./SocialPredict load seed --users 10 --moderators 2 --markets 5 --reset
 ./loadtest/cli/loadtest check
 ./loadtest/cli/loadtest host rate-limits staging
+./loadtest/cli/loadtest host profile staging
 ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
 ./loadtest/cli/loadtest host summarize loadtest/hostops/<run>-host.csv
 ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
@@ -52,6 +53,7 @@ Override the SSH target when needed:
 Capture CPU, RAM, disk, and Docker stats as CSV while you run a test:
 
 ```bash
+./loadtest/cli/loadtest host profile staging
 ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
 ```
 
@@ -80,8 +82,14 @@ Summarize a telemetry CSV after the fact:
 ```
 
 When `--monitor-env` is attached to a k6 run, the CLI automatically writes a
-sibling `<run>-host-summary.json` and prints the same summary after the k6
-output.
+sibling `<run>-host-profile.json`, `<run>-host-summary.json`, and prints the
+same summary after the k6 output.
+
+The profile answers whether Docker is capped below the host. If Docker reports
+the same CPU/RAM as the host and containers have no explicit CPU/memory limits,
+then `docker_cpu_pct_sum` near `100%` on a `1 vCPU` host means Docker is using
+essentially all available host CPU. There is no local Docker cap to raise in
+that case.
 
 ## Rate-Limit Equivalent Users
 

--- a/loadtest/cli/README.md
+++ b/loadtest/cli/README.md
@@ -83,6 +83,19 @@ When `--monitor-env` is attached to a k6 run, the CLI automatically writes a
 sibling `<run>-host-summary.json` and prints the same summary after the k6
 output.
 
+## Rate-Limit Equivalent Users
+
+The dossier summarizer calculates a normal-rate-limit equivalent using:
+
+```text
+ceil(successful_bets_per_second / normal_general_rate_per_second)
+```
+
+The current normal/model-office general API limit is `1` request/second per
+client identity with burst `10`. Because the runtime limiter is keyed by client
+identity/IP, this value should be read as client-identity equivalents. It only
+equals unique users when each user has a distinct limiter identity.
+
 ## Remote Fixture Seed And Pull
 
 Seed staging over SSH, then pull the generated fixture CSVs back to your

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -15,6 +15,7 @@ Commands:
   fixtures pull <env>    Pull generated fixture CSVs from a remote host
   host rate-limits <env> Show remote RATE_LIMIT_* values over SSH
   host monitor <env>     Capture host CPU/RAM/disk/Docker telemetry over SSH
+  host summarize <csv>   Summarize host telemetry CSV
   run <scenario>         Run k6 scenario: smoke, baseline, hot-market-burst, soak
   dossier                Generate release dossier JSON from a k6 summary
   help                   Show this help
@@ -23,6 +24,7 @@ Run examples:
   ./loadtest/cli/loadtest check
   ./loadtest/cli/loadtest host rate-limits staging
   ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
+  ./loadtest/cli/loadtest host summarize loadtest/hostops/<run>-host.csv
   ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
   ./loadtest/cli/loadtest fixtures pull staging
   ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
@@ -622,13 +624,17 @@ docker_totals() {
   '
 }
 
-echo "timestamp_utc,sample,load1,load5,load15,cpu_user_pct,cpu_system_pct,cpu_idle_pct,mem_total_mib,mem_used_mib,mem_available_mib,swap_used_mib,disk_used_pct,disk_used_mib,disk_available_mib,docker_cpu_pct_sum,docker_mem_mib_sum,container_count,backend_cpu_pct,postgres_cpu_pct,traefik_cpu_pct"
+echo "timestamp_utc,sample,load1,load5,load15,cpu_user_pct,cpu_system_pct,cpu_idle_pct,mem_total_mib,mem_used_mib,mem_available_mib,swap_used_mib,disk_used_pct,disk_used_mib,disk_available_mib,disk_read_kib_per_sec,disk_write_kib_per_sec,net_rx_kib_per_sec,net_tx_kib_per_sec,docker_cpu_pct_sum,docker_mem_mib_sum,container_count,backend_cpu_pct,postgres_cpu_pct,traefik_cpu_pct"
 
 while [ "$(date +%s)" -le "$end_at" ]; do
   sample=$((sample + 1))
   cpu_before="$(read_cpu)"
+  disk_io_before="$(awk '$3 !~ /^(loop|ram)/ { read += $6; write += $10 } END { printf "%d %d", read, write }' /proc/diskstats)"
+  net_io_before="$(awk -F'[: ]+' 'NR > 2 && $2 != "lo" { rx += $3; tx += $11 } END { printf "%d %d", rx, tx }' /proc/net/dev)"
   sleep 1
   cpu_after="$(read_cpu)"
+  disk_io_after="$(awk '$3 !~ /^(loop|ram)/ { read += $6; write += $10 } END { printf "%d %d", read, write }' /proc/diskstats)"
+  net_io_after="$(awk -F'[: ]+' 'NR > 2 && $2 != "lo" { rx += $3; tx += $11 } END { printf "%d %d", rx, tx }' /proc/net/dev)"
 
   cpu_values="$(
     awk -v before="$cpu_before" -v after="$cpu_after" '
@@ -645,6 +651,34 @@ while [ "$(date +%s)" -le "$end_at" ]; do
     '
   )"
 
+  disk_io_values="$(
+    awk -v before="$disk_io_before" -v after="$disk_io_after" '
+      BEGIN {
+        split(before, b, " ")
+        split(after, a, " ")
+        read_kib=(a[1]-b[1]) * 512 / 1024
+        write_kib=(a[2]-b[2]) * 512 / 1024
+        if (read_kib < 0) read_kib=0
+        if (write_kib < 0) write_kib=0
+        printf "%.2f,%.2f", read_kib, write_kib
+      }
+    '
+  )"
+
+  net_io_values="$(
+    awk -v before="$net_io_before" -v after="$net_io_after" '
+      BEGIN {
+        split(before, b, " ")
+        split(after, a, " ")
+        rx_kib=(a[1]-b[1]) / 1024
+        tx_kib=(a[2]-b[2]) / 1024
+        if (rx_kib < 0) rx_kib=0
+        if (tx_kib < 0) tx_kib=0
+        printf "%.2f,%.2f", rx_kib, tx_kib
+      }
+    '
+  )"
+
   load_values="$(awk '{ printf "%s,%s,%s", $1, $2, $3 }' /proc/loadavg)"
   mem_values="$(free -m | awk '/^Mem:/ { total=$2; used=$3; available=$7 } /^Swap:/ { swap_used=$3 } END { printf "%d,%d,%d,%d", total, used, available, swap_used }')"
   disk_values="$(df -Pm / | awk 'NR==2 { used_pct=$5; gsub(/%/, "", used_pct); printf "%d,%d,%d", used_pct, $3, $4 }')"
@@ -653,13 +687,15 @@ while [ "$(date +%s)" -le "$end_at" ]; do
     docker_values="0.00,0.00,0,0.00,0.00,0.00"
   fi
 
-  printf "%s,%d,%s,%s,%s,%s,%s\n" \
+  printf "%s,%d,%s,%s,%s,%s,%s,%s,%s\n" \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     "$sample" \
     "$load_values" \
     "$cpu_values" \
     "$mem_values" \
     "$disk_values" \
+    "$disk_io_values" \
+    "$net_io_values" \
     "$docker_values"
 
   if [ "$(date +%s)" -ge "$end_at" ]; then
@@ -672,17 +708,72 @@ REMOTE
   echo "Telemetry captured: ${out}" >&2
 }
 
+host_summarize_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest host summarize <csv> [OPTIONS]
+
+Summarize a host telemetry CSV produced by 'host monitor'.
+
+Options:
+  --out VALUE  Write JSON summary to this path
+  --help       Show this help
+
+Examples:
+  ./loadtest/cli/loadtest host summarize loadtest/hostops/hot-market-burst-staging-host.csv
+  ./loadtest/cli/loadtest host summarize loadtest/hostops/hot-market-burst-staging-host.csv --out loadtest/hostops/hot-market-burst-staging-host-summary.json
+HELP
+}
+
+host_summarize_cmd() {
+  case "${1:-}" in
+    --help|-h|help)
+      host_summarize_help
+      exit 0
+      ;;
+  esac
+
+  if [ "$#" -lt 1 ]; then
+    echo "host summarize requires <csv>." >&2
+    host_summarize_help
+    exit 1
+  fi
+
+  local csv="$1"
+  shift
+  local out=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --out) out="$2"; shift 2 ;;
+      --help|-h) host_summarize_help; exit 0 ;;
+      *) echo "Unknown host summarize option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  if [ ! -f "$csv" ]; then
+    echo "Host telemetry CSV not found: $csv" >&2
+    exit 1
+  fi
+
+  require_command node
+  local args=("${LOADTEST_DIR}/dossier/summarize-host.mjs" --csv "$csv")
+  if [ -n "$out" ]; then args+=(--out "$out"); fi
+  node "${args[@]}"
+}
+
 host_help() {
   cat <<'HELP'
-Usage: ./loadtest/cli/loadtest host <rate-limits|monitor> <env> [OPTIONS]
+Usage: ./loadtest/cli/loadtest host <rate-limits|monitor|summarize> [ARGS] [OPTIONS]
 
 Commands:
   rate-limits <env>  Show remote RATE_LIMIT_* values over SSH
   monitor <env>      Capture CPU/RAM/disk/Docker telemetry CSV over SSH
+  summarize <csv>    Summarize host telemetry CSV
 
 Examples:
   ./loadtest/cli/loadtest host rate-limits staging
   ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
+  ./loadtest/cli/loadtest host summarize loadtest/hostops/<run>-host.csv
 HELP
 }
 
@@ -692,6 +783,7 @@ host_cmd() {
   case "$subcommand" in
     rate-limits) host_rate_limits_cmd "$@" ;;
     monitor) host_monitor_cmd "$@" ;;
+    summarize) host_summarize_cmd "$@" ;;
     --help|-h|help) host_help ;;
     *) echo "Unknown host command: $subcommand" >&2; host_help; exit 1 ;;
   esac
@@ -816,6 +908,8 @@ run_cmd() {
   }
   trap cleanup_monitor EXIT INT TERM
 
+  local k6_status=0
+  set +e
   (
     cd "$REPO_DIR"
     BASE_URL="$base_url" \
@@ -834,26 +928,34 @@ run_cmd() {
     TIME_UNIT="$time_unit" \
     k6 run --summary-export "$out" "$script"
   )
+  k6_status="$?"
+  set -e
+
   if [ -n "$monitor_pid" ]; then
     kill "$monitor_pid" >/dev/null 2>&1 || true
     wait "$monitor_pid" >/dev/null 2>&1 || true
     monitor_pid=""
     echo "Host telemetry: $monitor_out"
+    local monitor_summary_out="${monitor_out%.csv}-summary.json"
+    "${BASH_SOURCE[0]}" host summarize "$monitor_out" --out "$monitor_summary_out" || true
   fi
   trap - EXIT INT TERM
   echo "Summary: $out"
+  return "$k6_status"
 }
 
 dossier_cmd() {
   local summary=""
   local out=""
   local metadata=""
+  local host_summary=""
   local decision=""
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --summary) summary="$2"; shift 2 ;;
       --out) out="$2"; shift 2 ;;
       --metadata) metadata="$2"; shift 2 ;;
+      --host-summary) host_summary="$2"; shift 2 ;;
       --decision) decision="$2"; shift 2 ;;
       --help|-h) print_help; exit 0 ;;
       *) echo "Unknown dossier option: $1" >&2; exit 1 ;;
@@ -866,6 +968,7 @@ dossier_cmd() {
   require_command node
   local args=("${LOADTEST_DIR}/dossier/summarize.mjs" --summary "$summary" --out "$out")
   if [ -n "$metadata" ]; then args+=(--metadata "$metadata"); fi
+  if [ -n "$host_summary" ]; then args+=(--host-summary "$host_summary"); fi
   if [ -n "$decision" ]; then args+=(--decision "$decision"); fi
   node "${args[@]}"
 }

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -14,6 +14,7 @@ Commands:
   fixtures seed <env>    Seed load-test fixtures on a remote host over SSH
   fixtures pull <env>    Pull generated fixture CSVs from a remote host
   host rate-limits <env> Show remote RATE_LIMIT_* values over SSH
+  host profile <env>     Capture static host/Docker profile JSON over SSH
   host monitor <env>     Capture host CPU/RAM/disk/Docker telemetry over SSH
   host summarize <csv>   Summarize host telemetry CSV
   run <scenario>         Run k6 scenario: smoke, baseline, hot-market-burst, soak
@@ -23,6 +24,7 @@ Commands:
 Run examples:
   ./loadtest/cli/loadtest check
   ./loadtest/cli/loadtest host rate-limits staging
+  ./loadtest/cli/loadtest host profile staging
   ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
   ./loadtest/cli/loadtest host summarize loadtest/hostops/<run>-host.csv
   ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
@@ -708,6 +710,120 @@ REMOTE
   echo "Telemetry captured: ${out}" >&2
 }
 
+host_profile_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest host profile <env> [OPTIONS]
+
+Capture static host, Docker, and container resource-limit profile over SSH.
+
+Defaults:
+  staging host:    root@kconfs.com
+  mo/prod host:    root@brierfoxforecast.com
+  key path:        ~/.keys/socialpredict/<env>/id_ed25519
+  SSH port:        22
+  output:          loadtest/hostops/<env>-host-profile-<timestamp>.json
+
+Options:
+  --host VALUE       SSH host, e.g. root@45.55.227.1 or root@kconfs.com
+  --key VALUE        SSH private key path
+  --port VALUE       SSH port; default 22
+  --out VALUE        Local JSON output path
+  --help             Show this help
+
+Examples:
+  ./loadtest/cli/loadtest host profile staging
+  ./loadtest/cli/loadtest host profile staging --out loadtest/hostops/staging-profile.json
+HELP
+}
+
+host_profile_cmd() {
+  case "${1:-}" in
+    --help|-h|help)
+      host_profile_help
+      exit 0
+      ;;
+  esac
+
+  if [ "$#" -lt 1 ]; then
+    echo "host profile requires <env>." >&2
+    host_profile_help
+    exit 1
+  fi
+
+  local env_name="$1"
+  shift
+  resolve_host_defaults "$env_name"
+  local host="$LOADTEST_HOST_RESOLVED_HOST"
+  local key="$LOADTEST_HOST_RESOLVED_KEY"
+  local port="$LOADTEST_HOST_RESOLVED_PORT"
+  local out="${LOADTEST_DIR}/hostops/${env_name}-host-profile-$(iso_stamp).json"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --host) host="$2"; shift 2 ;;
+      --key) key="$2"; shift 2 ;;
+      --port) port="$2"; shift 2 ;;
+      --out) out="$2"; shift 2 ;;
+      --help|-h) host_profile_help; exit 0 ;;
+      *) echo "Unknown host profile option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  require_command ssh
+  require_command node
+  if [ ! -f "$key" ]; then
+    echo "Missing SSH key: $key" >&2
+    exit 1
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  ssh -p "$port" -i "$key" "$host" "bash -s" > "$tmp" <<'REMOTE'
+set -euo pipefail
+
+kv() {
+  key="$1"
+  shift
+  value="$("$@" 2>/dev/null || true)"
+  value="$(printf "%s" "$value" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+  printf '%s=%s\n' "$key" "$value"
+}
+
+kv timestamp_utc date -u +%Y-%m-%dT%H:%M:%SZ
+kv hostname hostname
+kv kernel uname -srmo
+if [ -f /etc/os-release ]; then
+  # shellcheck source=/dev/null
+  . /etc/os-release
+  printf 'os_pretty_name=%s\n' "${PRETTY_NAME:-unknown}"
+else
+  printf 'os_pretty_name=unknown\n'
+fi
+kv architecture uname -m
+kv cpu_count nproc
+printf 'cpu_model=%s\n' "$(awk -F': ' '/model name/ { print $2; exit }' /proc/cpuinfo 2>/dev/null || true)"
+awk '/^MemTotal:/ { printf "mem_total_mib=%d\n", $2 / 1024 } /^SwapTotal:/ { printf "swap_total_mib=%d\n", $2 / 1024 }' /proc/meminfo
+df -Pm / | awk 'NR==2 { used_pct=$5; gsub(/%/, "", used_pct); printf "root_disk_size_mib=%d\nroot_disk_used_mib=%d\nroot_disk_available_mib=%d\nroot_disk_used_pct=%d\n", $2, $3, $4, used_pct }'
+kv docker_server_version docker version --format '{{.Server.Version}}'
+kv docker_storage_driver docker info --format '{{.Driver}}'
+kv docker_cgroup_driver docker info --format '{{.CgroupDriver}}'
+kv docker_cgroup_version docker info --format '{{.CgroupVersion}}'
+kv docker_ncpu docker info --format '{{.NCPU}}'
+docker info --format '{{.MemTotal}}' 2>/dev/null | awk '{ printf "docker_mem_total_mib=%d\n", $1 / 1024 / 1024 }'
+kv docker_root_dir docker info --format '{{.DockerRootDir}}'
+kv docker_operating_system docker info --format '{{.OperatingSystem}}'
+kv docker_kernel_version docker info --format '{{.KernelVersion}}'
+
+docker ps --format '{{.ID}}' | while read -r id; do
+  [ -n "$id" ] || continue
+  docker inspect --format 'container={{.Name}}|{{index .Config.Labels "com.docker.compose.service"}}|{{.HostConfig.NanoCpus}}|{{.HostConfig.CpuQuota}}|{{.HostConfig.CpuPeriod}}|{{.HostConfig.CpusetCpus}}|{{.HostConfig.Memory}}|{{.HostConfig.MemorySwap}}' "$id" | sed 's#container=/#container=#'
+done
+REMOTE
+
+  node "${LOADTEST_DIR}/dossier/host-profile-from-kv.mjs" --input "$tmp" --out "$out"
+  rm -f "$tmp"
+}
+
 host_summarize_help() {
   cat <<'HELP'
 Usage: ./loadtest/cli/loadtest host summarize <csv> [OPTIONS]
@@ -715,8 +831,9 @@ Usage: ./loadtest/cli/loadtest host summarize <csv> [OPTIONS]
 Summarize a host telemetry CSV produced by 'host monitor'.
 
 Options:
-  --out VALUE  Write JSON summary to this path
-  --help       Show this help
+  --profile VALUE  Host profile JSON from 'host profile'
+  --out VALUE      Write JSON summary to this path
+  --help           Show this help
 
 Examples:
   ./loadtest/cli/loadtest host summarize loadtest/hostops/hot-market-burst-staging-host.csv
@@ -741,9 +858,11 @@ host_summarize_cmd() {
   local csv="$1"
   shift
   local out=""
+  local profile=""
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
+      --profile) profile="$2"; shift 2 ;;
       --out) out="$2"; shift 2 ;;
       --help|-h) host_summarize_help; exit 0 ;;
       *) echo "Unknown host summarize option: $1" >&2; exit 1 ;;
@@ -757,21 +876,24 @@ host_summarize_cmd() {
 
   require_command node
   local args=("${LOADTEST_DIR}/dossier/summarize-host.mjs" --csv "$csv")
+  if [ -n "$profile" ]; then args+=(--profile "$profile"); fi
   if [ -n "$out" ]; then args+=(--out "$out"); fi
   node "${args[@]}"
 }
 
 host_help() {
   cat <<'HELP'
-Usage: ./loadtest/cli/loadtest host <rate-limits|monitor|summarize> [ARGS] [OPTIONS]
+Usage: ./loadtest/cli/loadtest host <rate-limits|profile|monitor|summarize> [ARGS] [OPTIONS]
 
 Commands:
   rate-limits <env>  Show remote RATE_LIMIT_* values over SSH
+  profile <env>      Capture static host/Docker profile JSON over SSH
   monitor <env>      Capture CPU/RAM/disk/Docker telemetry CSV over SSH
   summarize <csv>    Summarize host telemetry CSV
 
 Examples:
   ./loadtest/cli/loadtest host rate-limits staging
+  ./loadtest/cli/loadtest host profile staging
   ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
   ./loadtest/cli/loadtest host summarize loadtest/hostops/<run>-host.csv
 HELP
@@ -782,6 +904,7 @@ host_cmd() {
   shift || true
   case "$subcommand" in
     rate-limits) host_rate_limits_cmd "$@" ;;
+    profile) host_profile_cmd "$@" ;;
     monitor) host_monitor_cmd "$@" ;;
     summarize) host_summarize_cmd "$@" ;;
     --help|-h|help) host_help ;;
@@ -824,6 +947,7 @@ run_cmd() {
   local monitor_port="${MONITOR_PORT:-}"
   local monitor_interval="${MONITOR_INTERVAL:-5}"
   local monitor_out="${MONITOR_OUT:-}"
+  local monitor_profile_out="${MONITOR_PROFILE_OUT:-}"
   local out=""
 
   while [ "$#" -gt 0 ]; do
@@ -848,6 +972,7 @@ run_cmd() {
       --monitor-port) monitor_port="$2"; shift 2 ;;
       --monitor-interval) monitor_interval="$2"; shift 2 ;;
       --monitor-out) monitor_out="$2"; shift 2 ;;
+      --monitor-profile-out) monitor_profile_out="$2"; shift 2 ;;
       --out) out="$2"; shift 2 ;;
       --help|-h) print_help; exit 0 ;;
       *) echo "Unknown run option: $1" >&2; exit 1 ;;
@@ -888,10 +1013,17 @@ run_cmd() {
     if [ -z "$monitor_out" ]; then
       monitor_out="${LOADTEST_DIR}/hostops/${scenario}-${monitor_env}-$(iso_stamp)-host.csv"
     fi
+    if [ -z "$monitor_profile_out" ]; then
+      monitor_profile_out="${monitor_out%.csv}-profile.json"
+    fi
+    local profile_args=(host profile "$monitor_env" --out "$monitor_profile_out")
     local monitor_args=(host monitor "$monitor_env" --duration "${monitor_duration_seconds}s" --interval "$monitor_interval" --out "$monitor_out")
-    if [ -n "$monitor_host" ]; then monitor_args+=(--host "$monitor_host"); fi
-    if [ -n "$monitor_key" ]; then monitor_args+=(--key "$monitor_key"); fi
-    if [ -n "$monitor_port" ]; then monitor_args+=(--port "$monitor_port"); fi
+    if [ -n "$monitor_host" ]; then profile_args+=(--host "$monitor_host"); monitor_args+=(--host "$monitor_host"); fi
+    if [ -n "$monitor_key" ]; then profile_args+=(--key "$monitor_key"); monitor_args+=(--key "$monitor_key"); fi
+    if [ -n "$monitor_port" ]; then profile_args+=(--port "$monitor_port"); monitor_args+=(--port "$monitor_port"); fi
+
+    "${BASH_SOURCE[0]}" "${profile_args[@]}"
+    echo "Host profile output: ${monitor_profile_out}"
 
     "${BASH_SOURCE[0]}" "${monitor_args[@]}" &
     monitor_pid="$!"
@@ -937,7 +1069,7 @@ run_cmd() {
     monitor_pid=""
     echo "Host telemetry: $monitor_out"
     local monitor_summary_out="${monitor_out%.csv}-summary.json"
-    "${BASH_SOURCE[0]}" host summarize "$monitor_out" --out "$monitor_summary_out" || true
+    "${BASH_SOURCE[0]}" host summarize "$monitor_out" --profile "$monitor_profile_out" --out "$monitor_summary_out" || true
   fi
   trap - EXIT INT TERM
   echo "Summary: $out"

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -14,6 +14,7 @@ Commands:
   fixtures seed <env>    Seed load-test fixtures on a remote host over SSH
   fixtures pull <env>    Pull generated fixture CSVs from a remote host
   host rate-limits <env> Show remote RATE_LIMIT_* values over SSH
+  host monitor <env>     Capture host CPU/RAM/disk/Docker telemetry over SSH
   run <scenario>         Run k6 scenario: smoke, baseline, hot-market-burst, soak
   dossier                Generate release dossier JSON from a k6 summary
   help                   Show this help
@@ -21,11 +22,13 @@ Commands:
 Run examples:
   ./loadtest/cli/loadtest check
   ./loadtest/cli/loadtest host rate-limits staging
+  ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
   ./loadtest/cli/loadtest fixtures seed staging --users 100 --moderators 5 --markets 20 --hot-markets 2 --reset
   ./loadtest/cli/loadtest fixtures pull staging
   ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
   ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
   ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 50 --duration 60s --preauth-users 100
+  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 50 --duration 60s --preauth-users 100 --monitor-env staging
   ./loadtest/cli/loadtest dossier --summary loadtest/results/smoke-20260528T120000Z-summary.json --out loadtest/dossier/runs/smoke.json
 
 Fixture defaults:
@@ -33,6 +36,9 @@ Fixture defaults:
   markets: loadtest/fixtures/markets.csv
 
 This CLI does not use a god token. k6 logs in as normal fictional users.
+
+Use --monitor-env <env> on run commands to capture host telemetry CSVs under
+loadtest/hostops/ while k6 is running.
 HELP
 }
 
@@ -69,6 +75,43 @@ require_nonnegative_integer_value() {
     echo "${label} must be a non-negative integer." >&2
     exit 1
   fi
+}
+
+duration_to_seconds() {
+  local value="$1"
+  if [ -z "$value" ]; then
+    echo "0"
+    return 0
+  fi
+
+  case "$value" in
+    *s)
+      value="${value%s}"
+      ;;
+    *m)
+      value="${value%m}"
+      require_positive_integer_value "duration minutes" "$value"
+      echo $((value * 60))
+      return 0
+      ;;
+    *h)
+      value="${value%h}"
+      require_positive_integer_value "duration hours" "$value"
+      echo $((value * 3600))
+      return 0
+      ;;
+  esac
+
+  require_positive_integer_value "duration seconds" "$value"
+  echo "$value"
+}
+
+resolve_host_defaults() {
+  local env_name="$1"
+  LOADTEST_HOST_RESOLVED_HOST="$(fixture_host_for_env "$env_name")"
+  LOADTEST_HOST_RESOLVED_KEY="${HOME}/.keys/socialpredict/${env_name}/id_ed25519"
+  LOADTEST_HOST_RESOLVED_PORT="22"
+  LOADTEST_HOST_RESOLVED_REPO_PATH="/opt/socialpredict"
 }
 
 scenario_path() {
@@ -445,15 +488,201 @@ host_rate_limits_cmd() {
   ssh -p "$port" -i "$key" "$host" "$remote_script"
 }
 
+host_monitor_help() {
+  cat <<'HELP'
+Usage: ./loadtest/cli/loadtest host monitor <env> [OPTIONS]
+
+Capture host CPU, RAM, disk, and Docker container telemetry over SSH as CSV.
+
+Defaults:
+  staging host:    root@kconfs.com
+  mo/prod host:    root@brierfoxforecast.com
+  key path:        ~/.keys/socialpredict/<env>/id_ed25519
+  SSH port:        22
+  interval:        5 seconds
+  duration:        60 seconds
+  output:          loadtest/hostops/<env>-host-monitor-<timestamp>.csv
+
+Options:
+  --host VALUE       SSH host, e.g. root@45.55.227.1 or root@kconfs.com
+  --key VALUE        SSH private key path
+  --port VALUE       SSH port; default 22
+  --duration VALUE   Capture duration, e.g. 60s, 2m, 1h
+  --interval N       Seconds between samples
+  --out VALUE        Local CSV output path
+  --help             Show this help
+
+Examples:
+  ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
+  ./loadtest/cli/loadtest host monitor staging --out loadtest/hostops/staging-50rps.csv
+HELP
+}
+
+host_monitor_cmd() {
+  case "${1:-}" in
+    --help|-h|help)
+      host_monitor_help
+      exit 0
+      ;;
+  esac
+
+  if [ "$#" -lt 1 ]; then
+    echo "host monitor requires <env>." >&2
+    host_monitor_help
+    exit 1
+  fi
+
+  local env_name="$1"
+  shift
+  resolve_host_defaults "$env_name"
+  local host="$LOADTEST_HOST_RESOLVED_HOST"
+  local key="$LOADTEST_HOST_RESOLVED_KEY"
+  local port="$LOADTEST_HOST_RESOLVED_PORT"
+  local duration="60s"
+  local interval="5"
+  local out="${LOADTEST_DIR}/hostops/${env_name}-host-monitor-$(iso_stamp).csv"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --host) host="$2"; shift 2 ;;
+      --key) key="$2"; shift 2 ;;
+      --port) port="$2"; shift 2 ;;
+      --duration) duration="$2"; shift 2 ;;
+      --interval) interval="$2"; shift 2 ;;
+      --out) out="$2"; shift 2 ;;
+      --help|-h) host_monitor_help; exit 0 ;;
+      *) echo "Unknown host monitor option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  require_command ssh
+  if [ ! -f "$key" ]; then
+    echo "Missing SSH key: $key" >&2
+    exit 1
+  fi
+
+  local duration_seconds
+  duration_seconds="$(duration_to_seconds "$duration")"
+  require_positive_integer_value "--interval" "$interval"
+  if [ "$duration_seconds" -le 0 ]; then
+    echo "--duration must be greater than zero." >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$out")"
+  echo "Capturing host telemetry from ${host} every ${interval}s for ${duration_seconds}s." >&2
+  echo "Telemetry CSV: ${out}" >&2
+
+  ssh -p "$port" -i "$key" "$host" \
+    "LOADTEST_MONITOR_DURATION_SECONDS='$duration_seconds' LOADTEST_MONITOR_INTERVAL_SECONDS='$interval' bash -s" > "$out" <<'REMOTE'
+set -euo pipefail
+
+duration="${LOADTEST_MONITOR_DURATION_SECONDS}"
+interval="${LOADTEST_MONITOR_INTERVAL_SECONDS}"
+end_at=$(( $(date +%s) + duration ))
+sample=0
+
+read_cpu() {
+  awk '/^cpu / { print $2, $3, $4, $5, $6, $7, $8 }' /proc/stat
+}
+
+docker_totals() {
+  docker stats --no-stream --format '{{.Name}}|{{.CPUPerc}}|{{.MemUsage}}' 2>/dev/null | awk -F'|' '
+    function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+    function to_mib(value, n) {
+      value = trim(value)
+      n = value
+      gsub(/[^0-9.]/, "", n)
+      if (value ~ /GiB/) return n * 1024
+      if (value ~ /MiB/) return n
+      if (value ~ /KiB/) return n / 1024
+      if (value ~ /kB/) return n / 1024
+      if (value ~ /MB/) return n
+      if (value ~ /GB/) return n * 1024
+      if (value ~ /B/) return n / 1048576
+      return n
+    }
+    {
+      name=$1
+      cpu=$2
+      mem=$3
+      sub(/%.*/, "", cpu)
+      split(mem, mem_parts, "/")
+      mem_mib=to_mib(mem_parts[1])
+      total_cpu += cpu + 0
+      total_mem += mem_mib
+      count += 1
+      if (name ~ /backend/ && name !~ /startup-writer/) backend_cpu += cpu + 0
+      if (name ~ /postgres/) postgres_cpu += cpu + 0
+      if (name ~ /traefik/) traefik_cpu += cpu + 0
+    }
+    END {
+      printf "%.2f,%.2f,%d,%.2f,%.2f,%.2f", total_cpu, total_mem, count, backend_cpu, postgres_cpu, traefik_cpu
+    }
+  '
+}
+
+echo "timestamp_utc,sample,load1,load5,load15,cpu_user_pct,cpu_system_pct,cpu_idle_pct,mem_total_mib,mem_used_mib,mem_available_mib,swap_used_mib,disk_used_pct,disk_used_mib,disk_available_mib,docker_cpu_pct_sum,docker_mem_mib_sum,container_count,backend_cpu_pct,postgres_cpu_pct,traefik_cpu_pct"
+
+while [ "$(date +%s)" -le "$end_at" ]; do
+  sample=$((sample + 1))
+  cpu_before="$(read_cpu)"
+  sleep 1
+  cpu_after="$(read_cpu)"
+
+  cpu_values="$(
+    awk -v before="$cpu_before" -v after="$cpu_after" '
+      BEGIN {
+        split(before, b, " ")
+        split(after, a, " ")
+        b_user=b[1]+b[2]; b_system=b[3]+b[6]+b[7]; b_idle=b[4]+b[5]
+        a_user=a[1]+a[2]; a_system=a[3]+a[6]+a[7]; a_idle=a[4]+a[5]
+        d_user=a_user-b_user; d_system=a_system-b_system; d_idle=a_idle-b_idle
+        total=d_user+d_system+d_idle
+        if (total <= 0) total=1
+        printf "%.2f,%.2f,%.2f", (d_user/total)*100, (d_system/total)*100, (d_idle/total)*100
+      }
+    '
+  )"
+
+  load_values="$(awk '{ printf "%s,%s,%s", $1, $2, $3 }' /proc/loadavg)"
+  mem_values="$(free -m | awk '/^Mem:/ { total=$2; used=$3; available=$7 } /^Swap:/ { swap_used=$3 } END { printf "%d,%d,%d,%d", total, used, available, swap_used }')"
+  disk_values="$(df -Pm / | awk 'NR==2 { used_pct=$5; gsub(/%/, "", used_pct); printf "%d,%d,%d", used_pct, $3, $4 }')"
+  docker_values="$(docker_totals)"
+  if [ -z "$docker_values" ]; then
+    docker_values="0.00,0.00,0,0.00,0.00,0.00"
+  fi
+
+  printf "%s,%d,%s,%s,%s,%s,%s\n" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$sample" \
+    "$load_values" \
+    "$cpu_values" \
+    "$mem_values" \
+    "$disk_values" \
+    "$docker_values"
+
+  if [ "$(date +%s)" -ge "$end_at" ]; then
+    break
+  fi
+  sleep "$interval"
+done
+REMOTE
+
+  echo "Telemetry captured: ${out}" >&2
+}
+
 host_help() {
   cat <<'HELP'
-Usage: ./loadtest/cli/loadtest host <rate-limits> <env> [OPTIONS]
+Usage: ./loadtest/cli/loadtest host <rate-limits|monitor> <env> [OPTIONS]
 
 Commands:
   rate-limits <env>  Show remote RATE_LIMIT_* values over SSH
+  monitor <env>      Capture CPU/RAM/disk/Docker telemetry CSV over SSH
 
 Examples:
   ./loadtest/cli/loadtest host rate-limits staging
+  ./loadtest/cli/loadtest host monitor staging --duration 2m --interval 5
 HELP
 }
 
@@ -462,12 +691,20 @@ host_cmd() {
   shift || true
   case "$subcommand" in
     rate-limits) host_rate_limits_cmd "$@" ;;
+    monitor) host_monitor_cmd "$@" ;;
     --help|-h|help) host_help ;;
     *) echo "Unknown host command: $subcommand" >&2; host_help; exit 1 ;;
   esac
 }
 
 run_cmd() {
+  case "${1:-}" in
+    --help|-h|help)
+      print_help
+      exit 0
+      ;;
+  esac
+
   if [ "$#" -lt 1 ]; then
     echo "Missing scenario." >&2
     print_help
@@ -489,6 +726,12 @@ run_cmd() {
   local browse_time_unit="${BROWSE_TIME_UNIT:-}"
   local rate="${RATE:-}"
   local time_unit="${TIME_UNIT:-}"
+  local monitor_env="${MONITOR_ENV:-}"
+  local monitor_host="${MONITOR_HOST:-}"
+  local monitor_key="${MONITOR_KEY:-}"
+  local monitor_port="${MONITOR_PORT:-}"
+  local monitor_interval="${MONITOR_INTERVAL:-5}"
+  local monitor_out="${MONITOR_OUT:-}"
   local out=""
 
   while [ "$#" -gt 0 ]; do
@@ -507,6 +750,12 @@ run_cmd() {
       --browse-time-unit) browse_time_unit="$2"; shift 2 ;;
       --rate) rate="$2"; shift 2 ;;
       --time-unit) time_unit="$2"; shift 2 ;;
+      --monitor-env) monitor_env="$2"; shift 2 ;;
+      --monitor-host) monitor_host="$2"; shift 2 ;;
+      --monitor-key) monitor_key="$2"; shift 2 ;;
+      --monitor-port) monitor_port="$2"; shift 2 ;;
+      --monitor-interval) monitor_interval="$2"; shift 2 ;;
+      --monitor-out) monitor_out="$2"; shift 2 ;;
       --out) out="$2"; shift 2 ;;
       --help|-h) print_help; exit 0 ;;
       *) echo "Unknown run option: $1" >&2; exit 1 ;;
@@ -529,6 +778,7 @@ run_cmd() {
   require_positive_integer_value "--bet-rate" "$bet_rate"
   require_positive_integer_value "--browse-rate" "$browse_rate"
   require_positive_integer_value "--rate" "$rate"
+  require_positive_integer_value "--monitor-interval" "$monitor_interval"
 
   mkdir -p "${LOADTEST_DIR}/results"
   if [ -z "$out" ]; then
@@ -537,6 +787,35 @@ run_cmd() {
 
   echo "Running ${scenario} against ${base_url}"
   echo "API prefix: ${api_prefix:-<none>}"
+
+  local monitor_pid=""
+  if [ -n "$monitor_env" ]; then
+    local monitor_duration_seconds
+    monitor_duration_seconds="$(duration_to_seconds "${duration:-60s}")"
+    monitor_duration_seconds=$((monitor_duration_seconds + monitor_interval + 5))
+    if [ -z "$monitor_out" ]; then
+      monitor_out="${LOADTEST_DIR}/hostops/${scenario}-${monitor_env}-$(iso_stamp)-host.csv"
+    fi
+    local monitor_args=(host monitor "$monitor_env" --duration "${monitor_duration_seconds}s" --interval "$monitor_interval" --out "$monitor_out")
+    if [ -n "$monitor_host" ]; then monitor_args+=(--host "$monitor_host"); fi
+    if [ -n "$monitor_key" ]; then monitor_args+=(--key "$monitor_key"); fi
+    if [ -n "$monitor_port" ]; then monitor_args+=(--port "$monitor_port"); fi
+
+    "${BASH_SOURCE[0]}" "${monitor_args[@]}" &
+    monitor_pid="$!"
+    echo "Host telemetry monitor PID: ${monitor_pid}"
+    echo "Host telemetry output: ${monitor_out}"
+    sleep 2
+  fi
+
+  cleanup_monitor() {
+    if [ -n "${monitor_pid:-}" ]; then
+      kill "$monitor_pid" >/dev/null 2>&1 || true
+      wait "$monitor_pid" >/dev/null 2>&1 || true
+    fi
+  }
+  trap cleanup_monitor EXIT INT TERM
+
   (
     cd "$REPO_DIR"
     BASE_URL="$base_url" \
@@ -555,6 +834,13 @@ run_cmd() {
     TIME_UNIT="$time_unit" \
     k6 run --summary-export "$out" "$script"
   )
+  if [ -n "$monitor_pid" ]; then
+    kill "$monitor_pid" >/dev/null 2>&1 || true
+    wait "$monitor_pid" >/dev/null 2>&1 || true
+    monitor_pid=""
+    echo "Host telemetry: $monitor_out"
+  fi
+  trap - EXIT INT TERM
   echo "Summary: $out"
 }
 

--- a/loadtest/dossier/host-profile-from-kv.mjs
+++ b/loadtest/dossier/host-profile-from-kv.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (!value.startsWith('--')) continue;
+    const key = value.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function numberOrString(value) {
+  if (value === '') return null;
+  if (/^-?\d+$/.test(value)) return Number.parseInt(value, 10);
+  if (/^-?\d+\.\d+$/.test(value)) return Number.parseFloat(value);
+  return value;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.input || !args.out) {
+  console.error('Usage: node loadtest/dossier/host-profile-from-kv.mjs --input FILE --out FILE');
+  process.exit(1);
+}
+
+const lines = fs.readFileSync(args.input, 'utf8').split(/\r?\n/).filter(Boolean);
+const profile = {
+  schemaVersion: '0.1.0',
+  generatedAt: new Date().toISOString(),
+  host: {},
+  docker: {},
+  containers: [],
+};
+
+for (const line of lines) {
+  if (line.startsWith('container=')) {
+    const raw = line.slice('container='.length);
+    const [name, service, nanoCpus, cpuQuota, cpuPeriod, cpusetCpus, memoryBytes, memorySwapBytes] = raw.split('|');
+    profile.containers.push({
+      name: name || null,
+      composeService: service || null,
+      nanoCpus: numberOrString(nanoCpus || ''),
+      cpuQuota: numberOrString(cpuQuota || ''),
+      cpuPeriod: numberOrString(cpuPeriod || ''),
+      cpusetCpus: cpusetCpus || null,
+      memoryBytes: numberOrString(memoryBytes || ''),
+      memorySwapBytes: numberOrString(memorySwapBytes || ''),
+      cpuLimited: Number(nanoCpus || 0) > 0 || Number(cpuQuota || 0) > 0 || Boolean(cpusetCpus),
+      memoryLimited: Number(memoryBytes || 0) > 0,
+    });
+    continue;
+  }
+
+  const index = line.indexOf('=');
+  if (index < 0) continue;
+  const key = line.slice(0, index);
+  const value = line.slice(index + 1);
+  const target = key.startsWith('docker_') ? profile.docker : profile.host;
+  const cleanKey = key.replace(/^docker_/, '');
+  target[cleanKey] = numberOrString(value);
+}
+
+profile.docker.containersWithCpuLimits = profile.containers.filter((container) => container.cpuLimited).length;
+profile.docker.containersWithMemoryLimits = profile.containers.filter((container) => container.memoryLimited).length;
+profile.docker.hasExplicitContainerCpuLimits = profile.docker.containersWithCpuLimits > 0;
+profile.docker.hasExplicitContainerMemoryLimits = profile.docker.containersWithMemoryLimits > 0;
+
+fs.mkdirSync(path.dirname(args.out), { recursive: true });
+fs.writeFileSync(args.out, `${JSON.stringify(profile, null, 2)}\n`);
+console.log(`Host profile JSON: ${args.out}`);

--- a/loadtest/dossier/metadata.example.json
+++ b/loadtest/dossier/metadata.example.json
@@ -34,6 +34,7 @@
   },
   "hostTelemetry": {
     "csv": "loadtest/hostops/<scenario>-staging-<timestamp>-host.csv",
+    "summaryJson": "loadtest/hostops/<scenario>-staging-<timestamp>-host-summary.json",
     "captureCommand": "./loadtest/cli/loadtest run <scenario> ... --monitor-env staging"
   },
   "decision": "inconclusive",

--- a/loadtest/dossier/metadata.example.json
+++ b/loadtest/dossier/metadata.example.json
@@ -42,6 +42,7 @@
   },
   "hostTelemetry": {
     "csv": "loadtest/hostops/<scenario>-staging-<timestamp>-host.csv",
+    "profileJson": "loadtest/hostops/<scenario>-staging-<timestamp>-host-profile.json",
     "summaryJson": "loadtest/hostops/<scenario>-staging-<timestamp>-host-summary.json",
     "captureCommand": "./loadtest/cli/loadtest run <scenario> ... --monitor-env staging"
   },

--- a/loadtest/dossier/metadata.example.json
+++ b/loadtest/dossier/metadata.example.json
@@ -26,6 +26,14 @@
     "generalBurst": 10,
     "cleanupInterval": "5m"
   },
+  "normalRateLimitPolicy": {
+    "profile": "secure-default",
+    "loginRatePerSecond": 0.1,
+    "loginBurst": 3,
+    "generalRatePerSecond": 1,
+    "generalBurst": 10,
+    "cleanupInterval": "5m"
+  },
   "infrastructureObservations": {
     "appCpuPeakPercent": null,
     "memoryPeakPercent": null,

--- a/loadtest/dossier/metadata.example.json
+++ b/loadtest/dossier/metadata.example.json
@@ -32,6 +32,10 @@
     "diskIoNotes": "",
     "dbConnectionNotes": ""
   },
+  "hostTelemetry": {
+    "csv": "loadtest/hostops/<scenario>-staging-<timestamp>-host.csv",
+    "captureCommand": "./loadtest/cli/loadtest run <scenario> ... --monitor-env staging"
+  },
   "decision": "inconclusive",
   "knownRisks": []
 }

--- a/loadtest/dossier/schema.example.json
+++ b/loadtest/dossier/schema.example.json
@@ -48,6 +48,10 @@
     "diskIoNotes": "",
     "dbConnectionNotes": ""
   },
+  "hostTelemetry": {
+    "csv": "loadtest/hostops/<scenario>-staging-<timestamp>-host.csv",
+    "captureCommand": "./loadtest/cli/loadtest run <scenario> ... --monitor-env staging"
+  },
   "decision": "pass | fail | inconclusive",
   "knownRisks": []
 }

--- a/loadtest/dossier/schema.example.json
+++ b/loadtest/dossier/schema.example.json
@@ -42,6 +42,20 @@
     "generalBurst": 1000,
     "cleanupInterval": "5m"
   },
+  "normalRateLimitPolicy": {
+    "profile": "secure-default",
+    "loginRatePerSecond": 0.1,
+    "loginBurst": 3,
+    "generalRatePerSecond": 1,
+    "generalBurst": 10,
+    "cleanupInterval": "5m"
+  },
+  "rateLimitEquivalents": {
+    "formula": "ceil(successful_bets_per_second / allowed_bets_per_second_per_client_identity)",
+    "measuredSuccessfulBetsPerSecond": 0,
+    "normalGeneralLimitClientIdentities": 0,
+    "oneBetPerTenSecondsClientIdentities": 0
+  },
   "infrastructureObservations": {
     "appCpuPeakPercent": null,
     "memoryPeakPercent": null,

--- a/loadtest/dossier/schema.example.json
+++ b/loadtest/dossier/schema.example.json
@@ -50,6 +50,7 @@
   },
   "hostTelemetry": {
     "csv": "loadtest/hostops/<scenario>-staging-<timestamp>-host.csv",
+    "summaryJson": "loadtest/hostops/<scenario>-staging-<timestamp>-host-summary.json",
     "captureCommand": "./loadtest/cli/loadtest run <scenario> ... --monitor-env staging"
   },
   "decision": "pass | fail | inconclusive",

--- a/loadtest/dossier/schema.example.json
+++ b/loadtest/dossier/schema.example.json
@@ -64,6 +64,7 @@
   },
   "hostTelemetry": {
     "csv": "loadtest/hostops/<scenario>-staging-<timestamp>-host.csv",
+    "profileJson": "loadtest/hostops/<scenario>-staging-<timestamp>-host-profile.json",
     "summaryJson": "loadtest/hostops/<scenario>-staging-<timestamp>-host-summary.json",
     "captureCommand": "./loadtest/cli/loadtest run <scenario> ... --monitor-env staging"
   },

--- a/loadtest/dossier/staging-capacity-2026-05-29.md
+++ b/loadtest/dossier/staging-capacity-2026-05-29.md
@@ -22,6 +22,13 @@ The current conservative capacity envelope for this specific staging Droplet is 
 - Upper observed clean hot-market write rate: about `35` bets/second.
 - Needs retest with pre-authenticated users: `50+` bets/second.
 
+May 31, 2026 update:
+
+- `50/sec` pre-authenticated hot-market run passed cleanly with `3001/3001` bets succeeded and HTTP p95 around `704ms`.
+- `75/sec` for `1m` passed functionally with `4412/4412` bets succeeded, but HTTP p95 rose to about `1.67s` and k6 dropped `89` iterations.
+- `75/sec` for `5m` was aborted under stress and is a failure/ceiling datapoint: `295` failed bets, HTTP p95 about `11.18s`, and minimum available RAM about `119 MiB`.
+- `100/sec` for `1m` was beyond the current tiny Droplet: `42.96%` HTTP failures, HTTP p95 about `21.04s`, and minimum available RAM about `82 MiB`.
+
 This dossier does not prove capacity for `10,000`, `30,000`, or `50,000` simultaneously active users. It translates those user counts into required request/write rates and proposes machine-size ranges to validate next.
 
 ## Fixture State
@@ -89,6 +96,10 @@ This means the actual machine under test behaved closer to a `1 vCPU / 1 GiB` ho
 | Hot market | `target=20/s`, `1m` | Pass | `1200/1200` | `38.77` | `63ms` | `122ms` | Clean hot-market write result. |
 | Hot market | `target=35/s`, `1m` | Pass with warning | `2101/2101` | `65.43` | `787ms` | `2.68s` | No failures, but tail latency is rising. |
 | Hot market | `target=50/s`, `1m` | Invalid for write ceiling | `2037/2081` succeeded | `71.16` | `11.04s` | `14.00s` | Login churn caused `204` login failures and `191` login rate-limit events. Retest with pre-auth is required. |
+| Hot market pre-auth | `target=50/s`, `1m` | Pass | `3001/3001` | `47.04` | `704ms` | `2.49s` | Cleanest current capacity-pass datapoint. |
+| Hot market pre-auth | `target=75/s`, `1m` | Pass with warning | `4412/4412` | `67.31` | `1.67s` | `3.86s` | No failed bets, but p95 crossed `1s` and k6 dropped `89` iterations. |
+| Hot market pre-auth | `target=75/s`, `5m` | Fail / aborted | `7619/8785` attempted | `59.62` | `11.18s` | `17.06s` | Aborted under pressure; `295` failed bets and `982` dropped iterations. |
+| Hot market pre-auth | `target=100/s`, `1m` | Fail / aborted | `1502/3297` attempted | `42.63` | `21.04s` | `30.47s` | Beyond current host capacity; `42.96%` HTTP failures. |
 
 ## Host Stats During 50/sec Contaminated Run
 
@@ -129,6 +140,58 @@ For a one-hour spread, the same volume is much easier:
 
 The risky scenario is not total daily or hourly volume. The risky scenario is a hot market where many users act inside a one-minute or sub-minute window.
 
+## Normal Rate-Limit Identity Matrix
+
+OpenPredictionMarkets staging uses intentionally high per-IP limits so a single
+Mac/k6 source can produce load:
+
+```env
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=500
+RATE_LIMIT_GENERAL_BURST=1000
+```
+
+The normal/model-office profile is conservative:
+
+```env
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+```
+
+The current runtime limiter is keyed by client identity/IP and is in-process.
+Therefore, the matrix below estimates normal-limit **client identities**, not
+guaranteed unique human users if many users share one NAT/proxy identity.
+
+Formula:
+
+```text
+required_client_identities =
+  ceil(successful_bets_per_second / allowed_bets_per_second_per_client_identity)
+```
+
+The `1.0` bet/sec row is the normal sustained general API limit midpoint/anchor:
+one client identity using the full normal sustained allowance for one betting
+request per second. Slower rows model less aggressive users.
+
+| Assumed betting rate per client identity | `50/s` pass, `45.48` successful bets/s | `75/s` 1m warning, `65.78` successful bets/s | `75/s` 5m aborted, `56.66` successful bets/s | `100/s` aborted, `22.76` successful bets/s |
+| ---: | ---: | ---: | ---: | ---: |
+| `0.10` bet/s, 1 bet every 10s | `455` identities | `658` identities | `567` identities | `228` identities |
+| `0.25` bet/s, 1 bet every 4s | `182` identities | `264` identities | `227` identities | `92` identities |
+| `0.50` bet/s, 1 bet every 2s | `91` identities | `132` identities | `114` identities | `46` identities |
+| `1.00` bet/s, normal-limit anchor | `46` identities | `66` identities | `57` identities | `23` identities |
+
+Interpretation:
+
+- The clean `50/s` run corresponds to about `46` normal-limit client identities
+  if each identity places one bet per second, or about `455` identities if each
+  identity places one bet every ten seconds.
+- The `75/s` one-minute run corresponds to about `66` normal-limit client
+  identities at one bet per second, but the host already showed warning signs:
+  p95 latency above `1s` and dropped iterations.
+- The aborted `75/s` five-minute and `100/s` one-minute runs should be treated
+  as ceiling/failure evidence, not usable capacity targets.
+
 ## Machine-Size Estimate
 
 These are planning estimates, not validated production limits.
@@ -150,13 +213,13 @@ DigitalOcean's current Basic Droplet table lists relevant reference sizes includ
 
 For the next release dossier, report the current staging result as:
 
-> On a single small DigitalOcean staging Droplet with colocated Docker Postgres, SocialPredict passed `20` hot-market bets/second cleanly and passed `35` hot-market bets/second without request failures, though p95 latency rose to about `787ms`. A `50` bets/second run exposed login-rate-limit contamination and must be rerun with pre-authenticated users before it can be used as a write-capacity datapoint.
+> On a single small DigitalOcean staging Droplet with colocated Docker Postgres, SocialPredict passed a pre-authenticated `50/sec` hot-market burst with `3001/3001` bets succeeded, `0%` HTTP failures, and HTTP p95 around `704ms`. A `75/sec` one-minute burst also had no failed bets, but p95 rose to about `1.67s` and k6 dropped iterations. Sustained `75/sec` and `100/sec` runs crossed into failure/ceiling territory.
 
 For production-style planning:
 
 - Use the current smallest staging Droplet only as a functional staging target.
 - Treat `2 vCPU / 4 GiB` as the minimum serious single-node model-office target.
-- Treat `4 vCPU / 8 GiB` plus managed Postgres as the first credible target for hot-market load beyond `35` bets/second.
+- Treat `4 vCPU / 8 GiB` plus managed Postgres as the first credible target for hot-market load beyond the current `50-65` successful bets/second stressed envelope.
 - Treat `50,000` active users with one-minute hot windows as requiring a split app/database architecture, not a single small Droplet.
 
 ## Next Engineering Steps
@@ -189,9 +252,9 @@ ssh -i ~/.keys/socialpredict/staging/id_ed25519 root@kconfs.com '
 '
 ```
 
-5. If `50/sec` passes, test `75/sec`, then `100/sec`.
-6. If p95 exceeds `1s`, dropped iterations appear, or errors exceed `1%`, stop and capture the run as the current staging ceiling.
-7. Add a repeatable host-stat sampler to the load-test CLI so the release dossier can include synchronized k6 and host metrics.
+5. Use `50/sec` as the current clean reference run for this tiny Droplet.
+6. Treat `75/sec` one-minute as a warning-zone run, not a comfortable target.
+7. Treat sustained `75/sec` and `100/sec` as current ceiling/failure evidence unless host resources are increased.
 
 ## Known Gaps
 

--- a/loadtest/dossier/staging-capacity-2026-05-29.md
+++ b/loadtest/dossier/staging-capacity-2026-05-29.md
@@ -27,7 +27,7 @@ May 31, 2026 update:
 - `50/sec` pre-authenticated hot-market run passed cleanly with `3001/3001` bets succeeded and HTTP p95 around `704ms`.
 - `75/sec` for `1m` passed functionally with `4412/4412` bets succeeded, but HTTP p95 rose to about `1.67s` and k6 dropped `89` iterations.
 - `75/sec` for `5m` was aborted under stress and is a failure/ceiling datapoint: `295` failed bets, HTTP p95 about `11.18s`, and minimum available RAM about `119 MiB`.
-- `100/sec` for `1m` was beyond the current tiny Droplet: `42.96%` HTTP failures, HTTP p95 about `21.04s`, and minimum available RAM about `82 MiB`.
+- `100/sec` for `1m` was beyond the current Basic `1 vCPU / 1 GiB` Droplet: `42.96%` HTTP failures, HTTP p95 about `21.04s`, and minimum available RAM about `82 MiB`.
 
 This dossier does not prove capacity for `10,000`, `30,000`, or `50,000` simultaneously active users. It translates those user counts into required request/write rates and proposes machine-size ranges to validate next.
 
@@ -71,20 +71,27 @@ These are intentionally permissive staging values. They should not be copied to 
 
 ## Machine Observed
 
-The user-reported target tier was the smallest DigitalOcean tier:
+The measured and DigitalOcean-reported staging tier is:
 
+- DigitalOcean Basic
 - `1 vCPU`
-- `512 MiB` RAM
-- `10 GiB` SSD
+- `1 GiB` RAM
+- `25 GiB` SSD
+- Pricing reference from the 2026-05-29 snapshot below: `$0.00893/hr`, `$6/mo`
 
-The actual runtime observations from `free -h` and Docker showed:
+Runtime host profile and Docker observations showed:
 
 - Host memory visible to Docker: about `957 MiB`
+- Docker-visible CPU: `1`
+- Docker-visible memory: about `957 MiB`
+- Root disk visible to the host: about `24,625 MiB`
 - Swap: `0B`
+- Explicit container CPU limits: none observed
+- Explicit container memory limits: none observed
 - App, database, proxy, and frontend all colocated on one host
 - Database: local Docker Postgres
 
-This means the actual machine under test behaved closer to a `1 vCPU / 1 GiB` host than a `512 MiB` host.
+This corrects the earlier draft assumption that the test target was the `512 MiB / 10 GiB` tier. The capacity results in this dossier apply to the current `1 vCPU / 1 GiB / 25 GiB` staging host. They should not be quoted as validated evidence for the smaller `512 MiB` tier.
 
 ## Test Results
 
@@ -196,16 +203,16 @@ Interpretation:
 
 These are planning estimates, not validated production limits.
 
-DigitalOcean's current Basic Droplet table lists relevant reference sizes including `512 MiB / 1 vCPU`, `4 GiB / 2 vCPUs`, `8 GiB / 4 vCPUs`, and `16 GiB / 8 vCPUs`. The table below uses those resource bands as sizing shorthand; it does not assert that Basic shared CPU is the right final production class for every tier.
+DigitalOcean's current Basic Droplet table lists relevant reference sizes including the tested `1 GiB / 1 vCPU / 25 GiB SSD` host, `4 GiB / 2 vCPUs`, `8 GiB / 4 vCPUs`, and `16 GiB / 8 vCPUs`. The table below uses those resource bands as sizing shorthand; it does not assert that Basic shared CPU is the right final production class for every tier.
 
-| Target | Traffic assumption | Estimated starting point | Why | Estimated DigitalOcean Droplet price |
-| --- | --- | --- | --- | --- |
-| `10,000` active users | Up to `10%` betting in a one-minute hot window, about `17` bets/s | `2 vCPU / 4 GiB` single node, or current node for staging only | Current staging passed `20` bets/s cleanly, but production needs memory headroom, deploy headroom, migrations, logs, and spikes. | Basic `4 GiB / 2 vCPU`: `$0.03571/hr`, `$24/mo`[^digitalocean-basic-pricing-2026-05-29] |
-| `10,000` active users | `25%` betting in one minute, about `42` bets/s | `4 vCPU / 8 GiB`, preferably with managed Postgres | This exceeds the conservative `20-35` bets/s envelope and enters the unvalidated `50/sec` range. | Basic `8 GiB / 4 vCPU`: `$0.07143/hr`, `$48/mo`[^digitalocean-basic-pricing-2026-05-29] |
-| `30,000` active users | `5-10%` betting in one minute, about `25-50` bets/s | `4 vCPU / 8 GiB` app host plus managed Postgres | The app may handle the low end, but colocated Postgres on a tiny host is the wrong production shape. | Basic app host `8 GiB / 4 vCPU`: `$0.07143/hr`, `$48/mo`; managed Postgres not included[^digitalocean-basic-pricing-2026-05-29] |
-| `30,000` active users | `25%` betting in one minute, about `125` bets/s | Multiple app nodes or `8 vCPU / 16 GiB` app tier plus managed Postgres | This is several times the validated envelope and needs horizontal app capacity and database tuning. | Basic `16 GiB / 8 vCPU`: `$0.14286/hr`, `$96/mo`; managed Postgres/load balancing not included[^digitalocean-basic-pricing-2026-05-29] |
-| `50,000` active users | `5-10%` betting in one minute, about `42-83` bets/s | `8 vCPU / 16 GiB` app tier plus managed Postgres | The low end is just beyond current clean validation; the high end requires dedicated database capacity. | Basic `16 GiB / 8 vCPU`: `$0.14286/hr`, `$96/mo`; managed Postgres not included[^digitalocean-basic-pricing-2026-05-29] |
-| `50,000` active users | `25-50%` betting in one minute, about `208-417` bets/s | Load-balanced app nodes, managed Postgres sized separately, connection pooling, observability, and possibly async/caching changes | This is not a single tiny-Droplet workload. It should be treated as a dedicated scale project. | At least multiple Basic `16 GiB / 8 vCPU` app nodes at `$96/mo` each, plus managed Postgres/load balancer costs not included[^digitalocean-basic-pricing-2026-05-29] |
+| Target | Traffic assumption | Estimated starting point | Scale vs tested host | Why | Estimated DigitalOcean Droplet price |
+| --- | --- | --- | --- | --- | --- |
+| `10,000` active users | Up to `10%` betting in a one-minute hot window, about `17` bets/s | `2 vCPU / 4 GiB` single node, or current node for staging only | `2x` vCPU, `4x` RAM, about `3.2x` disk | Current staging passed `20` bets/s cleanly, but production needs memory headroom, deploy headroom, migrations, logs, and spikes. | Basic `4 GiB / 2 vCPU`: `$0.03571/hr`, `$24/mo`[^digitalocean-basic-pricing-2026-05-29] |
+| `10,000` active users | `25%` betting in one minute, about `42` bets/s | `4 vCPU / 8 GiB`, preferably with managed Postgres | `4x` vCPU, `8x` RAM, about `6.4x` disk | This approaches the validated `50/sec` envelope, but production should not run at the edge of a colocated app/database host. | Basic `8 GiB / 4 vCPU`: `$0.07143/hr`, `$48/mo`[^digitalocean-basic-pricing-2026-05-29] |
+| `30,000` active users | `5-10%` betting in one minute, about `25-50` bets/s | `4 vCPU / 8 GiB` app host plus managed Postgres | `4x` vCPU, `8x` RAM, about `6.4x` disk for the app host | The app may handle the low end, but colocated Postgres on the tested host is the wrong production shape. | Basic app host `8 GiB / 4 vCPU`: `$0.07143/hr`, `$48/mo`; managed Postgres not included[^digitalocean-basic-pricing-2026-05-29] |
+| `30,000` active users | `25%` betting in one minute, about `125` bets/s | Multiple app nodes or `8 vCPU / 16 GiB` app tier plus managed Postgres | `8x` vCPU, `16x` RAM, about `12.8x` disk for one app host | This is several times the validated envelope and needs horizontal app capacity and database tuning. | Basic `16 GiB / 8 vCPU`: `$0.14286/hr`, `$96/mo`; managed Postgres/load balancing not included[^digitalocean-basic-pricing-2026-05-29] |
+| `50,000` active users | `5-10%` betting in one minute, about `42-83` bets/s | `8 vCPU / 16 GiB` app tier plus managed Postgres | `8x` vCPU, `16x` RAM, about `12.8x` disk for the app host | The low end is within the current warning range; the high end requires dedicated database capacity. | Basic `16 GiB / 8 vCPU`: `$0.14286/hr`, `$96/mo`; managed Postgres not included[^digitalocean-basic-pricing-2026-05-29] |
+| `50,000` active users | `25-50%` betting in one minute, about `208-417` bets/s | Load-balanced app nodes, managed Postgres sized separately, connection pooling, observability, and possibly async/caching changes | Multiple app hosts, each much larger than the tested host | This is not a single small-Droplet workload. It should be treated as a dedicated scale project. | At least multiple Basic `16 GiB / 8 vCPU` app nodes at `$96/mo` each, plus managed Postgres/load balancer costs not included[^digitalocean-basic-pricing-2026-05-29] |
 
 [^digitalocean-basic-pricing-2026-05-29]: DigitalOcean Basic Droplet pricing shown on 2026-05-29 from <https://www.digitalocean.com/pricing/droplets>: `512 MiB / 1 vCPU / 500 GiB transfer / 10 GiB SSD` at `$0.00595/hr`, `$4/mo`; `1 GiB / 1 vCPU / 1,000 GiB transfer / 25 GiB SSD` at `$0.00893/hr`, `$6/mo`; `2 GiB / 1 vCPU / 2,000 GiB transfer / 50 GiB SSD` at `$0.01786/hr`, `$12/mo`; `2 GiB / 2 vCPU / 3,000 GiB transfer / 60 GiB SSD` at `$0.02679/hr`, `$18/mo`; `4 GiB / 2 vCPU / 4,000 GiB transfer / 80 GiB SSD` at `$0.03571/hr`, `$24/mo`; `8 GiB / 4 vCPU / 5,000 GiB transfer / 160 GiB SSD` at `$0.07143/hr`, `$48/mo`; `16 GiB / 8 vCPU / 6,000 GiB transfer / 320 GiB SSD` at `$0.14286/hr`, `$96/mo`.
 
@@ -213,11 +220,11 @@ DigitalOcean's current Basic Droplet table lists relevant reference sizes includ
 
 For the next release dossier, report the current staging result as:
 
-> On a single small DigitalOcean staging Droplet with colocated Docker Postgres, SocialPredict passed a pre-authenticated `50/sec` hot-market burst with `3001/3001` bets succeeded, `0%` HTTP failures, and HTTP p95 around `704ms`. A `75/sec` one-minute burst also had no failed bets, but p95 rose to about `1.67s` and k6 dropped iterations. Sustained `75/sec` and `100/sec` runs crossed into failure/ceiling territory.
+> On a DigitalOcean Basic `1 vCPU / 1 GiB RAM / 25 GiB SSD` staging Droplet with colocated Docker Postgres, SocialPredict passed a pre-authenticated `50/sec` hot-market burst with `3001/3001` bets succeeded, `0%` HTTP failures, and HTTP p95 around `704ms`. A `75/sec` one-minute burst also had no failed bets, but p95 rose to about `1.67s` and k6 dropped iterations. Sustained `75/sec` and `100/sec` runs crossed into failure/ceiling territory.
 
 For production-style planning:
 
-- Use the current smallest staging Droplet only as a functional staging target.
+- Use the current `1 vCPU / 1 GiB` staging Droplet only as a functional staging target.
 - Treat `2 vCPU / 4 GiB` as the minimum serious single-node model-office target.
 - Treat `4 vCPU / 8 GiB` plus managed Postgres as the first credible target for hot-market load beyond the current `50-65` successful bets/second stressed envelope.
 - Treat `50,000` active users with one-minute hot windows as requiring a split app/database architecture, not a single small Droplet.
@@ -252,7 +259,7 @@ ssh -i ~/.keys/socialpredict/staging/id_ed25519 root@kconfs.com '
 '
 ```
 
-5. Use `50/sec` as the current clean reference run for this tiny Droplet.
+5. Use `50/sec` as the current clean reference run for this `1 vCPU / 1 GiB` Droplet.
 6. Treat `75/sec` one-minute as a warning-zone run, not a comfortable target.
 7. Treat sustained `75/sec` and `100/sec` as current ceiling/failure evidence unless host resources are increased.
 

--- a/loadtest/dossier/summarize-host.mjs
+++ b/loadtest/dossier/summarize-host.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (!value.startsWith('--')) continue;
+    const key = value.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function parseCSV(file) {
+  const raw = fs.readFileSync(file, 'utf8').trim();
+  if (!raw) return { header: [], rows: [] };
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+  const header = lines.shift().split(',');
+  const rows = lines.map((line) => {
+    const values = line.split(',');
+    return Object.fromEntries(header.map((key, index) => [key, values[index] ?? '']));
+  });
+  return { header, rows };
+}
+
+function numeric(row, key) {
+  const value = Number.parseFloat(row[key]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function stats(rows, key) {
+  const values = rows.map((row) => numeric(row, key)).filter((value) => value !== null);
+  if (values.length === 0) return null;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const avg = values.reduce((sum, value) => sum + value, 0) / values.length;
+  return {
+    min: round(min),
+    avg: round(avg),
+    max: round(max),
+  };
+}
+
+function minValue(rows, key) {
+  const s = stats(rows, key);
+  return s ? s.min : null;
+}
+
+function maxValue(rows, key) {
+  const s = stats(rows, key);
+  return s ? s.max : null;
+}
+
+function round(value) {
+  if (value === null || value === undefined) return null;
+  return Math.round(value * 100) / 100;
+}
+
+function printLine(label, value, unit = '') {
+  if (value === null || value === undefined) return;
+  console.log(`${label}: ${value}${unit}`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.csv) {
+  console.error('Usage: node loadtest/dossier/summarize-host.mjs --csv FILE [--out FILE]');
+  process.exit(1);
+}
+
+const { rows } = parseCSV(args.csv);
+if (rows.length === 0) {
+  console.error(`No telemetry rows found: ${args.csv}`);
+  process.exit(1);
+}
+
+const first = rows[0];
+const last = rows[rows.length - 1];
+const summary = {
+  schemaVersion: '0.1.0',
+  generatedAt: new Date().toISOString(),
+  source: {
+    csv: args.csv,
+  },
+  sampleCount: rows.length,
+  startedAt: first.timestamp_utc || null,
+  endedAt: last.timestamp_utc || null,
+  host: {
+    load1: stats(rows, 'load1'),
+    load5: stats(rows, 'load5'),
+    load15: stats(rows, 'load15'),
+    cpuUserPct: stats(rows, 'cpu_user_pct'),
+    cpuSystemPct: stats(rows, 'cpu_system_pct'),
+    cpuIdlePct: stats(rows, 'cpu_idle_pct'),
+    memTotalMiB: maxValue(rows, 'mem_total_mib'),
+    memUsedMiB: stats(rows, 'mem_used_mib'),
+    memAvailableMiB: stats(rows, 'mem_available_mib'),
+    minMemAvailableMiB: minValue(rows, 'mem_available_mib'),
+    swapUsedMiB: stats(rows, 'swap_used_mib'),
+    diskUsedPct: stats(rows, 'disk_used_pct'),
+    diskUsedMiB: stats(rows, 'disk_used_mib'),
+    diskAvailableMiB: stats(rows, 'disk_available_mib'),
+    diskReadKiBPerSec: stats(rows, 'disk_read_kib_per_sec'),
+    diskWriteKiBPerSec: stats(rows, 'disk_write_kib_per_sec'),
+    netRxKiBPerSec: stats(rows, 'net_rx_kib_per_sec'),
+    netTxKiBPerSec: stats(rows, 'net_tx_kib_per_sec'),
+  },
+  docker: {
+    cpuPctSum: stats(rows, 'docker_cpu_pct_sum'),
+    memMiBSum: stats(rows, 'docker_mem_mib_sum'),
+    containerCount: maxValue(rows, 'container_count'),
+    backendCpuPct: stats(rows, 'backend_cpu_pct'),
+    postgresCpuPct: stats(rows, 'postgres_cpu_pct'),
+    traefikCpuPct: stats(rows, 'traefik_cpu_pct'),
+  },
+};
+
+if (args.out) {
+  fs.mkdirSync(path.dirname(args.out), { recursive: true });
+  fs.writeFileSync(args.out, `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+console.log('Host telemetry summary');
+console.log(`Samples: ${summary.sampleCount}`);
+console.log(`Window: ${summary.startedAt} -> ${summary.endedAt}`);
+printLine('Max CPU user', summary.host.cpuUserPct?.max, '%');
+printLine('Max CPU system', summary.host.cpuSystemPct?.max, '%');
+printLine('Min CPU idle', summary.host.cpuIdlePct?.min, '%');
+printLine('Min RAM available', summary.host.minMemAvailableMiB, ' MiB');
+printLine('Max RAM used', summary.host.memUsedMiB?.max, ' MiB');
+printLine('Max disk used', summary.host.diskUsedPct?.max, '%');
+printLine('Max disk read', summary.host.diskReadKiBPerSec?.max, ' KiB/s');
+printLine('Max disk write', summary.host.diskWriteKiBPerSec?.max, ' KiB/s');
+printLine('Max network RX', summary.host.netRxKiBPerSec?.max, ' KiB/s');
+printLine('Max network TX', summary.host.netTxKiBPerSec?.max, ' KiB/s');
+printLine('Max Docker CPU sum', summary.docker.cpuPctSum?.max, '%');
+printLine('Max Docker RAM sum', summary.docker.memMiBSum?.max, ' MiB');
+printLine('Max backend CPU', summary.docker.backendCpuPct?.max, '%');
+printLine('Max Postgres CPU', summary.docker.postgresCpuPct?.max, '%');
+printLine('Max Traefik CPU', summary.docker.traefikCpuPct?.max, '%');
+if (args.out) console.log(`Host summary JSON: ${args.out}`);

--- a/loadtest/dossier/summarize-host.mjs
+++ b/loadtest/dossier/summarize-host.mjs
@@ -71,7 +71,7 @@ function printLine(label, value, unit = '') {
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.csv) {
-  console.error('Usage: node loadtest/dossier/summarize-host.mjs --csv FILE [--out FILE]');
+  console.error('Usage: node loadtest/dossier/summarize-host.mjs --csv FILE [--profile FILE] [--out FILE]');
   process.exit(1);
 }
 
@@ -83,11 +83,13 @@ if (rows.length === 0) {
 
 const first = rows[0];
 const last = rows[rows.length - 1];
+const profile = args.profile ? JSON.parse(fs.readFileSync(args.profile, 'utf8')) : null;
 const summary = {
   schemaVersion: '0.1.0',
   generatedAt: new Date().toISOString(),
   source: {
     csv: args.csv,
+    profile: args.profile || null,
   },
   sampleCount: rows.length,
   startedAt: first.timestamp_utc || null,
@@ -120,6 +122,7 @@ const summary = {
     postgresCpuPct: stats(rows, 'postgres_cpu_pct'),
     traefikCpuPct: stats(rows, 'traefik_cpu_pct'),
   },
+  profile,
 };
 
 if (args.out) {
@@ -145,4 +148,12 @@ printLine('Max Docker RAM sum', summary.docker.memMiBSum?.max, ' MiB');
 printLine('Max backend CPU', summary.docker.backendCpuPct?.max, '%');
 printLine('Max Postgres CPU', summary.docker.postgresCpuPct?.max, '%');
 printLine('Max Traefik CPU', summary.docker.traefikCpuPct?.max, '%');
+if (summary.profile) {
+  printLine('Host CPU count', summary.profile.host?.cpu_count);
+  printLine('Host RAM total', summary.profile.host?.mem_total_mib, ' MiB');
+  printLine('Docker CPU count', summary.profile.docker?.ncpu);
+  printLine('Docker RAM total', summary.profile.docker?.mem_total_mib, ' MiB');
+  console.log(`Explicit container CPU limits: ${summary.profile.docker?.containersWithCpuLimits ?? 0}/${summary.profile.containers?.length ?? 0}`);
+  console.log(`Explicit container memory limits: ${summary.profile.docker?.containersWithMemoryLimits ?? 0}/${summary.profile.containers?.length ?? 0}`);
+}
 if (args.out) console.log(`Host summary JSON: ${args.out}`);

--- a/loadtest/dossier/summarize.mjs
+++ b/loadtest/dossier/summarize.mjs
@@ -42,6 +42,40 @@ function percentile(summary, name, p) {
   return metric(summary, name, `p(${p})`, fallback);
 }
 
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function rateLimitEquivalentUsers(summary, metadata) {
+  const successfulBetsPerSecond = rate(summary, 'sp_bets_succeeded');
+  const normalPolicy = metadata.normalRateLimitPolicy || {
+    profile: 'secure-default',
+    loginRatePerSecond: 0.1,
+    loginBurst: 3,
+    generalRatePerSecond: 1,
+    generalBurst: 10,
+    cleanupInterval: '5m',
+  };
+  const generalRatePerSecond = Number(normalPolicy.generalRatePerSecond);
+  const oneBetPerTenSeconds = 0.1;
+
+  return {
+    note: 'Rate-limit equivalent users are client identities/IPs for the current in-process limiter. They are user-equivalent only when each user has a distinct limiter identity.',
+    formula: 'ceil(successful_bets_per_second / allowed_bets_per_second_per_client_identity)',
+    measuredSuccessfulBetsPerSecond: round(successfulBetsPerSecond),
+    normalRateLimitPolicy: normalPolicy,
+    normalGeneralLimitClientIdentities: generalRatePerSecond > 0
+      ? Math.ceil(successfulBetsPerSecond / generalRatePerSecond)
+      : null,
+    oneBetPerTenSecondsClientIdentities: Math.ceil(successfulBetsPerSecond / oneBetPerTenSeconds),
+    assumptions: {
+      normalGeneralLimitAllowedBetsPerSecondPerClientIdentity: generalRatePerSecond || null,
+      oneBetPerTenSecondsAllowedBetsPerSecondPerClientIdentity: oneBetPerTenSeconds,
+      burstIsIgnoredForSustainedHotWindowEstimate: true,
+    },
+  };
+}
+
 const args = parseArgs(process.argv.slice(2));
 if (!args.summary || !args.out) {
   console.error('Usage: node loadtest/dossier/summarize.mjs --summary FILE --out FILE [--metadata FILE] [--host-summary FILE] [--decision VALUE]');
@@ -80,6 +114,7 @@ const dossier = {
     loginRateLimited: count(summary, 'sp_login_rate_limited'),
   },
   rateLimitPolicy: metadata.rateLimitPolicy || {},
+  rateLimitEquivalents: rateLimitEquivalentUsers(summary, metadata),
   infrastructureObservations: metadata.infrastructureObservations || {},
   hostTelemetry: hostSummary ? {
     ...(metadata.hostTelemetry || {}),

--- a/loadtest/dossier/summarize.mjs
+++ b/loadtest/dossier/summarize.mjs
@@ -44,12 +44,13 @@ function percentile(summary, name, p) {
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.summary || !args.out) {
-  console.error('Usage: node loadtest/dossier/summarize.mjs --summary FILE --out FILE [--metadata FILE] [--decision VALUE]');
+  console.error('Usage: node loadtest/dossier/summarize.mjs --summary FILE --out FILE [--metadata FILE] [--host-summary FILE] [--decision VALUE]');
   process.exit(1);
 }
 
 const summary = readJSON(args.summary);
 const metadata = args.metadata ? readJSON(args.metadata) : {};
+const hostSummary = args['host-summary'] ? readJSON(args['host-summary']) : null;
 const dossier = {
   schemaVersion: '0.1.0',
   generatedAt: new Date().toISOString(),
@@ -80,11 +81,15 @@ const dossier = {
   },
   rateLimitPolicy: metadata.rateLimitPolicy || {},
   infrastructureObservations: metadata.infrastructureObservations || {},
-  hostTelemetry: metadata.hostTelemetry || {},
+  hostTelemetry: hostSummary ? {
+    ...(metadata.hostTelemetry || {}),
+    summary: hostSummary,
+  } : metadata.hostTelemetry || {},
   decision: args.decision || metadata.decision || 'inconclusive',
   knownRisks: metadata.knownRisks || [],
   source: {
     k6Summary: args.summary,
+    hostSummary: args['host-summary'] || null,
     metadata: args.metadata || null,
   },
 };

--- a/loadtest/dossier/summarize.mjs
+++ b/loadtest/dossier/summarize.mjs
@@ -80,6 +80,7 @@ const dossier = {
   },
   rateLimitPolicy: metadata.rateLimitPolicy || {},
   infrastructureObservations: metadata.infrastructureObservations || {},
+  hostTelemetry: metadata.hostTelemetry || {},
   decision: args.decision || metadata.decision || 'inconclusive',
   knownRisks: metadata.knownRisks || [],
   source: {

--- a/loadtest/hostops/README.md
+++ b/loadtest/hostops/README.md
@@ -5,6 +5,7 @@ This directory is for operator-captured observations gathered during load tests,
 - HostOps command notes.
 - `docker stats` snapshots.
 - `df -h` snapshots.
+- CSV telemetry from `./loadtest/cli/loadtest host monitor`.
 - DigitalOcean metric exports or screenshots notes.
 - Safe Postgres observation notes.
 


### PR DESCRIPTION
## Summary
- Adds HostOps wrappers for remote disk inspection and app-owned Docker cleanup.
- Adds loadtest host telemetry capture over SSH for CPU, RAM, disk, and Docker/container stats.
- Allows k6 runs to attach host telemetry via --monitor-env and links telemetry paths into dossier metadata.
- Updates loadtest and HostOps docs with the small-Droplet capacity ladder and cleanup guidance.

## Validation
- bash -n HostOps loadtest/cli/loadtest scripts/docker-commands.sh
- node --check loadtest/dossier/summarize.mjs
- jq empty loadtest/dossier/metadata.example.json loadtest/dossier/schema.example.json
- ./loadtest/cli/loadtest host monitor staging --duration 3s --interval 1 --out /tmp/socialpredict-host-monitor-smoke-2.csv
- ./HostOps host disk staging

## Notes
- A smoke run with current local fixture CSVs failed after the merge/deploy because staging fixtures are stale, with MARKET_NOT_FOUND and AUTHORIZATION_DENIED. Reseed staging before the next capacity run.