### PR TITLE
feat: support temporary load-test HTTP installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@ DOMAIN='domain.com'
 DOMAIN_URL='domain.com'
 API_URL='domain.com'
 PUBLIC_BASE_URL='https://domain.com'
+# Public edge mode for production-style installs: https or http.
+# Use http only for temporary raw-IP load-test hosts.
+TLS_MODE=https
 
 # Public sharing and iframe policy.
 # Default backend behavior is frame-ancestors 'none' plus X-Frame-Options DENY.

--- a/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/05-runtime-rate-limit-policy.md
@@ -88,6 +88,11 @@ small-droplet-staging
   Intended for the current $6/mo 1 GiB / 1 vCPU DigitalOcean droplet.
   Values are provisional and must be verified by load-test evidence.
 
+loadtest
+  Intended for temporary raw-IP capacity-test hosts.
+  Uses permissive values so one k6 load-generator IP can stress the host before
+  the app limiter becomes the bottleneck.
+
 env-file
   Non-interactive deployment mode.
   Uses RATE_LIMIT_* values sourced from a non-secret deploy env overlay.

--- a/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/05/DESIGN.md
@@ -33,6 +33,7 @@ The install UI should prefer profiles over raw fields:
 
 - `secure-default`
 - `small-droplet-staging`
+- `loadtest`
 - `env-file`
 - `custom`
 
@@ -48,6 +49,10 @@ Non-interactive production installs can pass the profile with:
 ```
 
 or by setting `RATE_LIMIT_PROFILE` before invoking the installer.
+
+Temporary raw-IP load-test hosts can use the more permissive `loadtest` profile
+with the HTTP-only edge mode documented in
+[`FEATURES/06`](../06/06-temporary-loadtest-droplets.md).
 
 OpenPredictionMarkets Ansible uses non-secret overlays under `deploy/env/`
 instead of committing full generated host `.env` files. The overlays only carry

--- a/README/PRODUCTION-NOTES/FEATURES/06/06-temporary-loadtest-droplets.md
+++ b/README/PRODUCTION-NOTES/FEATURES/06/06-temporary-loadtest-droplets.md
@@ -1,0 +1,64 @@
+# 06 Temporary Load-Test Droplets
+
+Status: implemented baseline
+Date: 2026-05-31
+
+## Purpose
+
+SocialPredict needs a reusable way to deploy production-like temporary hosts for capacity tests without resizing or disrupting `kconfs.com` staging.
+
+The target use case is an ephemeral DigitalOcean Droplet addressed by raw public IP, tested for a few hours or days, then destroyed. These hosts should run the same packaged production topology, but with two deliberate differences:
+
+- HTTP-only public edge for IP-based testing, because Let's Encrypt requires a domain.
+- Permissive load-test rate limits so one load-generator IP can stress the app, database, proxy, and host before the app limiter becomes the bottleneck.
+
+## Non-Goals
+
+This is not a new application environment class. Do not add `-e loadtest` unless production and temporary capacity-test topology diverge materially.
+
+This feature should not add autoscaling, managed Postgres, Terraform, DigitalOcean provisioning, or GitHub workflow orchestration yet. Those can be layered on once the manual temporary host path is proven.
+
+## Operator Shape
+
+Use production environment with explicit load-test knobs:
+
+```bash
+./SocialPredict install \
+  -e production \
+  -d 45.55.227.1 \
+  -r loadtest \
+  --tls-mode http
+
+./SocialPredict up
+```
+
+Then test from a separate load generator:
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url http://45.55.227.1 \
+  --api-prefix /api \
+  --duration 5m \
+  --target-rate 250 \
+  --monitor-env loadtest
+```
+
+## Ownership Boundary
+
+`./SocialPredict install` owns app runtime configuration:
+
+- app environment remains `production`
+- public base URL scheme
+- API URL scheme
+- Traefik edge mode
+- rate-limit profile values
+
+HostOps and future Ansible wrappers may choose the target host and invoke this command, but they should not reimplement app install logic.
+
+## Safety Notes
+
+The `loadtest` rate-limit profile is not a production recommendation. It is for short-lived controlled hosts where the operator is intentionally generating high traffic from one source IP.
+
+HTTP-only mode is not for public model-office or production domains. It is for raw-IP temporary load-test hosts where TLS would add setup friction and Let's Encrypt cannot issue for the IP.
+
+Destroy temporary hosts after testing to avoid cost drift. Prefer creating new temporary Droplets over permanently increasing the disk on staging.

--- a/README/PRODUCTION-NOTES/FEATURES/06/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/06/DESIGN.md
@@ -1,0 +1,51 @@
+# Temporary Load-Test Droplets Design
+
+Status: implemented baseline
+Date: 2026-05-31
+
+## Design Position
+
+Temporary capacity-test hosts are production-like runtime deployments, not a new app environment. Keep `APP_ENV=production` so the same Docker Compose, startup-writer, Postgres, nginx, Traefik, and backend readiness paths are exercised.
+
+Add narrow install-time knobs instead of a broad `-e loadtest` mode:
+
+- `-r loadtest` for permissive single-source load-test rate limits.
+- `--tls-mode http` for raw-IP HTTP-only public edge.
+
+## Rate-Limit Profile
+
+The `loadtest` profile should be high enough that a single Mac/k6 source does not trip the app limiter before host capacity becomes visible:
+
+```env
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=100
+RATE_LIMIT_LOGIN_BURST=200
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1000
+RATE_LIMIT_GENERAL_BURST=2000
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+These values are intentionally higher than staging and much higher than model-office/production defaults.
+
+## TLS Mode
+
+Supported install TLS modes:
+
+- `https`: default production/domain mode. Writes `https://DOMAIN`, renders Traefik with HTTP-to-HTTPS redirect and Let's Encrypt.
+- `http`: temporary IP mode. Writes `http://DOMAIN_OR_IP`, renders Traefik with plain HTTP only, and skips Let's Encrypt certificate registration.
+
+The CLI name is `--tls-mode` even though `http` disables TLS, because the choice describes the public edge mode.
+
+## Compose and Proxy Boundary
+
+Do not fork the production compose file for load testing. The same `scripts/docker-compose-prod.yaml` should run in both modes.
+
+Traefik config can be generated from different templates while the nginx production template continues to route `/api`, `/health`, `/readyz`, `/ops/status`, Swagger/OpenAPI, market share shell pages, and frontend traffic.
+
+## Future Re-Entry Points
+
+Revisit this design when:
+
+- Ansible needs a `loadtest` dispatch target.
+- HostOps needs first-class temporary host provisioning.
+- Capacity tests need managed Postgres instead of colocated Docker Postgres.
+- We need DNS-backed temporary subdomains and real HTTPS for public demos.

--- a/README/PRODUCTION-NOTES/FEATURES/06/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/06/PLAN.md
@@ -1,0 +1,49 @@
+# Temporary Load-Test Droplets Plan
+
+Status: implemented baseline
+Date: 2026-05-31
+
+## 01. Planning Docs
+
+Checklist:
+
+- [x] Add feature overview.
+- [x] Add design document.
+- [x] Add implementation checklist.
+- [x] Cross-link from production-notes index.
+
+## 02. Installer Rate-Limit Profile
+
+Checklist:
+
+- [x] Add `loadtest` to supported rate-limit profiles.
+- [x] Include `loadtest` in interactive install profile choices.
+- [x] Update unknown-profile error copy.
+
+## 03. Installer TLS Mode
+
+Checklist:
+
+- [x] Add `--tls-mode https|http` to non-interactive install args.
+- [x] Keep `https` as the default.
+- [x] In `https` mode, preserve current behavior.
+- [x] In `http` mode, write `DOMAIN_URL`, `API_URL`, and `PUBLIC_BASE_URL` with `http://`.
+- [x] In `http` mode, render HTTP-only Traefik config without Let's Encrypt.
+- [x] Reject unsupported TLS modes.
+
+## 04. Documentation
+
+Checklist:
+
+- [x] Document temporary raw-IP load-test install command.
+- [x] Document that `-e production` remains correct for load-test hosts.
+- [x] Document that `--tls-mode http` is not for model-office/production domains.
+
+## 05. Verification
+
+Checklist:
+
+- [x] Run shell syntax check on changed scripts.
+- [x] Run non-interactive install smoke in a temporary directory with Docker stubbed.
+- [x] Confirm generated `.env` uses HTTP URLs for `--tls-mode http`.
+- [x] Confirm generated Traefik config has no HTTPS redirect or Let's Encrypt resolver for HTTP mode.

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -80,6 +80,7 @@ Current feature specs:
 3. **Embeddable Pages And Market Sharing** - [`FEATURES/03/03-embeddable-pages-and-market-sharing.md`](./FEATURES/03/03-embeddable-pages-and-market-sharing.md), [`FEATURES/03/DESIGN.md`](./FEATURES/03/DESIGN.md), [`FEATURES/03/PLAN.md`](./FEATURES/03/PLAN.md)
 4. **Load Testing And Release Dossier Evidence** - [`FEATURES/04/04-load-testing.md`](./FEATURES/04/04-load-testing.md), [`FEATURES/04/DESIGN.md`](./FEATURES/04/DESIGN.md), [`FEATURES/04/PLAN.md`](./FEATURES/04/PLAN.md)
 5. **Runtime Rate Limit Policy** - [`FEATURES/05/05-runtime-rate-limit-policy.md`](./FEATURES/05/05-runtime-rate-limit-policy.md), [`FEATURES/05/DESIGN.md`](./FEATURES/05/DESIGN.md), [`FEATURES/05/PLAN.md`](./FEATURES/05/PLAN.md)
+6. **Temporary Load-Test Droplets** - [`FEATURES/06/06-temporary-loadtest-droplets.md`](./FEATURES/06/06-temporary-loadtest-droplets.md), [`FEATURES/06/DESIGN.md`](./FEATURES/06/DESIGN.md), [`FEATURES/06/PLAN.md`](./FEATURES/06/PLAN.md)
 
 ## Implementation Priority
 

--- a/data/traefik/config/traefik-http.template
+++ b/data/traefik/config/traefik-http.template
@@ -1,0 +1,18 @@
+log:
+  filePath: "/logs/error.log"
+  format: json
+  level: WARN
+
+entryPoints:
+  web:
+    address: ":80"
+    asDefault: true
+
+providers:
+  docker:
+    # Temporary load-test hosts may use raw public IPs without Let's Encrypt.
+    # Path publishing for backend-owned /health, /readyz, /ops/status,
+    # /swagger/, and /openapi.yaml remains explicit in nginx.
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: socialpredict_external_network

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -45,6 +45,25 @@ Run k6 from:
 
 Do not run capacity tests from the same droplet that hosts the app and database. That would consume CPU, memory, disk, and network on the system being measured. Same-droplet runs are only useful for tiny smoke checks.
 
+### Temporary Raw-IP Hosts
+
+For short-lived DigitalOcean capacity tests, prefer creating a temporary Droplet
+instead of permanently resizing staging. Install it as a production-style host
+with load-test limits and an HTTP-only raw-IP edge:
+
+```bash
+./SocialPredict install \
+  -e production \
+  -d 45.55.227.1 \
+  -r loadtest \
+  --tls-mode http
+
+./SocialPredict up
+```
+
+Then run k6 from a separate load generator against `http://45.55.227.1`.
+Destroy the temporary Droplet after testing to avoid ongoing cost.
+
 ## Authentication Model
 
 k6 uses normal SocialPredict fake-user credentials and `POST /v0/login` for API traffic. It does not use DigitalOcean credentials and it does not use a betting god key.

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -47,6 +47,29 @@ Override those when needed with:
 --repo-path /opt/socialpredict
 ```
 
+For temporary raw-IP load-test hosts, create an arbitrary HostOps environment
+directory such as:
+
+```text
+~/.keys/socialpredict/loadtest/
+```
+
+with `hostops.env` pointing at the temporary Droplet IP. The app install on that
+host should use production topology, load-test rate limits, and HTTP-only edge:
+
+```bash
+./SocialPredict install \
+  -e production \
+  -d 45.55.227.1 \
+  -r loadtest \
+  --tls-mode http
+
+./SocialPredict up
+```
+
+Run tests against `http://45.55.227.1`, not `https://...`, unless you attach a
+real DNS name and use the default `--tls-mode https`.
+
 ## Command Sequence For Staging
 
 1. Confirm public readiness:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -191,6 +191,9 @@ apply_rate_limit_profile() {
     small-droplet-staging)
       apply_rate_limit_values "5" "20" "25" "50" "5m"
       ;;
+    loadtest)
+      apply_rate_limit_values "100" "200" "1000" "2000" "5m"
+      ;;
     env-file)
       apply_rate_limit_env_file_values
       ;;
@@ -208,7 +211,7 @@ apply_rate_limit_profile() {
       apply_rate_limit_values "${login_rate}" "${login_burst}" "${general_rate}" "${general_burst}" "${cleanup_interval}"
       ;;
     *)
-      print_error "Unknown rate-limit profile '${profile}'. Use secure-default, small-droplet-staging, env-file, or custom."
+      print_error "Unknown rate-limit profile '${profile}'. Use secure-default, small-droplet-staging, loadtest, env-file, or custom."
       exit 1
       ;;
   esac
@@ -225,21 +228,130 @@ select_rate_limit_profile() {
 
   echo "### Select Rate Limit Profile:"
   echo "1) secure-default - conservative public defaults"
-  echo "2) small-droplet-staging - initial load-test profile for 512 MiB / 1 vCPU DigitalOcean staging"
-  echo "3) env-file - use RATE_LIMIT_* values from the current shell environment"
-  echo "4) custom - enter explicit values"
+  echo "2) small-droplet-staging - initial load-test profile for small DigitalOcean staging"
+  echo "3) loadtest - permissive profile for temporary single-source k6 hosts"
+  echo "4) env-file - use RATE_LIMIT_* values from the current shell environment"
+  echo "5) custom - enter explicit values"
   read -r -p "Please enter your choice [1]: " profile_choice
 
   case "${profile_choice:-1}" in
     1) apply_rate_limit_profile "secure-default" ;;
     2) apply_rate_limit_profile "small-droplet-staging" ;;
-    3) apply_rate_limit_profile "env-file" ;;
-    4) apply_rate_limit_profile "custom" ;;
+    3) apply_rate_limit_profile "loadtest" ;;
+    4) apply_rate_limit_profile "env-file" ;;
+    5) apply_rate_limit_profile "custom" ;;
     *)
       print_error "Invalid rate-limit profile choice '${profile_choice}'."
       exit 1
       ;;
   esac
+}
+
+validate_tls_mode() {
+  local tls_mode="${1:-https}"
+  case "${tls_mode}" in
+    https|http)
+      ;;
+    *)
+      print_error "Unknown TLS mode '${tls_mode}'. Use https or http."
+      exit 1
+      ;;
+  esac
+}
+
+configure_public_urls() {
+  local domain="$1"
+  local tls_mode="${2:-https}"
+  local scheme="https"
+
+  validate_tls_mode "${tls_mode}"
+  if [ "${tls_mode}" = "http" ]; then
+    scheme="http"
+  fi
+
+  "${SED_INPLACE[@]}" "s|^DOMAIN=.*|DOMAIN='${domain}'|" "${SCRIPT_DIR}/.env"
+  "${SED_INPLACE[@]}" "s|^DOMAIN_URL=.*|DOMAIN_URL='${scheme}://${domain}'|" "${SCRIPT_DIR}/.env"
+  "${SED_INPLACE[@]}" "s|^API_URL=.*|API_URL=${scheme}://${domain}/api|" "${SCRIPT_DIR}/.env"
+  set_env_value "PUBLIC_BASE_URL" "'${scheme}://${domain}'"
+  set_env_value "TLS_MODE" "${tls_mode}"
+
+  echo "Setting DOMAIN to: ${domain}"
+  echo "Setting TLS Mode to: ${tls_mode}"
+}
+
+render_traefik_config() {
+  local email="$1"
+  local tls_mode="${2:-https}"
+  local template
+  local file="${SCRIPT_DIR}/data/traefik/config/traefik.yaml"
+
+  validate_tls_mode "${tls_mode}"
+  if [ "${tls_mode}" = "http" ]; then
+    template="${SCRIPT_DIR}/data/traefik/config/traefik-http.template"
+    envsubst < "${template}" > "${file}"
+    echo "Setting Traefik edge to HTTP-only mode"
+    return
+  fi
+
+  if [ -z "${email}" ]; then
+    print_error "TLS mode https requires an email address for Let's Encrypt."
+    exit 1
+  fi
+
+  template="${SCRIPT_DIR}/data/traefik/config/traefik.template"
+  export EMAIL="${email}"
+  envsubst < "${template}" > "${file}"
+  echo "Setting EMAIL to: ${email}"
+}
+
+select_tls_mode() {
+  local tls_mode="${TLS_MODE:-https}"
+  echo "### Select Public Edge TLS Mode:" >&2
+  echo "1) https - domain-backed HTTPS with Let's Encrypt" >&2
+  echo "2) http - raw-IP HTTP mode for temporary load-test hosts" >&2
+  read -r -p "Please enter your choice [1]: " tls_choice
+
+  case "${tls_choice:-1}" in
+    1) tls_mode="https" ;;
+    2) tls_mode="http" ;;
+    *)
+      print_error "Invalid TLS mode choice '${tls_choice}'."
+      exit 1
+      ;;
+  esac
+
+  echo "${tls_mode}"
+}
+
+print_install_help() {
+  cat <<'EOF'
+Usage: ./SocialPredict install [OPTIONS]
+
+Initialize SocialPredict.
+
+Options:
+  -e VALUE              Environment: development, localhost, production
+  -d VALUE              Public domain or raw IP for production installs
+  -m VALUE              Email for Let's Encrypt when --tls-mode https
+  -r VALUE              Rate-limit profile
+  --tls-mode VALUE      Public edge mode: https or http
+  -h, --help            Show this help
+
+Rate-limit profiles:
+  secure-default        Conservative public defaults
+  small-droplet-staging Initial staging/load-test profile
+  loadtest              Permissive single-source k6 profile for temporary hosts
+  env-file              Read RATE_LIMIT_* values from the shell environment
+  custom                Prompt for explicit values in interactive production install
+
+Temporary raw-IP load-test example:
+  ./SocialPredict install -e production -d 45.55.227.1 -r loadtest --tls-mode http
+  ./SocialPredict up
+
+Production/domain example:
+  ./SocialPredict install -e production -d example.com -m ops@example.com
+  ./SocialPredict up
+EOF
 }
 
 # Check if Docker Image exists on the system
@@ -382,27 +494,21 @@ build_production() {
     read -r -p "What domain do you wish to use for the application? " domain_answer
   done
 
-  "${SED_INPLACE[@]}" "s|^DOMAIN=.*|DOMAIN='$domain_answer'|" "${SCRIPT_DIR}/.env"
-  "${SED_INPLACE[@]}" "s|^DOMAIN_URL=.*|DOMAIN_URL='https://$domain_answer'|" "${SCRIPT_DIR}/.env"
-  "${SED_INPLACE[@]}" "s|^API_URL=.*|API_URL=https://$domain_answer/api|" "${SCRIPT_DIR}/.env"
-  set_env_value "PUBLIC_BASE_URL" "'https://$domain_answer'"
-
-  echo "Setting DOMAIN to: $domain_answer"
+  tls_mode="$(select_tls_mode)"
+  configure_public_urls "${domain_answer}" "${tls_mode}"
 
   # Update Email Address
-  read -r -p "What email address do you wish to use for the SSL Certificate? " email_answer
-  while [ -z "$email_answer" ]
-  do
-    echo "You need to specify an email address."
+  email_answer=""
+  if [ "${tls_mode}" = "https" ]; then
     read -r -p "What email address do you wish to use for the SSL Certificate? " email_answer
-  done
+    while [ -z "$email_answer" ]
+    do
+      echo "You need to specify an email address."
+      read -r -p "What email address do you wish to use for the SSL Certificate? " email_answer
+    done
+  fi
 
-  template="${SCRIPT_DIR}/data/traefik/config/traefik.template"
-  file="${SCRIPT_DIR}/data/traefik/config/traefik.yaml"
-  export EMAIL="$email_answer"
-  envsubst < "$template" > "$file"
-
-  echo "Setting EMAIL to: $email_answer"
+  render_traefik_config "${email_answer}" "${tls_mode}"
 
   select_rate_limit_profile
 
@@ -444,21 +550,11 @@ build_production_args() {
   # Update APP_ENV
   "${SED_INPLACE[@]}" "s|^APP_ENV=.*|APP_ENV=production|" "${SCRIPT_DIR}/.env"
 
-  # Change the Domain settings:
-  "${SED_INPLACE[@]}" "s|^DOMAIN=.*|DOMAIN='$1'|" "${SCRIPT_DIR}/.env"
-  "${SED_INPLACE[@]}" "s|^DOMAIN_URL=.*|DOMAIN_URL='https://$1'|" "${SCRIPT_DIR}/.env"
-  "${SED_INPLACE[@]}" "s|^API_URL=.*|API_URL=https://$1/api|" "${SCRIPT_DIR}/.env"
-  set_env_value "PUBLIC_BASE_URL" "'https://$1'"
-
-  echo "Setting DOMAIN to: $1"
+  local tls_mode="${4:-${TLS_MODE:-https}}"
+  configure_public_urls "$1" "${tls_mode}"
 
   # Update Email Address
-  template="${SCRIPT_DIR}/data/traefik/config/traefik.template"
-  file="${SCRIPT_DIR}/data/traefik/config/traefik.yaml"
-  export EMAIL="$2"
-  envsubst < "$template" > "$file"
-
-  echo "Setting EMAIL to: $2"
+  render_traefik_config "$2" "${tls_mode}"
 
   apply_rate_limit_profile "${3:-${RATE_LIMIT_PROFILE:-secure-default}}"
 
@@ -539,35 +635,88 @@ if [ "$#" -eq 0 ]; then
     esac
   done
 else
+  env=""
+  domain=""
+  email=""
   rate_limit_profile="${RATE_LIMIT_PROFILE:-secure-default}"
-  while getopts ":e:d:m:r:" opt; do
-    case $opt in
-      e)
-        if [ "$OPTARG" != "development" ] && [ "$OPTARG" != "localhost" ] && [ "$OPTARG" != "production" ]; then
+  tls_mode="${TLS_MODE:-https}"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -e)
+        if [ "$#" -lt 2 ]; then
+          print_error "Option -e requires an argument."
+          exit 1
+        fi
+        if [ "$2" != "development" ] && [ "$2" != "localhost" ] && [ "$2" != "production" ]; then
           print_error "Wrong environment selection."
           print_status "Acceptable environments: 'development', 'localhost', 'production'"
           exit 1
-        else
-          env="$OPTARG"
         fi
+        env="$2"
+        shift 2
         ;;
-      d)
-        domain="$OPTARG"
+      -d)
+        if [ "$#" -lt 2 ]; then
+          print_error "Option -d requires an argument."
+          exit 1
+        fi
+        domain="$2"
+        shift 2
         ;;
-      m)
-        email="$OPTARG"
+      -m)
+        if [ "$#" -lt 2 ]; then
+          print_error "Option -m requires an argument."
+          exit 1
+        fi
+        email="$2"
+        shift 2
         ;;
-      r)
-        rate_limit_profile="$OPTARG"
+      -r)
+        if [ "$#" -lt 2 ]; then
+          print_error "Option -r requires an argument."
+          exit 1
+        fi
+        rate_limit_profile="$2"
+        shift 2
         ;;
-      \?)
-        echo "Invalid option: -$OPTARG"
+      --tls-mode|-t)
+        if [ "$#" -lt 2 ]; then
+          print_error "Option $1 requires an argument."
+          exit 1
+        fi
+        tls_mode="$2"
+        validate_tls_mode "${tls_mode}"
+        shift 2
         ;;
-      :)
-        echo "Option -$OPTARG requires an argument."
+      --help|-h)
+        print_install_help
+        exit 0
+        ;;
+      *)
+        print_error "Invalid option: $1"
+        print_install_help
+        exit 1
         ;;
     esac
   done
+
+  if [ -z "${env}" ]; then
+    print_error "Missing required -e environment option."
+    print_install_help
+    exit 1
+  fi
+
+  if [ "$env" == "production" ]; then
+    if [ -z "${domain}" ]; then
+      print_error "Production install requires -d DOMAIN_OR_IP."
+      exit 1
+    fi
+    if [ "${tls_mode}" = "https" ] && [ -z "${email}" ]; then
+      print_error "Production HTTPS install requires -m EMAIL for Let's Encrypt."
+      exit 1
+    fi
+  fi
+
   FORCE="y"
   # Check if SocialPredict is running
   check_if_running
@@ -583,6 +732,6 @@ else
   elif [ "$env" == "localhost" ]; then
     build_local
   elif [ "$env" == "production" ]; then
-    build_production_args "$domain" "$email" "$rate_limit_profile"
+    build_production_args "$domain" "${email:-}" "$rate_limit_profile" "$tls_mode"
   fi
 fi


### PR DESCRIPTION
## Summary

Adds a minimal temporary load-test Droplet install path without creating a new application environment mode.

Implemented:
- keeps temporary capacity hosts on `APP_ENV=production`
- adds `-r loadtest` rate-limit profile for single-source k6 tests
- adds `--tls-mode https|http` install option
- keeps `https` as the default production/domain behavior
- supports raw-IP HTTP installs with `--tls-mode http`
- adds an HTTP-only Traefik template without redirect, TLS, or Let's Encrypt
- adds `FEATURES/06` production notes using the existing feature-doc format
- documents temporary raw-IP host usage in load-test docs

Example:

```bash
./SocialPredict install \
  -e production \
  -d 45.55.227.1 \
  -r loadtest \
  --tls-mode http

./SocialPredict up
```

## Why not `-e loadtest`?

This keeps load-test hosts production-like. The target host still exercises the production Docker Compose topology, startup writer, local Docker Postgres, nginx, Traefik, readiness, and backend runtime. The differences are intentionally narrow: public edge mode and rate-limit posture.

## Validation

- `bash -n scripts/install.sh`
- `bash -n SocialPredict`
- `bash -n scripts/docker-commands.sh`
- `./SocialPredict install --help`
- Stubbed non-interactive HTTP/loadtest install in a temporary repo copy:
  - confirmed `DOMAIN_URL=http://203.0.113.10`
  - confirmed `API_URL=http://203.0.113.10/api`
  - confirmed `PUBLIC_BASE_URL=http://203.0.113.10`
  - confirmed `TLS_MODE=http`
  - confirmed `RATE_LIMIT_GENERAL_RATE_PER_SECOND=1000`
  - confirmed generated Traefik config has no HTTPS redirect, cert resolver, or Let's Encrypt block
- Stubbed non-interactive HTTPS/default install in a temporary repo copy:
  - confirmed existing HTTPS URLs and secure-default rate limits
  - confirmed generated Traefik config still includes redirect, websecure, cert resolver, and Let's Encrypt email
