### PR TITLE
docs: add temporary load-test droplet smoke runbook

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -64,6 +64,9 @@ with load-test limits and an HTTP-only raw-IP edge:
 Then run k6 from a separate load generator against `http://45.55.227.1`.
 Destroy the temporary Droplet after testing to avoid ongoing cost.
 
+For the exact OpenPredictionMarkets `doctl` + GitHub secrets + Ansible workflow
+smoke sequence, see `loadtest/cli/OPERATING.md`.
+
 ## Authentication Model
 
 k6 uses normal SocialPredict fake-user credentials and `POST /v0/login` for API traffic. It does not use DigitalOcean credentials and it does not use a betting god key.

--- a/loadtest/cli/OPERATING.md
+++ b/loadtest/cli/OPERATING.md
@@ -70,6 +70,132 @@ host should use production topology, load-test rate limits, and HTTP-only edge:
 Run tests against `http://45.55.227.1`, not `https://...`, unless you attach a
 real DNS name and use the default `--tls-mode https`.
 
+## Temporary DigitalOcean Host Smoke Path
+
+This sequence documents the OpenPredictionMarkets raw-IP smoke path used for
+short-lived load-test hosts. It intentionally starts with the cheapest useful
+Droplet to prove SSH, Docker, Ansible, and HTTP deploy wiring before resizing or
+creating a larger host.
+
+1. Create a dedicated local SSH key for the temporary host:
+
+```bash
+mkdir -p ~/.keys/socialpredict/loadtest
+chmod 700 ~/.keys/socialpredict/loadtest
+ssh-keygen -t ed25519 \
+  -f ~/.keys/socialpredict/loadtest/id_ed25519 \
+  -N '' \
+  -C socialpredict-loadtest-YYYYMMDD
+```
+
+2. Import the public key into DigitalOcean:
+
+```bash
+doctl compute ssh-key import socialpredict-loadtest-YYYYMMDD \
+  --public-key-file ~/.keys/socialpredict/loadtest/id_ed25519.pub
+```
+
+3. Create a temporary Ubuntu 24.04 Droplet with Docker bootstrap cloud-init:
+
+```bash
+doctl compute droplet create socialpredict-loadtest-YYYYMMDD \
+  --region nyc3 \
+  --image ubuntu-24-04-x64 \
+  --size s-1vcpu-1gb \
+  --ssh-keys <DIGITALOCEAN_SSH_KEY_ID> \
+  --tag-names socialpredict-loadtest,socialpredict \
+  --user-data-file loadtest/hostops/cloud-init-docker-ubuntu2404.yml \
+  --wait
+```
+
+The initial `s-1vcpu-1gb` host is for smoke only. It has a 25GB disk and can be
+resized later to DigitalOcean sizes with at least a 25GB disk, such as
+`g-2vcpu-8gb`, without permanently increasing disk. Avoid disk resize unless the
+test specifically requires it because DigitalOcean disk increases are not
+reversible.
+
+4. Attach the normal HTTP/HTTPS/SSH firewall:
+
+```bash
+doctl compute firewall add-droplets <FIREWALL_ID> --droplet-ids <DROPLET_ID>
+```
+
+For OpenPredictionMarkets, the current shared firewall is `port80-access`.
+
+5. Verify SSH and Docker:
+
+```bash
+ssh -i ~/.keys/socialpredict/loadtest/id_ed25519 root@<DROPLET_IP> '
+  lsb_release -ds
+  docker --version
+  docker compose version
+  free -h
+  df -h /
+'
+```
+
+6. Point the Ansible load-test workflow at the temporary host:
+
+```bash
+gh secret set LOADTEST_HOST --repo openpredictionmarkets/ansible_playbooks --body '<DROPLET_IP>'
+gh secret set LOADTEST_PORT --repo openpredictionmarkets/ansible_playbooks --body '22'
+gh secret set LOADTEST_USER --repo openpredictionmarkets/ansible_playbooks --body 'root'
+gh secret set LOADTEST_DOMAIN_OR_IP --repo openpredictionmarkets/ansible_playbooks --body '<DROPLET_IP>'
+gh secret set LOADTEST_RATE_LIMIT_PROFILE --repo openpredictionmarkets/ansible_playbooks --body 'loadtest'
+gh secret set LOADTEST_PRIVATE_KEY --repo openpredictionmarkets/ansible_playbooks < ~/.keys/socialpredict/loadtest/id_ed25519
+```
+
+7. Run the manual Ansible workflow:
+
+```bash
+gh workflow run deploy_loadtest.yml \
+  --repo openpredictionmarkets/ansible_playbooks \
+  -f socialpredict_ref=main \
+  -f tls_mode=http \
+  -f domain_or_ip=<DROPLET_IP>
+```
+
+8. Verify the raw-IP deployment:
+
+```bash
+curl -sS http://<DROPLET_IP>/health
+curl -sS http://<DROPLET_IP>/readyz
+curl -sS http://<DROPLET_IP>/api/ops/status
+```
+
+9. Run a smoke test from the local load generator:
+
+```bash
+./loadtest/cli/loadtest fixtures seed loadtest \
+  --host root@<DROPLET_IP> \
+  --key ~/.keys/socialpredict/loadtest/id_ed25519 \
+  --repo-path /opt/socialpredict \
+  --users 100 \
+  --moderators 5 \
+  --markets 20 \
+  --hot-markets 2 \
+  --reset
+
+./loadtest/cli/loadtest fixtures pull loadtest \
+  --host root@<DROPLET_IP> \
+  --key ~/.keys/socialpredict/loadtest/id_ed25519 \
+  --remote-path /opt/socialpredict/loadtest/fixtures \
+  --local-path loadtest/fixtures
+
+./loadtest/cli/loadtest run smoke \
+  --base-url http://<DROPLET_IP> \
+  --api-prefix /api
+```
+
+10. Destroy the temporary host after testing:
+
+```bash
+doctl compute droplet delete <DROPLET_ID>
+```
+
+Clean up or rotate `LOADTEST_*` secrets after deleting the host so future manual
+workflow runs cannot accidentally target a stale IP.
+
 ## Command Sequence For Staging
 
 1. Confirm public readiness:

--- a/loadtest/hostops/.gitignore
+++ b/loadtest/hostops/.gitignore
@@ -1,3 +1,4 @@
 *
 !.gitignore
 !README.md
+!cloud-init-docker-ubuntu2404.yml

--- a/loadtest/hostops/cloud-init-docker-ubuntu2404.yml
+++ b/loadtest/hostops/cloud-init-docker-ubuntu2404.yml
@@ -1,0 +1,17 @@
+#cloud-config
+package_update: true
+package_upgrade: false
+packages:
+  - ca-certificates
+  - curl
+  - gnupg
+runcmd:
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list'
+  - apt-get update
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  - systemctl enable --now docker
+  - docker --version > /root/docker-bootstrap-complete.txt
+  - docker compose version >> /root/docker-bootstrap-complete.txt


### PR DESCRIPTION
## Summary

- document the doctl-based temporary DigitalOcean load-test host smoke path\n- add the tracked Ubuntu 24.04 cloud-init Docker bootstrap used by the runbook\n- point the top-level loadtest README at the detailed operator sequence\n\n## Verified\n- created Ubuntu 24.04 temporary load-test droplet 574624493 at 161.35.177.38
- attached the port80-access firewall\n- set LOADTEST_* secrets in openpredictionmarkets/ansible_playbooks\n- ran Deploy to Temporary Load-Test Host with Ansible against socialpredict main: https://github.com/openpredictionmarkets/ansible_playbooks/actions/runs/26786502953\n- verified http://161.35.177.38/health and /readyz\n- seeded 100 users, 5 moderators, 20 markets, 2 hot markets
- ran loadtest smoke successfully against http://161.35.177.38 with 0 failed requests