### PR TITLE
docs: refresh README for v3.2 release highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,18 +83,39 @@ Highlights:
 
 ### Admin and CMS Tools
 
-Admins have expanded operational controls for reviewing users, reviewing proposed markets, and managing public sharing metadata.
+Admins have expanded operational controls for reviewing users, reviewing proposed markets, stewarding market operations, organizing market discovery, and managing public sharing metadata.
 
 Highlights:
 
 - Admin user queue for moderator eligibility/status review
 - Market review tools with approval, rejection, review trail, and refund behavior
+- Market stewardship reassignment so admins can move operational responsibility from a suspended or unavailable moderator to another active moderator
+- Admin-managed market tags, topic navigation, market pins, and market discovery layout controls
 - CMS-managed social share title, description, image, and image-enable setting
 - Default OpenGraph/social share image support
 
 > Screenshot placeholder: admin dashboard user queue
 
+> Screenshot placeholder: admin market discovery layout / tag management
+
 > Screenshot placeholder: admin social share / CMS settings tab
+
+### Market Discovery and Governance
+
+Market discovery has moved beyond a flat market list. Admin-managed tags and market discovery layout controls now support topic navigation, pinned markets, and tag-filtered topic pages while keeping search as the primary entry point.
+
+Highlights:
+
+- Admin-managed tags shown on market creation, admin review, market lists, and market detail pages
+- `/markets` topic navigation with persistent tag/category pins
+- Tag-filtered secondary pages under `/markets/topic/:slug`
+- Pinned market cards for curated discovery
+- Infinite-scroll market lists for `/markets` and topic pages
+- Search and pagination improvements for admin market review and user/moderator queues
+
+> Screenshot placeholder: `/markets` page with topic navigation and pinned market cards
+
+> Screenshot placeholder: topic page filtered by tag/category
 
 ### Sharing and Embeddable Markets
 
@@ -109,11 +130,41 @@ Highlights:
 
 > Screenshot placeholder: market detail page with share preview or social card validation
 
+### Market Amendments, Stewardship, and Work Profits
+
+Market governance now includes clearer controls around who can operate a market after it is published and how contract-like text can be clarified.
+
+Highlights:
+
+- Immutable market titles with additive-only description amendments
+- Moderator/steward amendment proposal queues with admin pending/approved/rejected review
+- Optional admin auto-approval for market proposals and amendments
+- Suspended moderators lose market-creation/governance capabilities
+- Current stewards, not necessarily original creators, can govern and resolve assigned markets
+- Thresholded moderator work-profit payouts after successful market resolution
+- User financial reporting for moderator work profits
+
+> Screenshot placeholder: market page showing description amendments
+
+> Screenshot placeholder: admin amendment review queue
+
+### Read Models and Performance Foundations
+
+The backend now has a stronger performance boundary between transaction-time math and display/read-model data.
+
+Highlights:
+
+- Display-oriented market accounting snapshots for volume, dust, probability, participants, and chart data
+- Cached/read-model paths for system metrics, user financial metrics, market cards, leaderboards, and market widgets
+- Freshness messaging for cached display widgets
+- Pagination for market bets, positions, market leaderboards, global leaderboard, and market lists
+- Boundary tests to keep snapshots out of buy/sell/resolution transaction paths
+
 ### Load Testing and Release Dossiers
 
 The repository now includes an external load-testing harness under [`loadtest/`](./loadtest/README.md). It uses k6 from a separate load-generator machine and can seed remote staging fixtures, pull fixture CSVs, run smoke/baseline/hot-market tests, and capture host telemetry through HostOps.
 
-Current staging capacity evidence is summarized in the [staging load-test dossier](./loadtest/dossier/staging-capacity-2026-05-29.md).
+Current capacity evidence is summarized in the [staging load-test dossier](./loadtest/dossier/staging-capacity-2026-05-29.md), the [large Basic AMD experiment notebook](./loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md), and the [capacity forecast dossier](./loadtest/dossier/capacity-forecast-2026-06-02.md).
 
 Highlights:
 
@@ -124,6 +175,8 @@ Highlights:
 - Release dossier tooling for turning load-test results into reviewable evidence
 
 Example dossier: [Staging Capacity Dossier, 2026-05-29](./loadtest/dossier/staging-capacity-2026-05-29.md). Look for the most recent dossier before making deployment or sizing decisions, because capacity results depend on the exact release, host size, database topology, and rate-limit configuration under test.
+
+Latest forecast note: [Capacity Forecast Dossier, 2026-06-02](./loadtest/dossier/capacity-forecast-2026-06-02.md) records the strongest current sustained hot-market result as `250` bets/sec for `5m` on a single-node DigitalOcean Basic AMD `8 vCPU / 32 GiB RAM` host, while `300` bets/sec for `5m` is not yet a clean supported target.
 
 ## Getting Started
 
@@ -153,6 +206,7 @@ OpenPredictionMarkets deployment conventions:
 - [Load Testing Guide](/loadtest/README.md)
 - [Load Test CLI Runbook](/loadtest/cli/OPERATING.md)
 - [Current Staging Capacity Dossier](/loadtest/dossier/staging-capacity-2026-05-29.md)
+- [Capacity Forecast Dossier](/loadtest/dossier/capacity-forecast-2026-06-02.md)
 
 ### How Do Prediction Markets Work?
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Check out our staging instance at [kconfs.com](https://kconfs.com/) to see the n
 
 Our model office / production-style release target is [brierfoxforecast.com](https://brierfoxforecast.com/). This environment is intended to track published releases rather than every merge to `main`.
 
-> Screenshot placeholder: staging or model-office home page
-
 ## Feature Highlights
 
 ### Moderator Mode
@@ -125,7 +123,7 @@ Highlights:
 - Host profile capture to record the exact tested Droplet shape and Docker/container limits
 - Release dossier tooling for turning load-test results into reviewable evidence
 
-> Screenshot placeholder: load-test terminal summary or release dossier dashboard
+Example dossier: [Staging Capacity Dossier, 2026-05-29](./loadtest/dossier/staging-capacity-2026-05-29.md). Look for the most recent dossier before making deployment or sizing decisions, because capacity results depend on the exact release, host size, database topology, and rate-limit configuration under test.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,74 @@ flowchart LR
 
 ## Staging
 
-Check out our staging instance at [BrierFoxForecast](https://brierfoxforecast.com/) to see what our software looks like in action. May be down if we are testing something.
+Check out our staging instance at [kconfs.com](https://kconfs.com/) to see the newest `main` branch deployment in action. This environment may be reset, load tested, or temporarily unavailable while we test deployment and capacity changes.
+
+Our model office / production-style release target is [brierfoxforecast.com](https://brierfoxforecast.com/). This environment is intended to track published releases rather than every merge to `main`.
+
+> Screenshot placeholder: staging or model-office home page
+
+## Feature Highlights
+
+### Moderator Mode
+
+SocialPredict now supports a moderator-driven market workflow. Approved moderators can propose markets, while admins retain final publishing control. Proposed markets are not tradable until an admin approves them.
+
+Highlights:
+
+- Moderator approval/status management
+- Proposed, published, and rejected market lifecycle states
+- Proposal cost accounting and refund behavior for rejected proposals
+- Moderator profile tabs for proposed, published, and rejected markets
+- Admin review queues for proposed, approved, and rejected markets
+- Full market descriptions and custom YES/NO labels shown during review
+
+> Screenshot placeholder: moderator profile with proposed/published/rejected market tabs
+
+> Screenshot placeholder: admin market review queue showing custom labels and full description controls
+
+### Admin and CMS Tools
+
+Admins have expanded operational controls for reviewing users, reviewing proposed markets, and managing public sharing metadata.
+
+Highlights:
+
+- Admin user queue for moderator eligibility/status review
+- Market review tools with approval, rejection, review trail, and refund behavior
+- CMS-managed social share title, description, image, and image-enable setting
+- Default OpenGraph/social share image support
+
+> Screenshot placeholder: admin dashboard user queue
+
+> Screenshot placeholder: admin social share / CMS settings tab
+
+### Sharing and Embeddable Markets
+
+Market pages now have a stronger sharing foundation, including OpenGraph and Twitter card metadata for link previews. The embeddable-market feature plan is documented so individual markets can be shared and embedded more cleanly as that work continues.
+
+Highlights:
+
+- Market-aware OpenGraph metadata
+- Social share image endpoint and default image
+- Security-header updates needed for controlled embedding
+- Feature planning for iframe-friendly market embeds
+
+> Screenshot placeholder: market detail page with share preview or social card validation
+
+### Load Testing and Release Dossiers
+
+The repository now includes an external load-testing harness under [`loadtest/`](./loadtest/README.md). It uses k6 from a separate load-generator machine and can seed remote staging fixtures, pull fixture CSVs, run smoke/baseline/hot-market tests, and capture host telemetry through HostOps.
+
+Current staging capacity evidence is summarized in the [staging load-test dossier](./loadtest/dossier/staging-capacity-2026-05-29.md).
+
+Highlights:
+
+- k6 smoke, baseline, hot-market burst, and soak scenarios
+- Remote staging fixture seeding and fixture pull commands
+- Host telemetry capture for CPU, RAM, disk, network, Docker, backend, Postgres, and Traefik
+- Host profile capture to record the exact tested Droplet shape and Docker/container limits
+- Release dossier tooling for turning load-test results into reviewable evidence
+
+> Screenshot placeholder: load-test terminal summary or release dossier dashboard
 
 ## Getting Started
 
@@ -66,6 +133,7 @@ Check out our staging instance at [BrierFoxForecast](https://brierfoxforecast.co
 
 - [Info on Local Setup](/README/LOCAL_SETUP.md)
 - [Info on How Economics Can Be Customized](/README/README-CONFIG.md)
+- Development fixture helpers are available through `./SocialPredict dev-bootstrap-users` for local smoke testing.
 
 ### Deploying to the Web
 
@@ -73,6 +141,20 @@ Check out our staging instance at [BrierFoxForecast](https://brierfoxforecast.co
 - [HostOps Scaffold and Infra Boundary Notes](/README/INFRA/README-INFRA-HOSTOPS.md)
 - [Staging Deployment Guide](/README/INFRA/README-INFRA-STAGING.md)
 - [Production Deployment Guide](/README/INFRA/README-INFRA-PRODUCTION.md)
+
+OpenPredictionMarkets deployment conventions:
+
+- Merges to `main` deploy staging at [kconfs.com](https://kconfs.com/).
+- Published GitHub releases deploy the model office / production-style target at [brierfoxforecast.com](https://brierfoxforecast.com/).
+- GitHub Actions dispatch Ansible-based deploys and then verify public `/health` and `/readyz`.
+- HostOps is a local convenience wrapper for host SSH, environment discovery, disk checks, cleanup, and load-test telemetry support.
+
+### API, Operations, and Load Testing
+
+- [Canonical Backend API documentation](/backend/docs/README.md)
+- [Load Testing Guide](/loadtest/README.md)
+- [Load Test CLI Runbook](/loadtest/cli/OPERATING.md)
+- [Current Staging Capacity Dossier](/loadtest/dossier/staging-capacity-2026-05-29.md)
 
 ### How Do Prediction Markets Work?
 


### PR DESCRIPTION
## Summary

Updates `README.md` for the current `v3.2.0` release scope after the later feature work merged into `main`.

Highlights now called out in README:

- staging/model-office deployment language (`kconfs.com` vs `brierfoxforecast.com`)
- moderator mode and admin review workflows
- market stewardship and suspended-moderator governance
- market taxonomy, tags, topic pages, pinned markets, and CMS discovery layout
- market description amendments and auto-approval controls
- thresholded moderator work-profit accounting
- read-model/performance foundations, cached display widgets, and pagination
- social-share/OpenGraph CMS controls
- load-testing harness and current capacity dossiers
- API/ops/load-test documentation links

## Release Draft

The draft GitHub release was also updated:

https://github.com/openpredictionmarkets/socialpredict/releases/tag/untagged-6047b0d6d902813bdd89

Current recommendation remains `v3.2.0`, not a major bump. The release is substantial but additive: it adds product capability and normal additive migrations without intentionally breaking the public API, removing supported install paths, or requiring a new deployment topology.

## Testing

Docs-only change. No local test suite was run.
