### PR TITLE
docs: add large Basic AMD load-test experiment notebook

### DIFF
--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -1010,8 +1010,10 @@ run_cmd() {
   local monitor_pid=""
   if [ -n "$monitor_env" ]; then
     local monitor_duration_seconds
+    local monitor_setup_timeout_seconds
     monitor_duration_seconds="$(duration_to_seconds "${duration:-60s}")"
-    monitor_duration_seconds=$((monitor_duration_seconds + monitor_interval + 5))
+    monitor_setup_timeout_seconds="$(duration_to_seconds "${setup_timeout:-5m}")"
+    monitor_duration_seconds=$((monitor_duration_seconds + monitor_setup_timeout_seconds + monitor_interval + 5))
     if [ -z "$monitor_out" ]; then
       monitor_out="${LOADTEST_DIR}/hostops/${scenario}-${monitor_env}-$(iso_stamp)-host.csv"
     fi

--- a/loadtest/cli/loadtest
+++ b/loadtest/cli/loadtest
@@ -31,8 +31,8 @@ Run examples:
   ./loadtest/cli/loadtest fixtures pull staging
   ./loadtest/cli/loadtest run smoke --base-url https://kconfs.com --api-prefix /api
   ./loadtest/cli/loadtest run baseline --base-url https://kconfs.com --api-prefix /api --browse-rate 1 --browse-time-unit 5s --bet-rate 1 --bet-time-unit 20s
-  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 50 --duration 60s --preauth-users 100
-  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 50 --duration 60s --preauth-users 100 --monitor-env staging
+  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 50 --duration 60s --preauth-users 100 --setup-timeout 5m
+  ./loadtest/cli/loadtest run hot-market-burst --base-url https://kconfs.com --target-rate 50 --duration 60s --preauth-users 100 --setup-timeout 5m --monitor-env staging
   ./loadtest/cli/loadtest dossier --summary loadtest/results/smoke-20260528T120000Z-summary.json --out loadtest/dossier/runs/smoke.json
 
 Fixture defaults:
@@ -935,6 +935,7 @@ run_cmd() {
   local target_rate="${TARGET_RATE:-}"
   local target_time_unit="${TARGET_TIME_UNIT:-}"
   local preauth_users="${PREAUTH_USERS:-}"
+  local setup_timeout="${SETUP_TIMEOUT:-}"
   local bet_rate="${BET_RATE:-}"
   local bet_time_unit="${BET_TIME_UNIT:-}"
   local browse_rate="${BROWSE_RATE:-}"
@@ -960,6 +961,7 @@ run_cmd() {
       --target-rate) target_rate="$2"; shift 2 ;;
       --target-time-unit) target_time_unit="$2"; shift 2 ;;
       --preauth-users) preauth_users="$2"; shift 2 ;;
+      --setup-timeout) setup_timeout="$2"; shift 2 ;;
       --bet-rate) bet_rate="$2"; shift 2 ;;
       --bet-time-unit) bet_time_unit="$2"; shift 2 ;;
       --browse-rate) browse_rate="$2"; shift 2 ;;
@@ -1052,6 +1054,7 @@ run_cmd() {
     TARGET_RATE="$target_rate" \
     TARGET_TIME_UNIT="$target_time_unit" \
     PREAUTH_USERS="$preauth_users" \
+    SETUP_TIMEOUT="$setup_timeout" \
     BET_RATE="$bet_rate" \
     BET_TIME_UNIT="$bet_time_unit" \
     BROWSE_RATE="$browse_rate" \

--- a/loadtest/dossier/capacity-forecast-2026-06-02.md
+++ b/loadtest/dossier/capacity-forecast-2026-06-02.md
@@ -347,3 +347,96 @@ The practical forecast today is:
 - `500/sec`: not currently supported.
 
 The most important next work is not buying a bigger machine. It is fixing the bet-history query path, then repeating five-minute sustained tests.
+
+## Future Snapshot Cache Plan
+
+The goal of snapshot caching is to keep expensive read-side analytics fast without making Redis responsible for financial correctness. Postgres remains authoritative for bets, balances, market state, and the financial ledger.
+
+### Snapshot Rules
+
+- Every cached snapshot should include `generatedAt`, `expiresAt`, and enough cache-key context to explain what it represents.
+- UI should show `Last updated at ...` for cached analytics.
+- If Redis is unavailable, handlers should fall back to Postgres and log the cache failure.
+- Cached snapshots should be safe to delete at any time.
+- Do not cache write-path decisions such as duplicate-bet checks, balance updates, or payout correctness.
+
+### First Snapshot Candidates
+
+| Snapshot | Refresh Strategy | Suggested Freshness | Why |
+| --- | --- | --- | --- |
+| Global leaderboard | Scheduled refresh plus manual admin refresh | `15m-1h` | Expensive aggregate; users can tolerate leaderboard staleness if timestamped. |
+| System financial metrics | Scheduled refresh plus manual admin refresh | `5m-15m` | Useful operational aggregate; exact values can be recomputed on demand. |
+| Market summary cards | TTL or scheduled refresh | `10s-60s` | Hot market cards are read often and can be slightly stale. |
+| Market bet count / position count | TTL cache | `30s-5m` | Counts help paginated UI without loading full detail rows. |
+| Public setup/config snapshot | Startup/in-process cache, optionally Redis version key | hours or release/version scoped | Config rarely changes after install; mostly avoids repeated serialization. |
+
+### Concrete Implementation Steps
+
+1. Define a cache interface inside the backend, not in handlers.
+
+Example shape:
+
+```go
+type SnapshotCache interface {
+    Get(ctx context.Context, key string, dest any) (bool, error)
+    Set(ctx context.Context, key string, value any, ttl time.Duration) error
+    Delete(ctx context.Context, key string) error
+}
+```
+
+2. Add a no-op/in-memory implementation first.
+
+This keeps local dev and tests simple and lets the service boundary stabilize before adding Redis infrastructure.
+
+3. Add Redis as an optional runtime dependency.
+
+Suggested environment shape:
+
+```env
+CACHE_BACKEND=none|redis
+REDIS_URL=redis://redis:6379/0
+CACHE_GLOBAL_LEADERBOARD_TTL=1h
+CACHE_SYSTEM_STATS_TTL=15m
+CACHE_MARKET_SUMMARY_TTL=30s
+```
+
+4. Cache global leaderboard snapshots behind the analytics boundary.
+
+The code already has `GlobalLeaderboardSnapshot`, which is the right seam. The HTTP handler should ask the analytics service for a snapshot; the analytics service can decide whether to return cached data or compute from Postgres.
+
+5. Add scheduled refresh jobs only after the cache read path works.
+
+A scheduled job can recompute snapshots every `15m` or `1h`. The endpoint can also refresh on cache miss. This avoids making every user request recompute a large leaderboard.
+
+6. Add manual admin refresh controls for expensive snapshots.
+
+Admin-only controls should be able to refresh global leaderboard and system metrics. This is useful before demos, after test resets, or after deployments.
+
+7. Add API metadata so clients know data freshness.
+
+Responses should include fields like:
+
+```json
+{
+  "generatedAt": "2026-06-03T04:00:00Z",
+  "expiresAt": "2026-06-03T05:00:00Z",
+  "source": "cache"
+}
+```
+
+8. Keep pagination as the default for detail rows.
+
+Redis snapshots should not become a way to serve huge unpaginated histories. Bets, positions, and leaderboards should still expose `limit`, `cursor` or `offset`, and explicit sorting.
+
+9. Test cache behavior in load tests.
+
+Add read-heavy scenarios that compare:
+
+- cache disabled
+- cache enabled with warm snapshots
+- cache enabled after expiry
+- Redis unavailable fallback
+
+10. Revisit invalidation only after TTL snapshots are useful.
+
+Start with TTL/scheduled snapshots. Add write-triggered invalidation later only where staleness is unacceptable and the complexity is justified.

--- a/loadtest/dossier/capacity-forecast-2026-06-02.md
+++ b/loadtest/dossier/capacity-forecast-2026-06-02.md
@@ -1,0 +1,270 @@
+# SocialPredict Capacity Forecast Dossier
+
+Date: 2026-06-02
+
+Status: draft planning dossier
+
+Related dossiers:
+
+- `loadtest/dossier/staging-capacity-2026-05-29.md`
+- `loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md`
+
+## Executive Summary
+
+SocialPredict has enough evidence to make a cautious near-term capacity forecast, but not enough evidence yet to claim sustained large-scale hot-market throughput.
+
+Current evidence supports three practical conclusions:
+
+- The current small staging shape, DigitalOcean Basic `1 vCPU / 1 GiB RAM`, is useful for functional staging and light model-office traffic, not for large hot-market events.
+- A larger DigitalOcean Basic AMD shared-CPU `8 vCPU / 32 GiB RAM` single-node host produced clean one-minute hot-market bursts through about `300` bets/sec, but `350-400` bets/sec degraded and no sustained five-minute claim is valid yet.
+- Sustained hot-market capacity is currently limited more by Postgres/write-path behavior than by RAM. The leading finding is a missing composite bet-history index for the placement-time `market_id + username` lookup.
+
+The user-capacity forecast depends on how many users act inside a short event window. If `50,000` registered users produce only routine traffic, the system is likely fine at modest machine sizes. If `25-50%` of those users place bets inside the same one-minute hot window, the workload becomes a database scaling problem.
+
+Recommended next decision:
+
+- Treat `300` bets/sec for `1m` on the `8 vCPU / 32 GiB` Basic AMD host as the best current burst datapoint.
+- Do not claim `300` bets/sec sustained for `5m`.
+- Add the missing bet-history indexes through migrations, then rerun five-minute confirmation tests.
+- For a serious `50,000` user target, plan around split app/database architecture rather than a colocated single-Droplet topology.
+
+## Evidence Base
+
+### Staging Host, 2026-05-29
+
+Host shape:
+
+- DigitalOcean Basic
+- `1 vCPU`
+- `1 GiB RAM`
+- `25 GiB SSD`
+- App, Traefik, nginx, frontend, backend, and Postgres colocated in Docker
+- Approximate observed price: `$0.00893/hr`, `$6/mo`
+
+Best supported result:
+
+- `50` pre-authenticated hot-market bets/sec for `1m`
+- `3001/3001` bets succeeded
+- `0%` HTTP failures
+- HTTP p95 around `704ms`
+
+Ceiling evidence:
+
+- `75` bets/sec for `1m` passed functionally but p95 rose above `1s` and k6 dropped iterations.
+- `75` bets/sec for `5m` degraded/fell over under stress.
+- `100` bets/sec for `1m` was beyond this host.
+
+Interpretation:
+
+- This is a staging/model-office class machine, not a large-event machine.
+- Safe hot-market planning target on this host should be materially below `75` bets/sec.
+
+### Large Basic AMD Host, 2026-06-02
+
+Host shape:
+
+- DigitalOcean Basic AMD shared CPU
+- Size slug: `s-8vcpu-32gb-amd`
+- `8 vCPU`
+- `32 GiB RAM`
+- CPU/RAM-only resize; root disk remained about `25 GiB`
+- App, Traefik, nginx, frontend, backend, and Postgres colocated in Docker
+- Approximate observed price from `doctl`: `$0.250000/hr`, `$168/mo`
+- Approximate 48-hour experiment cost: `$12.00`
+
+One-minute burst evidence:
+
+| Target | Result | Notes |
+| ---: | --- | --- |
+| `100` bets/sec | clean pass | p95 `39.15ms`; no failures |
+| `200` bets/sec | clean pass | p95 `40.76ms`; no failures |
+| `300` bets/sec | clean pass | p95 `72.65ms`; no failures; CPU pressure visible |
+| `350` bets/sec | degraded | dropped iterations; p95 `1.3s`; CPU saturation |
+| `400` bets/sec | degraded | dropped iterations; p95 `2.3s`; CPU saturation |
+
+Sustained five-minute evidence:
+
+- `300` bets/sec for `5m` degraded.
+- `200` bets/sec for `5m` degraded.
+- `100` bets/sec for `5m` later produced timeout failures after cumulative bet history grew.
+
+Important diagnostic:
+
+- After cumulative tests, the `bets` table had about `258,785` rows concentrated across `10` hot markets.
+- The placement path checks whether a user has already bet in a market using `WHERE market_id = ? AND username = ?`.
+- The observed indexes did not include a composite `(market_id, username)` index.
+- Postgres CPU saturated during degraded sustained runs while RAM remained plentiful.
+
+Interpretation:
+
+- The larger host showed strong burst capacity.
+- Sustained capacity cannot be responsibly forecast until the bet-history indexing issue is fixed and retested.
+
+## Rate-Limit Model
+
+Normal/model-office rate limits are intentionally conservative:
+
+```env
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+Load-test/staging rate limits are intentionally permissive for single-source k6 testing:
+
+```env
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=100
+RATE_LIMIT_LOGIN_BURST=200
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1000
+RATE_LIMIT_GENERAL_BURST=2000
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+The normal runtime limiter is currently best interpreted as a per-client-identity limiter, effectively per IP/client identity in practical external traffic. Therefore:
+
+- One normal client identity can sustain about `1` general API action/sec.
+- A single NAT, proxy, school, office, VPN, or bot source may become capped even if many human users sit behind it.
+- Aggregate platform throughput can exceed `1` request/sec if traffic comes from many client identities.
+
+## User Forecast Formula
+
+For one hot-market event window:
+
+```text
+bets_per_second = active_bettors_in_window / window_seconds
+active_bettors_in_window = platform_users * fraction_betting_in_window
+```
+
+For active-user equivalents at a known bet rate:
+
+```text
+active_bettors = bets_per_second * seconds_between_bets_per_user
+```
+
+For client-identity requirements under normal rate limits:
+
+```text
+required_client_identities = ceil(bets_per_second / 1)
+```
+
+This assumes one bet request uses the full `1` general API action/sec sustained allowance for that client identity. Real page behavior can include additional reads, so this is a lower-bound identity estimate.
+
+## User Forecast Table
+
+This table translates user-event scenarios into required hot-market bet rates.
+
+| Platform users | Fraction betting in `1m` | Active bettors in window | Required bets/sec |
+| ---: | ---: | ---: | ---: |
+| `10,000` | `5%` | `500` | `8.3` |
+| `10,000` | `10%` | `1,000` | `16.7` |
+| `10,000` | `25%` | `2,500` | `41.7` |
+| `10,000` | `50%` | `5,000` | `83.3` |
+| `30,000` | `5%` | `1,500` | `25.0` |
+| `30,000` | `10%` | `3,000` | `50.0` |
+| `30,000` | `25%` | `7,500` | `125.0` |
+| `30,000` | `50%` | `15,000` | `250.0` |
+| `50,000` | `5%` | `2,500` | `41.7` |
+| `50,000` | `10%` | `5,000` | `83.3` |
+| `50,000` | `25%` | `12,500` | `208.3` |
+| `50,000` | `50%` | `25,000` | `416.7` |
+
+Interpretation against current evidence:
+
+- `10,000` users with `25%` betting in one minute requires about `42` bets/sec. This fits within staging's observed `50/sec` burst evidence, but staging is still too small for production comfort.
+- `30,000` users with `25%` betting in one minute requires about `125` bets/sec. This is plausible on the larger host as a one-minute burst, but sustained proof is still missing.
+- `50,000` users with `25%` betting in one minute requires about `208` bets/sec. This is within the larger host's one-minute clean evidence, but not yet within sustained proof.
+- `50,000` users with `50%` betting in one minute requires about `417` bets/sec. This exceeded the larger host's clean envelope in one-minute tests.
+
+## Normal Rate-Limit Identity Matrix
+
+Under the normal `1` general API action/sec per client identity policy, the minimum number of distinct client identities is numerically similar to required bets/sec. Real clients may need more headroom because browsing, market detail refreshes, portfolio reads, and other API actions share the same general limit.
+
+| Required bets/sec | Minimum client identities at `1` action/sec | Client identities if each places `1` bet every `10s` | User interpretation |
+| ---: | ---: | ---: | --- |
+| `50` | `50` | `500` | Roughly `30,000` users with `10%` betting in `1m`, or `10,000` with `30%` in `1m`. |
+| `100` | `100` | `1,000` | A moderate hot-window event; above small staging comfort. |
+| `200` | `200` | `2,000` | Roughly `50,000` users with `24%` betting in `1m`; plausible burst target on larger host, not yet sustained. |
+| `300` | `300` | `3,000` | Current best one-minute large-host burst datapoint; needs indexing and sustained retest. |
+| `400` | `400` | `4,000` | Degraded on the large Basic AMD host; do not claim yet. |
+| `500` | `500` | `5,000` | Ambitious target; not supported by current evidence. |
+
+## Cost And Machine Recommendation
+
+Observed/tested costs:
+
+| Host shape | Observed role | Approximate price | Evidence-supported use |
+| --- | --- | ---: | --- |
+| Basic `1 vCPU / 1 GiB / 25 GiB` | staging/model-office floor | `$0.00893/hr`, `$6/mo` | Functional staging and light traffic; clean `50/sec` burst, not large hot events. |
+| Basic AMD `8 vCPU / 32 GiB / 25 GiB root disk observed` | temporary load-test host | `$0.250000/hr`, `$168/mo` | Clean `300/sec` one-minute burst; sustained proof blocked by schema/index issue. |
+
+Recommendation by target:
+
+| Target | Recommendation | Rationale |
+| --- | --- | --- |
+| Functional staging | Keep current small staging shape. | Cheapest useful deploy validation target. |
+| Model office with modest public usage | Use at least `2 vCPU / 4 GiB` or `4 vCPU / 8 GiB`, ideally with headroom for deploys/logs. | The `1 GiB` host works but is memory-tight under stress. |
+| `10,000` users with normal traffic | `4 vCPU / 8 GiB` single node may be enough for early validation; test before launch. | One-minute `25%` event requires about `42/sec`, below current burst evidence. |
+| `30,000` users with hot events | Larger app host plus serious Postgres tuning; consider separating DB. | `25%` event requires `125/sec`, which should not rely on a tiny colocated DB. |
+| `50,000` users with `25%` one-minute hot participation | Larger app tier plus managed or separately tuned Postgres. | Requires about `208/sec`; current burst evidence says plausible, sustained evidence does not. |
+| `50,000` users with `50%` one-minute hot participation | Treat as a scale project, not a single-Droplet deployment. | Requires about `417/sec`; current large-host test degraded by `350-400/sec`. |
+
+## Recommendations
+
+### Product/Launch Recommendation
+
+Use the current evidence to say:
+
+> SocialPredict has demonstrated external hot-market burst capacity up to `300` bets/sec for one minute on a single DigitalOcean Basic AMD `8 vCPU / 32 GiB RAM` host, but sustained large-event capacity is not yet validated. The next release should not claim `500` bets/sec or `50,000`-user hot-window capacity until the bet-history indexing issue is fixed and retested.
+
+### Engineering Recommendation
+
+Prioritize the database write-path fix:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_bets_market_id_username ON bets (market_id, username);
+```
+
+Then consider:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_bets_market_id_placed_at_id ON bets (market_id, placed_at, id);
+```
+
+These must be implemented through SocialPredict's timestamped migration system and tested with the existing API/load-test tooling.
+
+### Testing Recommendation
+
+After the index migration:
+
+1. Create a fresh temporary load-test Droplet.
+2. Deploy with the load-test workflow.
+3. Seed `10000` users, `100` moderators, `1000` markets, and `10` hot markets.
+4. Verify local fixture IDs match server market IDs.
+5. Run `300/sec for 5m`.
+6. If clean, run `350/sec for 5m`.
+7. Only attempt `400/sec` or `500/sec` after `350/sec for 5m` is clean.
+
+### Architecture Recommendation
+
+For serious `30,000-50,000` user planning, move the thinking away from one all-in-one Docker host:
+
+- Keep app containers horizontally scalable.
+- Separate Postgres from the app host or use managed Postgres.
+- Add connection pooling if DB connection pressure appears.
+- Keep external load tests, not only internal container tests.
+- Add fixture integrity checks to the load-test CLI.
+- Preserve raw host telemetry CSVs and k6 summaries for cited runs, but do not commit raw summaries containing bearer tokens.
+
+## Current Planning Position
+
+The practical forecast today is:
+
+- `50/sec`: proven on small staging for `1m`; safe target for small/model-office traffic with headroom on larger hosts.
+- `100-200/sec`: likely feasible as event bursts on the larger host, but sustained proof should wait for index retest.
+- `300/sec`: proven as a one-minute burst on the larger host; not yet proven sustained.
+- `400/sec`: degraded on the larger host; not currently supported.
+- `500/sec`: not currently supported.
+
+The most important next work is not buying a bigger machine. It is fixing the bet-history query path, then repeating five-minute sustained tests.

--- a/loadtest/dossier/capacity-forecast-2026-06-02.md
+++ b/loadtest/dossier/capacity-forecast-2026-06-02.md
@@ -247,6 +247,36 @@ CREATE INDEX CONCURRENTLY idx_bets_market_id_placed_at_id ON bets (market_id, pl
 
 These must be implemented through SocialPredict's timestamped migration system and tested with the existing API/load-test tooling.
 
+### Future Optimization Recommendation
+
+After the first index migration, optimize in this order:
+
+1. Keep tuned persistence logic behind repository/domain-service boundaries.
+
+The current code already has GORM repositories for market and user persistence. That is the right boundary for custom SQL or GORM `Select(...)` projections. Handlers should not grow direct SQL.
+
+2. Replace full-history/full-row reads with narrower query shapes where behavior allows.
+
+High-traffic paths such as market bet history, market volume, probability projection, and market positions currently have paths that load market-scoped bet histories into Go. Future repository methods can use narrower projections or explicit SQL for common reads while preserving domain outputs.
+
+3. Push simple aggregates to Postgres.
+
+For example, market volume can eventually be backed by:
+
+```sql
+SELECT COALESCE(SUM(amount), 0) FROM bets WHERE market_id = $1;
+```
+
+That avoids transferring all bet rows only to sum them in Go.
+
+4. Consider summary state only after indexes and query-shape changes are measured.
+
+If hot-market tests still saturate Postgres CPU, introduce transactionally maintained summaries for current probability, market volume, bet counts, and per-user market positions. This is a larger design change because it moves selected values from computed-on-read to updated-on-write.
+
+5. Keep probability/game-engine changes explicit.
+
+If probability updates need to stop replaying full bet history on hot paths, that should be designed at the game-engine boundary: ledger replay for audit/debug paths, incremental state for hot writes, and optional reconciliation checks. It should not become an ad hoc persistence shortcut.
+
 ### Testing Recommendation
 
 After the index migration:

--- a/loadtest/dossier/capacity-forecast-2026-06-02.md
+++ b/loadtest/dossier/capacity-forecast-2026-06-02.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-02
 
-Status: draft planning dossier
+Status: draft planning dossier; June 3 fresh-state sustained test added
 
 Related dossiers:
 
@@ -16,15 +16,17 @@ SocialPredict has enough evidence to make a cautious near-term capacity forecast
 Current evidence supports three practical conclusions:
 
 - The current small staging shape, DigitalOcean Basic `1 vCPU / 1 GiB RAM`, is useful for functional staging and light model-office traffic, not for large hot-market events.
-- A larger DigitalOcean Basic AMD shared-CPU `8 vCPU / 32 GiB RAM` single-node host produced clean one-minute hot-market bursts through about `300` bets/sec, but `350-400` bets/sec degraded and no sustained five-minute claim is valid yet.
-- Sustained hot-market capacity is currently limited more by Postgres/write-path behavior than by RAM. The leading finding is a missing composite bet-history index for the placement-time `market_id + username` lookup.
+- A larger DigitalOcean Basic AMD shared-CPU `8 vCPU / 32 GiB RAM` single-node host produced clean one-minute hot-market bursts through about `300` bets/sec, and a clean five-minute sustained run at `250` bets/sec.
+- A June 3 repeat run started from zero fixture bets and still failed the strict clean-run standard at `300` bets/sec, with Postgres CPU peaking at `568%` and host CPU idle falling to `0.12%`.
+- Sustained hot-market capacity is currently limited more by Postgres/write-path CPU behavior than by RAM. The leading software finding remains the missing composite bet-history index for the placement-time `market_id + username` lookup.
 
 The user-capacity forecast depends on how many users act inside a short event window. If `50,000` registered users produce only routine traffic, the system is likely fine at modest machine sizes. If `25-50%` of those users place bets inside the same one-minute hot window, the workload becomes a database scaling problem.
 
 Recommended next decision:
 
 - Treat `300` bets/sec for `1m` on the `8 vCPU / 32 GiB` Basic AMD host as the best current burst datapoint.
-- Do not claim `300` bets/sec sustained for `5m`.
+- Treat `250` bets/sec for `5m` on the same host as the best current clean sustained datapoint.
+- Treat `300` bets/sec for `5m` as not cleanly supported on the current single-node shape and current write path.
 - Add the missing bet-history indexes through migrations, then rerun five-minute confirmation tests.
 - For a serious `50,000` user target, plan around split app/database architecture rather than a colocated single-Droplet topology.
 
@@ -87,6 +89,8 @@ Sustained five-minute evidence:
 - `300` bets/sec for `5m` degraded.
 - `200` bets/sec for `5m` degraded.
 - `100` bets/sec for `5m` later produced timeout failures after cumulative bet history grew.
+- A June 3 repeat at `300` bets/sec began from a verified zero-bet fixture state on a fresh temporary host and still produced `288` failed bets, `563` dropped iterations, host idle CPU as low as `0.12%`, and Postgres CPU as high as `568.27%`.
+- A June 3 fresh-state `250` bets/sec run passed for the full `5m`: `75001` successful bets, `0` failed bets, `0` dropped iterations, HTTP p95 `153.72ms`, Postgres CPU up to `407.78%`, and host idle CPU as low as `0.86%`.
 
 Important diagnostic:
 
@@ -98,7 +102,10 @@ Important diagnostic:
 Interpretation:
 
 - The larger host showed strong burst capacity.
-- Sustained capacity cannot be responsibly forecast until the bet-history indexing issue is fixed and retested.
+- Sustained `250/sec` capacity is cleanly supported by the June 3 fresh-state run on this single-node shared-CPU shape.
+- Sustained `300/sec` capacity is not cleanly supported on this single-node shared-CPU shape.
+- Sustained capacity cannot be responsibly forecast upward until the bet-history indexing issue is fixed and retested.
+- Because the fresh-state repeat saturated CPU while leaving more than `31 GiB` RAM available, a CPU-optimized or dedicated-CPU Droplet is a more relevant next hardware experiment than a RAM-optimized Droplet.
 
 ## Rate-Limit Model
 
@@ -197,7 +204,7 @@ Observed/tested costs:
 | Host shape | Observed role | Approximate price | Evidence-supported use |
 | --- | --- | ---: | --- |
 | Basic `1 vCPU / 1 GiB / 25 GiB` | staging/model-office floor | `$0.00893/hr`, `$6/mo` | Functional staging and light traffic; clean `50/sec` burst, not large hot events. |
-| Basic AMD `8 vCPU / 32 GiB / 25 GiB root disk observed` | temporary load-test host | `$0.250000/hr`, `$168/mo` | Clean `300/sec` one-minute burst; sustained proof blocked by schema/index issue. |
+| Basic AMD `8 vCPU / 32 GiB / 25 GiB root disk observed` | temporary load-test host | `$0.250000/hr`, `$168/mo` | Clean `300/sec` one-minute burst; clean `250/sec` five-minute sustained run; fresh-state `300/sec` five-minute repeat failed strict clean criteria under Postgres CPU saturation. |
 
 Recommendation by target:
 
@@ -209,6 +216,12 @@ Recommendation by target:
 | `30,000` users with hot events | Larger app host plus serious Postgres tuning; consider separating DB. | `25%` event requires `125/sec`, which should not rely on a tiny colocated DB. |
 | `50,000` users with `25%` one-minute hot participation | Larger app tier plus managed or separately tuned Postgres. | Requires about `208/sec`; current burst evidence says plausible, sustained evidence does not. |
 | `50,000` users with `50%` one-minute hot participation | Treat as a scale project, not a single-Droplet deployment. | Requires about `417/sec`; current large-host test degraded by `350-400/sec`. |
+
+Hardware interpretation:
+
+- The June 3 repeat indicates CPU, not RAM, is the binding resource for concentrated hot-market writes.
+- A CPU-optimized or dedicated-CPU Droplet is therefore the better next hardware comparison than a RAM-optimized Droplet.
+- Bigger hardware should not replace the schema work. The bet-placement write path still needs index/migration hardening before using larger-host results as production guidance.
 
 ## Recommendations
 
@@ -262,8 +275,9 @@ For serious `30,000-50,000` user planning, move the thinking away from one all-i
 The practical forecast today is:
 
 - `50/sec`: proven on small staging for `1m`; safe target for small/model-office traffic with headroom on larger hosts.
-- `100-200/sec`: likely feasible as event bursts on the larger host, but sustained proof should wait for index retest.
-- `300/sec`: proven as a one-minute burst on the larger host; not yet proven sustained.
+- `100-200/sec`: likely feasible as sustained hot-market traffic on the larger host, but still should be retested after index work.
+- `250/sec`: proven as a clean five-minute sustained hot-market run on the larger host.
+- `300/sec`: proven as a one-minute burst on the larger host; fresh-state five-minute repeat failed strict clean criteria.
 - `400/sec`: degraded on the larger host; not currently supported.
 - `500/sec`: not currently supported.
 

--- a/loadtest/dossier/capacity-forecast-2026-06-02.md
+++ b/loadtest/dossier/capacity-forecast-2026-06-02.md
@@ -277,6 +277,41 @@ If hot-market tests still saturate Postgres CPU, introduce transactionally maint
 
 If probability updates need to stop replaying full bet history on hot paths, that should be designed at the game-engine boundary: ledger replay for audit/debug paths, incremental state for hot writes, and optional reconciliation checks. It should not become an ad hoc persistence shortcut.
 
+6. Add Redis or another cache only for selected read snapshots.
+
+Redis can help with expensive read-side aggregates, but it should not become the source of truth for bets, balances, or duplicate-bet enforcement. Good initial cache candidates are:
+
+| Candidate | Likelihood | Notes |
+| --- | --- | --- |
+| Global leaderboard snapshot | High | The analytics service already has a snapshot seam suitable for caching. |
+| System financial metrics | Medium-High | Short-TTL diagnostic aggregate snapshots can avoid repeated full recomputation. |
+| Market summary cards | Medium | Cache probability/volume/bet-count summaries after those contracts are explicit. |
+| Market bet/position counts | Medium | Cache counts/summaries, but still paginate detail rows. |
+
+Avoid caching as a write-path shortcut:
+
+- Postgres should remain the ledger for bets and balances.
+- Redis should not decide financial correctness unless the app is redesigned around an explicit event/state model.
+- Cache failures should fall back to Postgres.
+- Cache keys need TTLs, query/page parameters, and invalidation/versioning on bet placement and market lifecycle changes.
+
+7. Reduce avoidable read load with pagination and progressive disclosure.
+
+The largest UX/API load-shaping candidates are:
+
+| Candidate | Likelihood of reducing avoidable load | Notes |
+| --- | --- | --- |
+| Paginate market bets | High | Hot markets can accumulate large bet histories; page at the DB/API boundary. |
+| Paginate market positions | High | Avoid full position calculations and full client-side filtering when users only inspect the first page. |
+| Default market activity to lightweight comments/overview, not positions/bets | High | Current market activity starts with positions; a cheap default avoids automatic heavy reads. |
+| Lazy-load bets, positions, and leaderboards only when opened | High | Prevents casual page views from triggering expensive secondary data paths. |
+| Require button clicks for user financial details and advanced statements | Medium-High | Lets simple profile views load cheaply while preserving deep financial analysis for intentional use. |
+| Reorder Stats tabs to setup config first, system stats second, global leaderboard third | Medium | Setup config is the safest default; leaderboard should remain explicit. |
+| Paginate global leaderboard | Medium-High | Leaderboards can grow with user/market count and should not return all rows by default. |
+| Hide complex system financial metrics behind "show advanced" | Medium | Keeps diagnostic views from becoming default expensive reads. |
+
+These changes should be backed by OpenAPI contract updates and repository-level pagination, not frontend-only slicing after full responses are already loaded.
+
 ### Testing Recommendation
 
 After the index migration:

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -1,0 +1,396 @@
+# SocialPredict General Purpose Droplet Capacity Experiment
+
+Date opened: 2026-06-02
+
+Status: experimental setup drafted; data collection pending
+
+Environment: `temporary-loadtest`
+
+Base URL: `http://161.35.177.38`
+
+Host: `socialpredict-loadtest-20260601`
+
+Droplet ID: `574624493`
+
+## Research Question
+
+What hot-market betting throughput can SocialPredict sustain on a larger single-node DigitalOcean General Purpose Droplet when app, Traefik, nginx, frontend, backend, and Postgres remain colocated in Docker?
+
+## Hypothesis
+
+A General Purpose `4 vCPU / 16 GiB RAM` Droplet should sustain materially higher concentrated hot-market betting throughput than the previous Basic `1 vCPU / 1 GiB RAM` staging result.
+
+The prior staging dossier identified `50` bets/second as the cleanest supported pre-authenticated hot-market datapoint on the Basic `1 vCPU / 1 GiB` host, while `75` bets/second showed one-minute warning signs and five-minute degradation.
+
+Expected outcome before testing:
+
+- `100` bets/second should pass cleanly.
+- `200-300` bets/second may be plausible but must be proven.
+- `500` bets/second is an ambitious event-window target, not assumed capacity.
+
+## Experimental Setup
+
+### System Under Test
+
+- Provider: DigitalOcean
+- Region: `nyc3`
+- Droplet name: `socialpredict-loadtest-20260601`
+- Droplet ID: `574624493`
+- Public IPv4: `161.35.177.38`
+- Public edge mode: HTTP-only raw IP
+- Base URL: `http://161.35.177.38`
+- Application environment: production topology with load-test rate limits
+- App checkout path: `/opt/socialpredict`
+- Database: local Docker Postgres
+- Runtime topology: single Droplet running Traefik, nginx, frontend, backend, backend startup writer, and Postgres
+
+### Current Host State Before Resize
+
+Observed before this experiment:
+
+- Size slug: `s-1vcpu-1gb`
+- Memory: `1024 MiB`
+- vCPUs: `1`
+- Disk reported by DigitalOcean: `25 GiB`
+- OS: Ubuntu 24.04 LTS
+- Docker: installed by cloud-init
+- Explicit Docker container CPU limits: none observed
+- Explicit Docker container memory limits: none observed
+
+### Target Host State
+
+Planned target:
+
+- Size slug: `g-4vcpu-16gb`
+- Memory: `16384 MiB`
+- vCPUs: `4`
+- Plan disk: `50 GiB`
+- Resize mode: CPU/RAM-only resize, without `--resize-disk`
+- Expected root disk after resize: remains approximately `25 GiB`
+- Price observed from `doctl` on 2026-06-02: `$0.187500/hr`, `$126/mo`
+- Approximate 48-hour test cost at target size: `$9.00`
+
+Resize command:
+
+```bash
+doctl compute droplet-action resize 574624493 --size g-4vcpu-16gb --wait
+```
+
+Do not pass `--resize-disk`. DigitalOcean CPU/RAM-only resize is reversible; disk increases are not.
+
+### Deployment Source
+
+- SocialPredict repository: `openpredictionmarkets/socialpredict`
+- Expected ref: `main`
+- Ansible repository: `openpredictionmarkets/ansible_playbooks`
+- Temporary load-test workflow: `deploy_loadtest.yml`
+- Image source: GitHub Container Registry images
+- Backend image: `ghcr.io/openpredictionmarkets/socialpredict-backend:latest`
+- Frontend image: `ghcr.io/openpredictionmarkets/socialpredict-frontend:latest`
+
+If containers do not recover after resize, rerun:
+
+```bash
+gh workflow run deploy_loadtest.yml \
+  --repo openpredictionmarkets/ansible_playbooks \
+  -f socialpredict_ref=main \
+  -f tls_mode=http \
+  -f domain_or_ip=161.35.177.38
+```
+
+## Constants
+
+These should remain fixed throughout this experiment unless a deviation is recorded.
+
+| Constant | Value |
+| --- | --- |
+| Base URL | `http://161.35.177.38` |
+| API prefix | `/api` |
+| Scenario | `hot-market-burst` |
+| Load generator | macOS local k6 |
+| k6 scenario executor | `constant-arrival-rate` |
+| Betting endpoint | `POST /api/v0/bet` |
+| Authentication pattern | setup-time pre-authentication, then bearer-token reuse |
+| Bet amount | default k6 `BET_AMOUNT`, currently `1` unless overridden |
+| Outcome selection | randomized `YES`/`NO` |
+| Market selection | hot markets only |
+| Monitoring interval | `5s` |
+| Host telemetry | CPU, RAM, disk, disk IO, network IO, Docker aggregate, backend/Postgres/Traefik CPU |
+| Pass preference | zero failed bets |
+| Final proof duration | `5m` |
+
+## Independent Variables
+
+These are intentionally varied.
+
+| Variable | Planned Values |
+| --- | --- |
+| Droplet size | Current `s-1vcpu-1gb`, target `g-4vcpu-16gb` |
+| Target betting rate | Discovery ladder: `100`, `150`, `200`, `250`, `300`, `400`, `500` bets/sec |
+| Confirmation target rate | Highest clean discovery rate, then adjusted downward if needed |
+| Confirmation duration | `5m` |
+| Pre-authenticated user pool | `2000` for one-minute discovery, `5000` for final confirmation |
+
+## Dependent Variables
+
+These are measured outcomes.
+
+| Measurement | Source |
+| --- | --- |
+| Successful bets/sec | k6 summary, `sp_bets_succeeded` |
+| Failed bets | k6 summary, `sp_bets_failed` |
+| HTTP failure rate | k6 summary, `http_req_failed` |
+| HTTP p50/p95/max latency | k6 summary |
+| Dropped iterations | k6 summary |
+| Host CPU user/system/idle | host telemetry CSV/summary |
+| Available RAM | host telemetry CSV/summary |
+| Disk used and disk IO | host telemetry CSV/summary |
+| Network RX/TX | host telemetry CSV/summary |
+| Docker CPU/RAM aggregate | host telemetry CSV/summary |
+| Backend/Postgres/Traefik CPU slices | host telemetry CSV/summary |
+| DB pool status | `/api/ops/status` before/after or during spot checks |
+
+## Controlled Variables
+
+These are held constant to isolate the host-size and target-rate effects.
+
+- Same temporary raw-IP host identity and IP.
+- Same single-node Docker topology.
+- Same local Docker Postgres topology.
+- Same HTTP-only edge mode.
+- Same k6 scenario implementation.
+- Same fixture prefixes and password policy.
+- Same load-test rate-limit profile.
+- Same local Mac load-generator unless a later deviation is recorded.
+
+## Rate-Limit Configuration
+
+Expected load-test profile:
+
+```env
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=100
+RATE_LIMIT_LOGIN_BURST=200
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1000
+RATE_LIMIT_GENERAL_BURST=2000
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+These limits are intentionally permissive for single-source capacity testing. They are not model-office or production recommendations.
+
+Normal/model-office comparison profile:
+
+```env
+RATE_LIMIT_LOGIN_RATE_PER_SECOND=0.1
+RATE_LIMIT_LOGIN_BURST=3
+RATE_LIMIT_GENERAL_RATE_PER_SECOND=1
+RATE_LIMIT_GENERAL_BURST=10
+RATE_LIMIT_CLEANUP_INTERVAL=5m
+```
+
+## Fixture Plan
+
+Planned seed:
+
+- Regular users: `10000`
+- Moderators: `100`
+- Markets: `1000`
+- Hot markets: `10`
+- `must_change_password`: `false`
+- User balance: load-test seed default unless overridden
+
+Seed and pull commands:
+
+```bash
+./loadtest/cli/loadtest fixtures seed loadtest \
+  --host root@161.35.177.38 \
+  --key ~/.keys/socialpredict/loadtest/id_ed25519 \
+  --repo-path /opt/socialpredict \
+  --users 10000 \
+  --moderators 100 \
+  --markets 1000 \
+  --hot-markets 10 \
+  --reset
+
+./loadtest/cli/loadtest fixtures pull loadtest \
+  --host root@161.35.177.38 \
+  --key ~/.keys/socialpredict/loadtest/id_ed25519 \
+  --remote-path /opt/socialpredict/loadtest/fixtures \
+  --local-path loadtest/fixtures
+```
+
+## User-Load Interpretation
+
+Bet rate is translated into active-user equivalents with:
+
+```text
+active_users = bets_per_second * seconds_between_bets_per_user
+```
+
+For `500` bets/sec:
+
+| Assumed user behavior | Active-user equivalent |
+| --- | ---: |
+| `1` bet/sec/user | `500` users |
+| `1` bet every `10s`/user | `5000` users |
+| `1` bet every `25s`/user | `12500` users |
+| `1` bet every `60s`/user | `30000` users |
+
+If `25%` of a `50000` user platform is active in hot markets, that is `12500` active users. `500` bets/sec corresponds to those `12500` active users averaging one bet every `25s`.
+
+## Procedure
+
+### 1. Resize And Verify Host
+
+```bash
+doctl compute droplet-action resize 574624493 --size g-4vcpu-16gb --wait
+
+doctl compute droplet get 574624493 \
+  --format ID,Name,PublicIPv4,Status,Memory,VCPUs,Disk,Region,Tags
+
+ssh -i ~/.keys/socialpredict/loadtest/id_ed25519 root@161.35.177.38 '
+  nproc
+  free -h
+  df -h /
+  docker ps --format "table {{.Names}}\t{{.Status}}"
+'
+
+curl -fsS http://161.35.177.38/readyz
+```
+
+### 2. Confirm Runtime Configuration
+
+```bash
+ssh -i ~/.keys/socialpredict/loadtest/id_ed25519 root@161.35.177.38 '
+  cd /opt/socialpredict
+  grep -E "^(DOMAIN_URL|API_URL|TLS_MODE|RATE_LIMIT_)" .env
+'
+```
+
+### 3. Seed And Pull Fixtures
+
+Use the fixture commands in the Fixture Plan section.
+
+### 4. Run Smoke Test
+
+```bash
+./loadtest/cli/loadtest run smoke \
+  --base-url http://161.35.177.38 \
+  --api-prefix /api
+```
+
+Smoke must pass before any capacity run.
+
+### 5. Run One-Minute Discovery Ladder
+
+```bash
+for rate in 100 150 200 250 300 400 500; do
+  ./loadtest/cli/loadtest run hot-market-burst \
+    --base-url http://161.35.177.38 \
+    --api-prefix /api \
+    --duration 1m \
+    --target-rate "$rate" \
+    --preauth-users 2000 \
+    --monitor-env loadtest-g4 \
+    --monitor-host root@161.35.177.38 \
+    --monitor-key ~/.keys/socialpredict/loadtest/id_ed25519 \
+    --monitor-interval 5
+done
+```
+
+If the first failure/degradation point appears, bisect around the boundary in `25` or `50` bets/sec increments.
+
+### 6. Run Five-Minute Confirmation
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url http://161.35.177.38 \
+  --api-prefix /api \
+  --duration 5m \
+  --target-rate <highest-clean-rate> \
+  --preauth-users 5000 \
+  --monitor-env loadtest-g4 \
+  --monitor-host root@161.35.177.38 \
+  --monitor-key ~/.keys/socialpredict/loadtest/id_ed25519 \
+  --monitor-interval 5
+```
+
+## Pass / Degraded / Fail Criteria
+
+### Pass
+
+- `0` failed bets preferred.
+- `http_req_failed` is effectively `0`.
+- No dropped iterations in final confirmation run.
+- HTTP p95 remains below `1s`.
+- Host CPU idle is not pinned near `0%` for most samples.
+- Available RAM remains comfortably above `500 MiB`.
+- No obvious sustained Postgres or proxy saturation.
+
+### Degraded
+
+- No failed bets, but HTTP p95 exceeds `1s`.
+- Dropped iterations appear during one-minute discovery.
+- Host CPU or memory shows concerning but not catastrophic pressure.
+
+### Fail
+
+- Any sustained failed bets.
+- HTTP failure rate above noise.
+- Repeated rate-limit failures.
+- Dropped iterations in the five-minute confirmation run.
+- Test aborts or the site becomes unreachable.
+- Host telemetry shows severe CPU/RAM exhaustion.
+
+## Planned Analysis
+
+After each meaningful run:
+
+1. Pair the k6 summary with the host telemetry summary.
+2. Generate dossier JSON using `.context/loadtest/metadata-g4-loadtest.json`.
+3. Classify the run as `pass`, `degraded`, or `fail`.
+4. Plot or tabulate:
+   - target bets/sec
+   - successful bets/sec
+   - failed bets
+   - dropped iterations
+   - HTTP p95/max
+   - max Docker CPU
+   - backend/Postgres/Traefik CPU
+   - minimum available RAM
+5. Compare the clean five-minute rate to the Basic `1 vCPU / 1 GiB` staging dossier.
+6. Translate the clean rate into active-user equivalents using the user-load formula.
+
+Dossier generation command shape:
+
+```bash
+./loadtest/cli/loadtest dossier \
+  --summary loadtest/results/<summary>.json \
+  --host-summary loadtest/hostops/<run>-host-summary.json \
+  --metadata .context/loadtest/metadata-g4-loadtest.json \
+  --decision <pass|degraded|fail> \
+  --out loadtest/dossier/runs/<run>-g4.json
+```
+
+## Data
+
+Data collection pending.
+
+| Run | Target bets/sec | Duration | Decision | Successful bets/sec | Failed bets | Dropped iterations | HTTP p95 | Host CPU notes | RAM notes |
+| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+## Analysis
+
+Analysis pending data collection.
+
+## Conclusion
+
+Conclusion pending data collection.
+
+## Deviations
+
+Record deviations here as they happen.
+
+| Time UTC | Deviation | Reason | Impact |
+| --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD |

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -2,7 +2,7 @@
 
 Date opened: 2026-06-02
 
-Status: first Basic AMD `8 vCPU / 32 GiB RAM` discovery and degradation analysis captured; fresh-reset confirmation still in progress
+Status: first Basic AMD `8 vCPU / 32 GiB RAM` discovery and degradation analysis captured; temporary Droplet destroyed after test window
 
 Environment: `temporary-loadtest`
 
@@ -11,6 +11,8 @@ Base URL: `http://161.35.177.38`
 Host: `socialpredict-loadtest-20260601`
 
 Droplet ID: `574624493`
+
+Final host lifecycle: destroyed on 2026-06-02 after the initial experiment window. Repeating this experiment requires creating a new temporary Droplet, updating the load-test workflow target IP, redeploying, reseeding fixtures, and pulling fresh fixtures.
 
 ## Research Question
 
@@ -98,6 +100,8 @@ gh workflow run deploy_loadtest.yml \
   -f tls_mode=http \
   -f domain_or_ip=161.35.177.38
 ```
+
+If the temporary Droplet has been destroyed, create a new load-test Droplet and run `deploy_loadtest.yml` with the new raw IP before repeating the test. The `domain_or_ip`, `--base-url`, `--monitor-host`, fixture seed/pull host, and local known-hosts entries must all be updated to the new IP.
 
 ### Interpretation Caveat
 
@@ -395,6 +399,8 @@ The k6 rate columns in the raw summaries include setup/pre-auth time. The table 
 | `20260602T040136Z` | `300` | `5m` | degraded | `85511` | `285.0` | `0` | `4490` | `4.96s` | min idle `0%`; Docker CPU `790.59%`; Postgres `664.07%` | min available `30753 MiB` | `loadtest/results/hot-market-burst-20260602T040136Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T040136Z-host-summary.json`; raw CSV same prefix |
 | `20260602T041807Z` | `200` | `5m` | degraded | `57542` | `191.8` | `0` | `2459` | `7.66s` | min idle `0%`; Docker CPU `795%`; Postgres `692.12%` | min available `30742 MiB` | `loadtest/results/hot-market-burst-20260602T041807Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T041807Z-host-summary.json`; raw CSV same prefix |
 | `20260602T042645Z` | `100` | `5m` | fail | `29952` | `99.8` | `48` | `0` | `88.05ms` expected responses; failed requests timed out at `1m0s` | min idle `2.68%`; Docker CPU `765.03%`; Postgres `696.55%` | min available `30925 MiB` | `loadtest/results/hot-market-burst-20260602T042645Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T042645Z-host-summary.json`; raw CSV same prefix |
+| `20260602T044554Z` | `300` | `1m` | near-clean post-reset probe | `17997` | `300.0` | `0` | `4` | `51.36ms` | min idle `30.58%`; Docker CPU `437.14%`; Postgres `134.43%` | min available `31179 MiB` | `loadtest/results/hot-market-burst-20260602T044554Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T044554Z-host-summary.json`; raw CSV same prefix |
+| `20260602T045057Z` | `300` | intended `5m` | invalid fixture mismatch | `0` valid bets | N/A | `1594` `MARKET_NOT_FOUND` responses | N/A | `39.35ms` | host mostly idle; min idle `96.28%`; Postgres `1.73%` | min available `31151 MiB` | `loadtest/results/hot-market-burst-20260602T045057Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T045057Z-host-summary.json`; raw CSV same prefix |
 
 ### Database Diagnostics After Cumulative Runs
 
@@ -417,6 +423,17 @@ WHERE market_id = ? AND username = ?
 ```
 
 Without a composite index on that predicate, the cost of each bet can grow as the `bets` table grows. This is the leading explanation for why the host could pass one-minute bursts on a fresher dataset but later timed out at only `100` bets/sec after the cumulative bet table reached roughly `259k` rows.
+
+### Post-Reset Probe
+
+After a fixture reset and pull, a `300` bets/sec one-minute probe improved materially:
+
+- p95 HTTP latency dropped to `51.36ms`.
+- Postgres max CPU dropped to `134.43%`.
+- Host min idle stayed at `30.58%`.
+- There were `4` dropped iterations, so this is recorded as near-clean rather than strict-clean.
+
+This supports the data-growth hypothesis: resetting the test state reduced Postgres pressure substantially. However, a following attempted five-minute `300` bets/sec run was invalid because k6 received `MARKET_NOT_FOUND` for market IDs such as `1023` and `1026` while the host was mostly idle. That run indicates a fixture mismatch between local `markets.csv` and the active server database, not application capacity degradation.
 
 ## Analysis
 
@@ -443,6 +460,7 @@ The current evidence supports two separate claims:
 
 1. On this resized Basic AMD shared-CPU Droplet, fresh-ish one-minute burst capacity is clean up to `300` bets/sec and degraded by `350-400` bets/sec.
 2. Sustained capacity cannot be claimed yet because cumulative bet-history growth degrades the write path. The next engineering step is to add and test the missing bet-history indexes, then rerun the sustained ladder from a reset fixture state.
+3. Fixture integrity is now a required precondition for long runs. A smoke test alone is not enough if the local hot-market fixture file can drift from the active server database.
 
 ## Conclusion
 
@@ -452,6 +470,7 @@ Preliminary conclusion:
 - Do not claim sustained `300` or `200` bets/sec on the current schema.
 - The best current burst claim is `300` bets/sec for `1m` on a reset or low-history dataset.
 - Sustained claims should wait for an indexed bet-history migration and fresh five-minute confirmation runs.
+- Any future five-minute run must first verify that local fixture market IDs exist on the server.
 
 Recommended schema investigation:
 
@@ -467,6 +486,27 @@ CREATE INDEX CONCURRENTLY idx_bets_market_id_placed_at_id ON bets (market_id, pl
 
 The first index directly targets `UserHasBet`, which runs during bet placement. The second targets market-scoped ordered bet reads observed in analytics and position paths. These should be implemented through the project migration system before using them as production evidence.
 
+Recommended fixture-integrity check before capacity runs:
+
+```bash
+ssh -i ~/.keys/socialpredict/loadtest/id_ed25519 root@<LOADTEST_IP> <<'REMOTE'
+PG=$(docker ps --format '{{.Names}}' | grep -E 'postgres' | head -1)
+docker exec -i "$PG" sh -lc '
+DB=${POSTGRES_DB:-${POSTGRES_DATABASE:-postgres}}
+U=${POSTGRES_USER:-postgres}
+psql -U "$U" -d "$DB" -v ON_ERROR_STOP=1 <<SQL
+SELECT min(id) AS min_market_id, max(id) AS max_market_id, count(*) AS markets FROM markets;
+SELECT count(*) AS bets FROM bets;
+SQL
+'
+REMOTE
+
+head -20 loadtest/fixtures/markets.csv
+tail -20 loadtest/fixtures/markets.csv
+```
+
+If local fixture IDs are not within the server market range, rerun fixture seed with `--reset`, then immediately pull fixtures again before running k6.
+
 ## Deviations
 
 Record deviations here as they happen.
@@ -477,3 +517,6 @@ Record deviations here as they happen.
 | `2026-06-02T03:37Z` | First post-timeout rerun captured insufficient host telemetry | Monitor duration did not include setup/pre-auth time | k6 result was useful, but host telemetry did not cover the full burst window |
 | `2026-06-02T03:39Z` | Host monitor duration was corrected to include setup timeout | Needed telemetry covering setup plus scenario execution | Later runs have usable host telemetry summaries |
 | `2026-06-02T04:26Z` | Later sustained runs were cumulative-state tests, not fresh-reset tests | Prior runs inserted hundreds of thousands of hot-market bets | Sustained degradation may reflect schema/data-growth behavior, not only raw host capacity |
+| `2026-06-02T04:45Z` | Post-reset `300` bets/sec one-minute probe was run | Needed to distinguish cumulative-state degradation from fresh-state host capacity | Improved latency and CPU data strengthened the bet-history growth hypothesis |
+| `2026-06-02T04:50Z` | Attempted post-reset `300` bets/sec five-minute run was invalid | k6 used market IDs not found by the server, producing `MARKET_NOT_FOUND` while host was idle | Not capacity evidence; fixture integrity check added as required precondition |
+| `2026-06-02T04:56Z` | Temporary load-test Droplet was powered off and destroyed | Avoid ongoing DigitalOcean hourly billing after experiment window | Future testing requires new Droplet/IP and workflow target update |

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -2,7 +2,7 @@
 
 Date opened: 2026-06-02
 
-Status: first Basic AMD `8 vCPU / 32 GiB RAM` discovery and degradation analysis captured; temporary Droplet destroyed after test window
+Status: first Basic AMD `8 vCPU / 32 GiB RAM` discovery and degradation analysis captured; June 3 repeat run added with fresh-zero-bet precondition and Postgres CPU saturation finding
 
 Environment: `temporary-loadtest`
 
@@ -13,6 +13,19 @@ Host: `socialpredict-loadtest-20260601`
 Droplet ID: `574624493`
 
 Final host lifecycle: destroyed on 2026-06-02 after the initial experiment window. Repeating this experiment requires creating a new temporary Droplet, updating the load-test workflow target IP, redeploying, reseeding fixtures, and pulling fresh fixtures.
+
+Repeat host lifecycle: a second temporary load-test Droplet was created for the June 3 repeat run.
+
+- Droplet ID: `574903216`
+- Droplet name: `socialpredict-loadtest-20260602-220232`
+- Public IPv4: `161.35.135.167`
+- Size slug after resize: `s-8vcpu-32gb-amd`
+- CPU model observed: `DO-Premium-AMD`
+- vCPUs observed: `8`
+- RAM observed: `32095 MiB`
+- Root disk observed: approximately `25 GiB`
+- Base URL: `http://161.35.135.167`
+- Backend image revision verified before repeat: `c42bc34900659bcb5a7cbd251fd7ff021920d0f7`
 
 ## Research Question
 
@@ -507,6 +520,63 @@ tail -20 loadtest/fixtures/markets.csv
 
 If local fixture IDs are not within the server market range, rerun fixture seed with `--reset`, then immediately pull fixtures again before running k6.
 
+### June 3 Repeat Run On Fresh Fixtures
+
+The June 3 repeat used a new temporary load-test host at `161.35.135.167`. Before the run, fixtures were reseeded with `--reset`, pulled locally, and verified directly in Postgres:
+
+| Precondition | Value |
+| --- | ---: |
+| Regular load users | `10000` |
+| Load moderators | `100` |
+| Markets | `1000` |
+| Hot markets | `10` |
+| Bets before smoke | `0` |
+
+Smoke then passed against `http://161.35.135.167` with `3/3` smoke bets succeeding. The following sustained run was attempted:
+
+```bash
+./loadtest/cli/loadtest run hot-market-burst \
+  --base-url http://161.35.135.167 \
+  --api-prefix /api \
+  --duration 5m \
+  --target-rate 300 \
+  --preauth-users 100 \
+  --setup-timeout 3m \
+  --monitor-env loadtest-basic-amd \
+  --monitor-host root@161.35.135.167 \
+  --monitor-key ~/.keys/socialpredict/loadtest/id_ed25519 \
+  --monitor-interval 5
+```
+
+Result:
+
+| Run timestamp | Target bets/sec | Duration | Decision | Successful bets | Failed bets | Dropped iterations | HTTP p95 | Host CPU notes | RAM notes | Artifact paths |
+| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+| `20260603T034323Z` | `300` | interrupted at `4m30.5s` measured scenario time | fail for strict clean-run standard | `80266` | `288` | `563` | `226.83ms`; max included stalled failed requests | min idle `0.12%`; Docker CPU `775.15%`; backend `134.43%`; Postgres `568.27%`; Traefik `35.73%` | min available `31012 MiB` | `loadtest/results/hot-market-burst-20260603T034323Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260603T034323Z-host-summary.json`; raw CSV same prefix |
+| `20260603T035954Z` | `250` | `5m` | pass | `75001` | `0` | `0` | `153.72ms`; max `550.66ms` | min idle `0.86%`; Docker CPU `767.69%`; backend `166.81%`; Postgres `407.78%`; Traefik `40.69%` | min available `31092 MiB` | `loadtest/results/hot-market-burst-20260603T035954Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260603T035954Z-host-summary.json`; raw CSV same prefix |
+
+Post-run database state:
+
+| Measurement | Value |
+| --- | ---: |
+| Total `bets` rows after `300/sec` attempt | `80313` |
+| Markets with bets after `300/sec` attempt | `11` |
+| Hot-market distribution after `300/sec` attempt | ten hot markets each had approximately `7904-8179` bets |
+| Total `bets` rows after fresh `250/sec` confirmation | `75001` |
+| Markets with bets after fresh `250/sec` confirmation | `10` |
+| Hot-market distribution after fresh `250/sec` confirmation | ten hot markets each had approximately `7382-7642` bets |
+
+Interpretation:
+
+- This run started from a zero-bet load-test state, so it is not merely a cumulative-history artifact.
+- The `300/sec` repeat still failed the project's preferred strict standard because there were `288` failed bet requests and `563` dropped iterations.
+- The following fresh `250/sec` repeat passed the strict standard: `0` failed bets and `0` dropped iterations for the full `5m` scenario.
+- RAM was not stressed. The minimum available RAM stayed above `31 GiB`.
+- CPU saturated the host, with Postgres consuming the largest slice.
+- This establishes `250/sec for 5m` as the current best clean sustained datapoint on this Basic AMD `8 vCPU / 32 GiB` shared-CPU single-node host.
+- This also strengthens the conclusion that the next scaling constraint is CPU-bound Postgres/write-path behavior, not memory.
+- A CPU-optimized or dedicated-CPU host is a more relevant next hardware experiment than a RAM-optimized host, but schema/index work should still happen before relying on bigger hardware as the solution.
+
 ## Deviations
 
 Record deviations here as they happen.
@@ -518,5 +588,7 @@ Record deviations here as they happen.
 | `2026-06-02T03:39Z` | Host monitor duration was corrected to include setup timeout | Needed telemetry covering setup plus scenario execution | Later runs have usable host telemetry summaries |
 | `2026-06-02T04:26Z` | Later sustained runs were cumulative-state tests, not fresh-reset tests | Prior runs inserted hundreds of thousands of hot-market bets | Sustained degradation may reflect schema/data-growth behavior, not only raw host capacity |
 | `2026-06-02T04:45Z` | Post-reset `300` bets/sec one-minute probe was run | Needed to distinguish cumulative-state degradation from fresh-state host capacity | Improved latency and CPU data strengthened the bet-history growth hypothesis |
+| `2026-06-03T03:43Z` | Repeated `300` bets/sec five-minute test on a new host after zero-bet fixture reset | Needed to separate fresh-state host ceiling from cumulative bet-history degradation | Run still failed strict clean criteria with Postgres CPU saturation, indicating a CPU/write-path ceiling even before large cumulative history |
+| `2026-06-03T03:59Z` | Repeated `250` bets/sec five-minute test after another zero-bet fixture reset | Needed to find the clean sustained boundary below failed `300/sec` | Run passed cleanly with `75001` successful bets, `0` failed bets, and `0` dropped iterations, but CPU still approached saturation |
 | `2026-06-02T04:50Z` | Attempted post-reset `300` bets/sec five-minute run was invalid | k6 used market IDs not found by the server, producing `MARKET_NOT_FOUND` while host was idle | Not capacity evidence; fixture integrity check added as required precondition |
 | `2026-06-02T04:56Z` | Temporary load-test Droplet was powered off and destroyed | Avoid ongoing DigitalOcean hourly billing after experiment window | Future testing requires new Droplet/IP and workflow target update |

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -1,4 +1,4 @@
-# SocialPredict General Purpose Droplet Capacity Experiment
+# SocialPredict Large Basic AMD Droplet Capacity Experiment
 
 Date opened: 2026-06-02
 
@@ -14,11 +14,11 @@ Droplet ID: `574624493`
 
 ## Research Question
 
-What hot-market betting throughput can SocialPredict sustain on a larger single-node DigitalOcean General Purpose Droplet when app, Traefik, nginx, frontend, backend, and Postgres remain colocated in Docker?
+What hot-market betting throughput can SocialPredict sustain on a larger single-node DigitalOcean Basic AMD shared-CPU Droplet when app, Traefik, nginx, frontend, backend, and Postgres remain colocated in Docker?
 
 ## Hypothesis
 
-A General Purpose `4 vCPU / 16 GiB RAM` Droplet should sustain materially higher concentrated hot-market betting throughput than the previous Basic `1 vCPU / 1 GiB RAM` staging result.
+A Basic AMD shared-CPU `8 vCPU / 32 GiB RAM` Droplet should sustain materially higher concentrated hot-market betting throughput than the previous Basic `1 vCPU / 1 GiB RAM` staging result. Because this is a shared-CPU class, the result should be reported as observed Basic/shared-CPU evidence rather than dedicated General Purpose evidence.
 
 The prior staging dossier identified `50` bets/second as the cleanest supported pre-authenticated hot-market datapoint on the Basic `1 vCPU / 1 GiB` host, while `75` bets/second showed one-minute warning signs and five-minute degradation.
 
@@ -61,19 +61,20 @@ Observed before this experiment:
 
 Planned target:
 
-- Size slug: `g-4vcpu-16gb`
-- Memory: `16384 MiB`
-- vCPUs: `4`
-- Plan disk: `50 GiB`
+- Size slug: `s-8vcpu-32gb-amd`
+- Class: DigitalOcean Basic AMD shared CPU
+- Memory: `32768 MiB`
+- vCPUs: `8`
+- Plan disk: `400 GiB`
 - Resize mode: CPU/RAM-only resize, without `--resize-disk`
 - Expected root disk after resize: remains approximately `25 GiB`
-- Price observed from `doctl` on 2026-06-02: `$0.187500/hr`, `$126/mo`
-- Approximate 48-hour test cost at target size: `$9.00`
+- Price observed from `doctl` on 2026-06-02: `$0.250000/hr`, `$168/mo`
+- Approximate 48-hour test cost at target size: `$12.00`
 
 Resize command:
 
 ```bash
-doctl compute droplet-action resize 574624493 --size g-4vcpu-16gb --wait
+doctl compute droplet-action resize 574624493 --size s-8vcpu-32gb-amd --wait
 ```
 
 Do not pass `--resize-disk`. DigitalOcean CPU/RAM-only resize is reversible; disk increases are not.
@@ -97,6 +98,10 @@ gh workflow run deploy_loadtest.yml \
   -f tls_mode=http \
   -f domain_or_ip=161.35.177.38
 ```
+
+### Interpretation Caveat
+
+The target host is a Basic AMD shared-CPU Droplet. A successful run can prove that this observed host, during this test window, sustained the measured traffic. It should not be presented as dedicated-CPU or General Purpose evidence. If the final result is used for production planning, the dossier should explicitly state that CPU scheduling may be less predictable than a dedicated General Purpose or CPU-Optimized class.
 
 ## Constants
 
@@ -125,7 +130,7 @@ These are intentionally varied.
 
 | Variable | Planned Values |
 | --- | --- |
-| Droplet size | Current `s-1vcpu-1gb`, target `g-4vcpu-16gb` |
+| Droplet size | Current `s-1vcpu-1gb`, target `s-8vcpu-32gb-amd` |
 | Target betting rate | Discovery ladder: `100`, `150`, `200`, `250`, `300`, `400`, `500` bets/sec |
 | Confirmation target rate | Highest clean discovery rate, then adjusted downward if needed |
 | Confirmation duration | `5m` |
@@ -162,6 +167,7 @@ These are held constant to isolate the host-size and target-rate effects.
 - Same fixture prefixes and password policy.
 - Same load-test rate-limit profile.
 - Same local Mac load-generator unless a later deviation is recorded.
+- Same Basic/shared-CPU caveat recorded in the final interpretation.
 
 ## Rate-Limit Configuration
 
@@ -242,7 +248,7 @@ If `25%` of a `50000` user platform is active in hot markets, that is `12500` ac
 ### 1. Resize And Verify Host
 
 ```bash
-doctl compute droplet-action resize 574624493 --size g-4vcpu-16gb --wait
+doctl compute droplet-action resize 574624493 --size s-8vcpu-32gb-amd --wait
 
 doctl compute droplet get 574624493 \
   --format ID,Name,PublicIPv4,Status,Memory,VCPUs,Disk,Region,Tags

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -547,6 +547,78 @@ The June 3 runs show CPU pressure concentrated in Postgres while RAM remains ple
 
 The right sequencing is: index migration, query-shape optimization, fresh five-minute load tests, then hardware/architecture comparison.
 
+7. Use Redis or another cache selectively for read-heavy, slightly stale views.
+
+Redis is an in-memory key-value store. In this context, "using Redis to cache Postgres" should not mean putting Redis in front of every database call or treating Redis as the source of truth. It means caching selected read results that are expensive to compute and safe to serve for a short time.
+
+Good candidates:
+
+| Candidate | Cache Shape | Likelihood | Notes |
+| --- | --- | --- | --- |
+| Global leaderboard | snapshot keyed by leaderboard version/query/page with short TTL | High | The analytics code already has a `GlobalLeaderboardSnapshot` seam, which is an appropriate cache boundary. |
+| System financial metrics | snapshot keyed by config/version with short TTL | Medium-High | Useful because these are diagnostic aggregates, not per-request transactional writes. |
+| Market summary cards | per-market summary with short TTL or write-through invalidation | Medium | Useful for list pages if cards repeatedly show probability, volume, bet count, and status. |
+| Market bet/position page counts | count/summary cache with short TTL | Medium | Can avoid repeated count queries on hot pages; detail rows should still be paginated. |
+| Public setup/config frontend policy | in-process or Redis cache with long TTL/version key | Medium | Config is mostly static after install; cache mainly reduces repeated serialization, not DB pressure. |
+
+Poor candidates:
+
+| Candidate | Why Not |
+| --- | --- |
+| Bet placement correctness | Bets must remain transactional in Postgres. Redis should not decide balances, duplicate-bet checks, or final financial correctness unless there is a much larger event-sourcing design. |
+| User balances during writes | Balance changes must be atomic with bet writes. A cache can display a recent balance, but Postgres must own the ledger. |
+| Full unpaginated histories | Caching huge payloads can move pressure from Postgres to Redis/network/memory rather than solving the shape problem. Paginate first. |
+
+Cache invalidation policy should be explicit:
+
+- Prefer short TTLs for analytics snapshots.
+- Include page/query parameters in cache keys.
+- Invalidate or version market summary keys after bet placement, market resolution, or market approval/rejection.
+- Keep cache failures non-fatal: if Redis is down, fall back to Postgres and log the miss/error.
+- Never let cached financial data become the ledger of record.
+
+Recommended Redis sequencing:
+
+1. Add indexes and pagination first.
+2. Add a cache interface behind analytics/repository boundaries.
+3. Start with global leaderboard and system stats snapshots.
+4. Add market summary caching only after summary contracts are explicit.
+5. Load test read-heavy browsing scenarios with cache on/off.
+
+## UX And API Demand-Shaping Checklist
+
+Not every capacity improvement needs to come from a faster database query. Some load can be avoided by changing default UI behavior so expensive data paths are opt-in, paginated, or progressively disclosed. These changes should be treated as product/API design work, not only frontend polish, because the backend endpoints must support the lighter access pattern.
+
+Likelihood estimates below mean "likelihood of reducing avoidable backend/database load during normal browsing." They are not a substitute for measurement.
+
+| Done | Idea | Likelihood | Reason |
+| --- | --- | --- | --- |
+| [ ] | Paginate market bet history on each market page. | High | `BetsActivity` currently fetches market bets as a full list. Hot markets can accumulate tens of thousands of rows, so pagination directly limits transfer, JSON encoding, sorting, and probability display work. |
+| [ ] | Paginate market positions on each market page. | High | `PositionsActivity` currently requests all market positions and filters/sorts client-side. Large markets can make this expensive even when users only inspect the first page. |
+| [ ] | Change market activity default tab away from heavy data. Prefer a lightweight `Comments`/overview tab once comments are real, or another cheap summary tab until then. | High | The current activity tab order starts with `Positions`, causing position fetches on market detail load. Defaulting to a cheap tab makes bets/positions user-initiated. |
+| [ ] | Lazy-load Bets, Positions, and Leaderboard tab contents only when the tab is opened. | High | Avoids paying for all market-adjacent views when a visitor only wants the market question/trade panel. |
+| [ ] | Add "Show bets" / "Show positions" buttons for expensive market detail sections. | High | Explicit disclosure is clearer than hidden automatic fetches and protects hot market pages during traffic spikes. |
+| [ ] | Make user financial positions opt-in behind a button on profile/user pages. | Medium-High | Public profile/portfolio/financial views can trigger multi-market position calculations; requiring a click prevents casual profile views from doing heavy accounting work. |
+| [ ] | Split simple user financial summary from complex financial statements. | Medium-High | Lightweight balances and totals can load first; high-cost derived financial/accounting views can be requested only by users who need them. |
+| [ ] | Paginate public portfolio positions. | Medium-High | User portfolios can grow with market count; pagination caps response size and client rendering cost. |
+| [ ] | Reorder Stats tabs to `Setup Configuration`, `System Financial Metrics`, then `Global Leaderboard`. | Medium | `Stats.jsx` currently defaults to Global Leaderboard, though it already requires a button click. Reordering communicates that setup config is the cheap/default view. |
+| [ ] | Keep Global Leaderboard behind an explicit "Calculate" button and add backend pagination. | Medium-High | The button already prevents automatic calculation, but once loaded the leaderboard should not require all rows at once. |
+| [ ] | Paginate global leaderboard results. | Medium-High | Global leaderboards can touch many users/markets and produce large result sets; pagination bounds response and render size. |
+| [ ] | Simplify System Financial Metrics by default and hide complex/derived metrics behind "Show advanced metrics." | Medium | Some system metrics are likely aggregate-heavy. Progressive disclosure prevents expensive diagnostics from being part of the default stats page. |
+| [ ] | Cache or snapshot system statistics with a short TTL. | Medium | System stats are read-style diagnostics and may not need exact real-time recomputation for every click. |
+| [ ] | Add endpoint-level `limit`, `cursor`/`offset`, and `sort` contracts to OpenAPI for bets, positions, and leaderboards. | High | UI pagination only reduces DB load if the API and repository actually page at the database boundary. |
+| [ ] | Return summary counts separately from full detail rows. | Medium | Pages often need "there are N bets/positions" before they need every row. Count/summary endpoints can be cheaper and cacheable. |
+| [ ] | Add load-test scenarios for browsing market detail pages with and without optional panels open. | Medium | Current hot-market tests focus on betting. A separate browsing scenario should measure whether pagination/lazy loading reduces read pressure. |
+
+Suggested implementation order:
+
+1. Add backend pagination contracts for market bets, market positions, and global leaderboard.
+2. Update market detail tabs so heavy tabs fetch only after user action.
+3. Default market detail activity to a cheap tab or placeholder until comments exist.
+4. Split profile/user financial views into summary-first and advanced-on-click.
+5. Reorder Stats tabs and keep leaderboard/system metrics explicit.
+6. Add load-test browsing scenarios to quantify read-path improvement.
+
 ## Conclusion
 
 Preliminary conclusion:

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -296,7 +296,8 @@ for rate in 100 150 200 250 300 400 500; do
     --duration 1m \
     --target-rate "$rate" \
     --preauth-users 2000 \
-    --monitor-env loadtest-g4 \
+    --setup-timeout 5m \
+    --monitor-env loadtest-basic-amd \
     --monitor-host root@161.35.177.38 \
     --monitor-key ~/.keys/socialpredict/loadtest/id_ed25519 \
     --monitor-interval 5
@@ -314,7 +315,8 @@ If the first failure/degradation point appears, bisect around the boundary in `2
   --duration 5m \
   --target-rate <highest-clean-rate> \
   --preauth-users 5000 \
-  --monitor-env loadtest-g4 \
+  --setup-timeout 10m \
+  --monitor-env loadtest-basic-amd \
   --monitor-host root@161.35.177.38 \
   --monitor-key ~/.keys/socialpredict/loadtest/id_ed25519 \
   --monitor-interval 5
@@ -352,7 +354,7 @@ If the first failure/degradation point appears, bisect around the boundary in `2
 After each meaningful run:
 
 1. Pair the k6 summary with the host telemetry summary.
-2. Generate dossier JSON using `.context/loadtest/metadata-g4-loadtest.json`.
+2. Generate dossier JSON using `.context/loadtest/metadata-basic-amd-loadtest.json`.
 3. Classify the run as `pass`, `degraded`, or `fail`.
 4. Plot or tabulate:
    - target bets/sec
@@ -372,7 +374,7 @@ Dossier generation command shape:
 ./loadtest/cli/loadtest dossier \
   --summary loadtest/results/<summary>.json \
   --host-summary loadtest/hostops/<run>-host-summary.json \
-  --metadata .context/loadtest/metadata-g4-loadtest.json \
+  --metadata .context/loadtest/metadata-basic-amd-loadtest.json \
   --decision <pass|degraded|fail> \
   --out loadtest/dossier/runs/<run>-g4.json
 ```

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -475,6 +475,78 @@ The current evidence supports two separate claims:
 2. Sustained capacity cannot be claimed yet because cumulative bet-history growth degrades the write path. The next engineering step is to add and test the missing bet-history indexes, then rerun the sustained ladder from a reset fixture state.
 3. Fixture integrity is now a required precondition for long runs. A smoke test alone is not enough if the local hot-market fixture file can drift from the active server database.
 
+## Future Optimization Analysis
+
+The current codebase already has repository boundaries around market and user persistence, so future Postgres optimizations should live behind those repositories and domain services rather than being scattered through handlers. The main candidates are:
+
+1. Add targeted indexes through timestamped migrations.
+
+The most immediate candidate remains:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_bets_market_id_username ON bets (market_id, username);
+```
+
+This targets the placement-time check for whether a user has already bet in a market. A second candidate is:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_bets_market_id_placed_at_id ON bets (market_id, placed_at, id);
+```
+
+This targets market-scoped history reads that need deterministic chronological order.
+
+2. Replace full-row GORM loads with narrow query projections where the domain only needs a subset of columns.
+
+Current repository paths such as `ListBetsForMarket` and `loadMarketData` load full bet rows before converting them into boundary/domain structs. That is appropriate for correctness-first implementation, but it can be wasteful under hot-market load. Candidate follow-up work:
+
+- use GORM `Select(...)` for known domain projections
+- use custom SQL through the repository for high-traffic read paths
+- avoid loading fields that are not consumed by probability, volume, position, or display calculations
+- add tests that preserve domain output while changing the persistence query shape
+
+3. Move common aggregates into explicit repository methods.
+
+`CalculateMarketVolume` currently asks the repository for all bets and then sums in Go. For larger histories, the repository can expose a database-backed aggregate such as:
+
+```sql
+SELECT COALESCE(SUM(amount), 0) FROM bets WHERE market_id = $1;
+```
+
+That keeps the domain service API clean while letting Postgres do the aggregate without transferring every bet row.
+
+4. Introduce market summary state for write-heavy hot paths if indexes and narrow reads are not enough.
+
+If sustained tests still show Postgres CPU saturation after indexing, add transactionally maintained summary tables or columns for:
+
+- current market probability
+- market volume
+- per-market bet count
+- per-user per-market position
+
+This is a larger design change because it shifts some values from computed-on-read to updated-on-write. It should only happen after index and query-shape changes are measured.
+
+5. Revisit the game/probability engine boundary.
+
+The probability engine currently operates over bet history. That is simple and auditable, but hot markets expose the cost of repeatedly replaying history. A future game-engine design can define whether probability is:
+
+- replayed from the event ledger for audit/debug paths
+- incrementally updated from the prior market state for hot write paths
+- periodically reconciled by a background consistency check
+
+This should be designed at the game-engine boundary rather than as an ad hoc Postgres shortcut.
+
+6. Separate Postgres or use managed Postgres before treating bigger app hosts as the only answer.
+
+The June 3 runs show CPU pressure concentrated in Postgres while RAM remains plentiful. A CPU-optimized or dedicated-CPU Droplet is a useful next hardware comparison, but a production-oriented architecture should also evaluate:
+
+- app/database separation
+- managed Postgres sizing
+- connection pooling
+- Postgres parameter tuning
+- backups and recovery posture
+
+The right sequencing is: index migration, query-shape optimization, fresh five-minute load tests, then hardware/architecture comparison.
+
 ## Conclusion
 
 Preliminary conclusion:

--- a/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
+++ b/loadtest/dossier/general-purpose-capacity-experiment-2026-06-02.md
@@ -2,7 +2,7 @@
 
 Date opened: 2026-06-02
 
-Status: experimental setup drafted; data collection pending
+Status: first Basic AMD `8 vCPU / 32 GiB RAM` discovery and degradation analysis captured; fresh-reset confirmation still in progress
 
 Environment: `temporary-loadtest`
 
@@ -59,15 +59,15 @@ Observed before this experiment:
 
 ### Target Host State
 
-Planned target:
+Observed target after resize:
 
 - Size slug: `s-8vcpu-32gb-amd`
 - Class: DigitalOcean Basic AMD shared CPU
 - Memory: `32768 MiB`
 - vCPUs: `8`
-- Plan disk: `400 GiB`
-- Resize mode: CPU/RAM-only resize, without `--resize-disk`
-- Expected root disk after resize: remains approximately `25 GiB`
+- Plan disk if resized with disk: `400 GiB`
+- Resize mode used: CPU/RAM-only resize, without `--resize-disk`
+- Root disk after resize: remained approximately `25 GiB`
 - Price observed from `doctl` on 2026-06-02: `$0.250000/hr`, `$168/mo`
 - Approximate 48-hour test cost at target size: `$12.00`
 
@@ -381,19 +381,91 @@ Dossier generation command shape:
 
 ## Data
 
-Data collection pending.
+Initial data collection was performed against the resized Basic AMD host. The one-minute runs show clean burst behavior through `300` bets/sec. The five-minute runs show sustained degradation once the hot-market bet history has grown, with Postgres saturating the host CPU.
 
-| Run | Target bets/sec | Duration | Decision | Successful bets/sec | Failed bets | Dropped iterations | HTTP p95 | Host CPU notes | RAM notes |
-| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
-| TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+The k6 rate columns in the raw summaries include setup/pre-auth time. The table below computes achieved bet throughput from successful bets divided by the scenario duration.
+
+| Run timestamp | Target bets/sec | Duration | Decision | Successful bets | Achieved bets/sec | Failed bets | Dropped iterations | HTTP p95 | Host CPU notes | RAM notes | Artifact paths |
+| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
+| `20260602T033940Z` | `100` | `1m` | pass | `6001` | `100.0` | `0` | `0` | `39.15ms` | min idle `87.58%`; Docker CPU `94.42%`; Postgres `35.39%` | min available `31238 MiB` | `loadtest/results/hot-market-burst-20260602T033940Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T033940Z-host-summary.json`; raw CSV same prefix |
+| `20260602T034343Z` | `200` | `1m` | pass | `12001` | `200.0` | `0` | `0` | `40.76ms` | min idle `71.45%`; Docker CPU `218.38%`; Postgres `108.75%` | min available `31235 MiB` | `loadtest/results/hot-market-burst-20260602T034343Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T034343Z-host-summary.json`; raw CSV same prefix |
+| `20260602T034654Z` | `300` | `1m` | pass | `18001` | `300.0` | `0` | `0` | `72.65ms` | min idle `6.68%`; Docker CPU `633.07%`; Postgres `272.4%` | min available `31207 MiB` | `loadtest/results/hot-market-burst-20260602T034654Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T034654Z-host-summary.json`; raw CSV same prefix |
+| `20260602T035651Z` | `350` | `1m` | degraded | `20583` | `343.1` | `0` | `418` | `1.3s` | min idle `0%`; Docker CPU `783.4%`; Postgres `632.09%` | min available `31040 MiB` | `loadtest/results/hot-market-burst-20260602T035651Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T035651Z-host-summary.json`; raw CSV same prefix |
+| `20260602T035223Z` | `400` | `1m` | degraded | `23143` | `385.7` | `0` | `858` | `2.3s` | min idle `0%`; Docker CPU `786.93%`; Postgres `540.31%` | min available `31020 MiB` | `loadtest/results/hot-market-burst-20260602T035223Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T035223Z-host-summary.json`; raw CSV same prefix |
+| `20260602T040136Z` | `300` | `5m` | degraded | `85511` | `285.0` | `0` | `4490` | `4.96s` | min idle `0%`; Docker CPU `790.59%`; Postgres `664.07%` | min available `30753 MiB` | `loadtest/results/hot-market-burst-20260602T040136Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T040136Z-host-summary.json`; raw CSV same prefix |
+| `20260602T041807Z` | `200` | `5m` | degraded | `57542` | `191.8` | `0` | `2459` | `7.66s` | min idle `0%`; Docker CPU `795%`; Postgres `692.12%` | min available `30742 MiB` | `loadtest/results/hot-market-burst-20260602T041807Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T041807Z-host-summary.json`; raw CSV same prefix |
+| `20260602T042645Z` | `100` | `5m` | fail | `29952` | `99.8` | `48` | `0` | `88.05ms` expected responses; failed requests timed out at `1m0s` | min idle `2.68%`; Docker CPU `765.03%`; Postgres `696.55%` | min available `30925 MiB` | `loadtest/results/hot-market-burst-20260602T042645Z-summary.json`; `loadtest/hostops/hot-market-burst-loadtest-basic-amd-20260602T042645Z-host-summary.json`; raw CSV same prefix |
+
+### Database Diagnostics After Cumulative Runs
+
+Read-only diagnostics after the degraded `100` bets/sec five-minute run showed:
+
+| Diagnostic | Observation |
+| --- | --- |
+| Total `bets` rows | `258785` |
+| Hot-market distribution | ten hot markets each had approximately `25603-26141` bets |
+| `bets` table total size | `35 MB` |
+| `bets` indexes observed | `bets_pkey`, `idx_bets_deleted_at` |
+| Missing write-path index | no composite index on `(market_id, username)` |
+| Autovacuum/analyze | `bets` had recent autovacuum and autoanalyze |
+| Active DB state after settling | no persistent active backlog observed |
+
+The placement path calls `UserHasBet` on every bet:
+
+```sql
+WHERE market_id = ? AND username = ?
+```
+
+Without a composite index on that predicate, the cost of each bet can grow as the `bets` table grows. This is the leading explanation for why the host could pass one-minute bursts on a fresher dataset but later timed out at only `100` bets/sec after the cumulative bet table reached roughly `259k` rows.
 
 ## Analysis
 
-Analysis pending data collection.
+The first one-minute ladder established a clear burst profile:
+
+- `100` and `200` bets/sec were clean with low latency and substantial CPU headroom.
+- `300` bets/sec was still a clean functional pass, but CPU idle dropped to `6.68%`, so it was already near the top of the clean burst envelope.
+- `350` and `400` bets/sec remained correct at the application level but degraded through dropped iterations, multi-second p95 latency, and host CPU saturation.
+
+The five-minute confirmation runs changed the interpretation:
+
+- `300` bets/sec for `5m` degraded: `4490` dropped iterations and HTTP p95 `4.96s`.
+- `200` bets/sec for `5m` also degraded: `2459` dropped iterations and HTTP p95 `7.66s`.
+- `100` bets/sec for `5m` then produced `48` timeout failures despite low p95 among successful responses.
+
+This pattern is not simply "the host cannot do 100 bets/sec." The earlier `100` and `200` one-minute runs were clean. The later sustained failures happened after cumulative test state had inserted hundreds of thousands of hot-market bets. The database diagnostic points to a data-growth-sensitive write-path query rather than RAM pressure:
+
+- RAM remained plentiful throughout the experiment.
+- Postgres CPU repeatedly saturated multiple cores during degraded runs.
+- The `bets` table was not huge in disk terms, but the hot predicate lacked an index.
+- The hot-market workload concentrates repeated writes and lookups against the same small set of markets, making it intentionally adversarial.
+
+The current evidence supports two separate claims:
+
+1. On this resized Basic AMD shared-CPU Droplet, fresh-ish one-minute burst capacity is clean up to `300` bets/sec and degraded by `350-400` bets/sec.
+2. Sustained capacity cannot be claimed yet because cumulative bet-history growth degrades the write path. The next engineering step is to add and test the missing bet-history indexes, then rerun the sustained ladder from a reset fixture state.
 
 ## Conclusion
 
-Conclusion pending data collection.
+Preliminary conclusion:
+
+- Do not claim `500` bets/sec on this host.
+- Do not claim sustained `300` or `200` bets/sec on the current schema.
+- The best current burst claim is `300` bets/sec for `1m` on a reset or low-history dataset.
+- Sustained claims should wait for an indexed bet-history migration and fresh five-minute confirmation runs.
+
+Recommended schema investigation:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_bets_market_id_username ON bets (market_id, username);
+```
+
+Likely follow-up index for market-history reads:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_bets_market_id_placed_at_id ON bets (market_id, placed_at, id);
+```
+
+The first index directly targets `UserHasBet`, which runs during bet placement. The second targets market-scoped ordered bet reads observed in analytics and position paths. These should be implemented through the project migration system before using them as production evidence.
 
 ## Deviations
 
@@ -401,4 +473,7 @@ Record deviations here as they happen.
 
 | Time UTC | Deviation | Reason | Impact |
 | --- | --- | --- | --- |
-| TBD | TBD | TBD | TBD |
+| `2026-06-02T03:28Z` | Initial `100` bets/sec run used `--preauth-users 2000` without enough k6 setup timeout | k6 default setup timeout is `60s` | Run timed out during setup and was not counted as capacity evidence |
+| `2026-06-02T03:37Z` | First post-timeout rerun captured insufficient host telemetry | Monitor duration did not include setup/pre-auth time | k6 result was useful, but host telemetry did not cover the full burst window |
+| `2026-06-02T03:39Z` | Host monitor duration was corrected to include setup timeout | Needed telemetry covering setup plus scenario execution | Later runs have usable host telemetry summaries |
+| `2026-06-02T04:26Z` | Later sustained runs were cumulative-state tests, not fresh-reset tests | Prior runs inserted hundreds of thousands of hot-market bets | Sustained degradation may reflect schema/data-growth behavior, not only raw host capacity |

--- a/loadtest/k6/hot-market-burst.js
+++ b/loadtest/k6/hot-market-burst.js
@@ -5,8 +5,10 @@ const duration = __ENV.DURATION || '60s';
 const targetRate = Number(__ENV.TARGET_RATE || '50');
 const targetTimeUnit = __ENV.TARGET_TIME_UNIT || '1s';
 const preauthUsers = Number(__ENV.PREAUTH_USERS || '100');
+const setupTimeout = __ENV.SETUP_TIMEOUT || '5m';
 
 export const options = {
+  setupTimeout,
   scenarios: {
     hot_market_burst: {
       executor: 'constant-arrival-rate',


### PR DESCRIPTION
## Summary

This PR adds a second load-test dossier markdown notebook for the planned DigitalOcean large Basic AMD capacity experiment.

The notebook documents:
- Research question
- Hypothesis
- Experimental setup
- Constants
- Independent variables
- Dependent variables
- Controlled variables
- Rate-limit configuration
- Fixture plan
- User-load interpretation
- Procedure
- Pass / degraded / fail criteria
- Planned analysis

## Scope

This is a preparation document only. It intentionally leaves the following sections open until the experiment is run:
- Data
- Analysis
- Conclusion
- Deviations

## Planned Experiment

Target host:

```text
http://161.35.177.38
```

Planned resize target:

```text
DigitalOcean s-8vcpu-32gb-amd
```

Interpretation caveat:

```text
This is Basic AMD shared-CPU evidence, not dedicated General Purpose evidence.
```

Resize rule:

```text
Do not pass --resize-disk.
```

Proof pattern:
- One-minute discovery ladder
- Pull back from the first degradation/failure point
- Five-minute confirmation run at the highest clean candidate rate

## Verification

- `git diff --check`
