### PR TITLE
Fix suspended moderator market creation policy

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/07/07-market-stewardship.md
+++ b/README/PRODUCTION-NOTES/FEATURES/07/07-market-stewardship.md
@@ -1,0 +1,51 @@
+---
+title: Market Stewardship
+document_type: production-notes
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-03T00:00:00Z
+updated_at_display: "Wednesday, June 3, 2026"
+update_reason: "Define creator attribution versus operational market stewardship for moderator governance."
+status: draft
+---
+
+# Market Stewardship
+
+## Purpose
+
+Market creators should remain immutable for attribution, proposal-cost history, and audit context. Operational authority over a market should be assignable by admins when the original moderator is suspended, inactive, conflicted, or otherwise unavailable to resolve or maintain the market.
+
+## Ubiquitous Language
+
+- Creator: immutable original market author.
+- Steward: current moderator responsible for market-governance actions such as resolution and future edit/yank workflows.
+- Stewardship reassignment: admin action that moves operational responsibility from one steward to another without changing the creator.
+- Stewardship audit: append-only record of who reassigned stewardship, from whom, to whom, why, and when.
+
+## Rules
+
+- New markets default `steward_username` to `creator_username`.
+- Existing markets backfill steward to creator through an additive migration.
+- Creator attribution is not rewritten during stewardship changes.
+- Admins can reassign stewardship to an active moderator only.
+- Suspended moderators cannot receive stewardship and cannot use steward-only actions.
+- The current steward, not necessarily the original creator, is the moderator allowed to resolve a market.
+- Admins remain platform override authority.
+- Reassignment must persist an audit row in the same unit of work as the market update.
+
+## Design Alignment
+
+This feature follows the canonical design plan at `/Users/patrick/Projects/spec-socialpredict-tasks/lib/design/design-plan.json`:
+
+- Prediction Market Core Context owns market lifecycle and governance rules.
+- Participant Account Context owns moderator status semantics.
+- Backend Persistence and Migration Boundary owns additive timestamped Go migrations.
+- Auditability requires reconstructable governance history rather than destructive creator rewrites.
+
+## Implementation Notes
+
+- Add `markets.steward_username` with default/backfill behavior.
+- Add `market_stewardship_audits` for append-only reassignment facts.
+- Add admin API: `PATCH /v0/admin/markets/{id}/steward`.
+- Include `stewardUsername` in admin market review payloads and public market metadata.
+- Keep reassignment UI controls as a later frontend slice unless immediate admin workflow requires it.

--- a/README/PRODUCTION-NOTES/FEATURES/07/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/07/DESIGN.md
@@ -1,0 +1,32 @@
+---
+title: Market Stewardship Design
+document_type: design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-03T00:00:00Z
+status: draft
+---
+
+# Market Stewardship Design
+
+## Boundary Decisions
+
+Creator and steward are intentionally separate:
+
+- Creator is attribution and history.
+- Steward is current operational authority.
+
+The market domain owns the policy that steward authority controls market-governance actions. The account domain owns whether a moderator is active or suspended. Persistence owns additive storage and audit rows.
+
+## Invariants
+
+- A market can have only one current steward.
+- Empty steward values fall back to creator for legacy compatibility.
+- Steward reassignment must not mutate `creator_username`.
+- Steward reassignment must write an audit fact.
+- A suspended moderator cannot be assigned as steward.
+- A suspended steward cannot resolve a market.
+
+## Tradeoffs
+
+This is more schema and API surface than mutating `creator_username`, but it preserves attribution and supports future governance workflows such as overdue resolution, voluntary handoff, or conflict-of-interest reassignment.

--- a/README/PRODUCTION-NOTES/FEATURES/07/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/07/PLAN.md
@@ -1,0 +1,21 @@
+---
+title: Market Stewardship Plan
+document_type: plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-03T00:00:00Z
+status: draft
+---
+
+# Market Stewardship Plan
+
+- [x] Add additive timestamped migration for `steward_username` and stewardship audit table.
+- [x] Backfill existing markets to steward = creator.
+- [x] Add domain steward helpers and reassignment service.
+- [x] Validate new steward is an active moderator.
+- [x] Make market resolution use current steward authority.
+- [x] Add repository transaction for reassignment plus audit row.
+- [x] Add admin reassignment API.
+- [x] Expose `stewardUsername` in market review responses.
+- [ ] Add full admin UI reassignment controls.
+- [ ] Extend future edit/yank workflows to use steward authority.

--- a/README/PRODUCTION-NOTES/FEATURES/09/09-market-taxonomy-navigation.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/09-market-taxonomy-navigation.md
@@ -1,0 +1,251 @@
+---
+title: Market Taxonomy And Hierarchical Navigation
+document_type: production-notes
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-04T00:00:00Z
+updated_at_display: "Thursday, June 4, 2026"
+update_reason: "Start the feature spec for tags, category pages, featured market pinning, and CMS-driven market discovery."
+status: draft
+---
+
+# Market Taxonomy And Hierarchical Navigation
+
+## Purpose
+
+SocialPredict needs a richer market discovery model than a single `/markets` page with search and status tabs.
+
+Search should remain the primary entry point because it is direct, familiar, and works even when taxonomy content is sparse. Under that search-first entry point, the platform should support a CMS-managed market taxonomy: tags, top-level and secondary category pages, pinned featured markets, optional and curated page layouts.
+
+This feature creates the design foundation for that hierarchy before implementation.
+
+## Feature Artifact Map
+
+This directory keeps the market taxonomy/navigation feature work together:
+
+- [09-market-taxonomy-navigation.md](./09-market-taxonomy-navigation.md): feature overview, product behavior, and acceptance criteria.
+- [DESIGN.md](./DESIGN.md): domain, CMS, persistence, search, and frontend architecture design.
+- [PLAN.md](./PLAN.md): backend-first implementation checklist and PR sequencing.
+
+## Product Shape
+
+The market discovery hierarchy should support:
+
+1. A top-level `/markets` page with search as the first control.
+2. A small default recommendation panel under search, initially random active markets.
+3. CMS-pinned featured markets on the top-level page.
+4. CMS-pinned secondary category pages on the top-level page.
+5. Secondary category pages organized by tag/category.
+6. Search on each secondary page, filtered by that category/tag by default.
+7. Featured/pinned markets within a page.
+8. Market tags displayed as chips in search results, market cards, admin review, and market detail pages.
+9. Moderator-selected tags during market creation, constrained to admin-managed tags.
+10. Admin tag review during market approval.
+11. Admin-only tag creation, deletion, ordering, and page layout management.
+
+## Current Behavior
+
+Current market discovery is mostly flat:
+
+- `/markets` has a search bar and status tabs.
+- Search can query across active, closed, resolved, or all public markets.
+- Default tab content shows markets by status.
+- There is no durable category/tag vocabulary.
+- There is no CMS-managed page hierarchy.
+- There is no way to pin markets or category pages.
+- Moderator market creation does not attach category metadata.
+- Admin approval does not review tags.
+
+## Ubiquitous Language
+
+- Tag: admin-managed label that can be attached to markets and used for search/filtering.
+- Category page: CMS-managed market discovery page, usually backed by one primary tag or tag query.
+- Secondary page: category page below the top-level `/markets` page.
+- Featured market: market manually pinned to a page by an admin.
+- Featured category: secondary category page manually pinned to the top-level markets page.
+- Recommendation panel: automatic non-CMS fallback list, initially random active markets.
+- Tag chip: compact UI label that shows market tags in lists/details/review flows.
+- Taxonomy: the admin-managed set of tags, category pages, and layout rules.
+
+Avoid confusing:
+
+- Tag is not a free-form user hashtag.
+- Category page is not necessarily a backend route hardcoded in React.
+- Featured is manual CMS curation, not the same as algorithmic recommendation.
+- Recommendation is automatic fallback content, not an endorsement unless later copy says so.
+
+## Top-Level `/markets` Page
+
+Search remains first.
+
+Default layout when nothing is pinned:
+
+1. Search bar.
+2. Up to 20 recommended active markets, using the current loose/random behavior or a backend-owned equivalent.
+3. Existing status navigation remains available: Active, Closed, Resolved, All.
+
+Layout when CMS pinning exists:
+
+1. Search bar.
+2. Compact recommendation panel, about 5 markets.
+3. Featured category/page cards.
+4. Featured market cards.
+
+The top-level page should not become blank just because CMS content is empty. Search and recommendation fallback keep the page useful from day one.
+
+## Secondary Category Pages
+
+A secondary category page should feel familiar relative to the top-level page.
+
+Each secondary page should support:
+
+- search bar at the top
+- search filtered by the page's category/tag by default
+- status tabs: Active, Closed, Resolved, All
+- recommendation/fallback markets for that tag if nothing is pinned
+- pinned featured markets
+- tag chips on market cards/results
+
+Default layout when nothing is pinned:
+
+1. Category title/description.
+2. Search bar filtered to the category.
+3. Up to 20 random/recommended markets for that category.
+
+Layout when page is curated:
+
+1. Category title/description.
+2. Search bar filtered to the category.
+3. Compact recommendation panel, about 5 markets.
+4. Pinned featured markets.
+
+## Tag Assignment Flow
+
+### Moderator Create Flow
+
+Moderators should select tags from admin-managed options while creating a market.
+
+Rules:
+
+- moderators cannot create new tags
+- moderators can select one or more available tags
+- UI should support search/typeahead because tag lists can grow
+- default can be no tag only if policy allows it
+- future policy may require at least one tag before submission
+
+### Admin Review Flow
+
+Admin market review should show proposed tags.
+
+Admins should be able to:
+
+- approve tags as proposed
+- add/remove tags before approval if policy allows
+- see tag chips next to title/description/custom labels
+- treat inappropriate tags as a reason for rejection or adjustment
+
+### Published Market Display
+
+Published markets should show tag chips:
+
+- market detail page
+- `/markets` list/search results
+- category page results
+- admin review/governance tables
+- moderator profile market lists where useful
+
+## CMS And Admin Management
+
+Admins should own taxonomy management.
+
+Admin capabilities:
+
+- create tag
+- edit tag display name/slug/description/color/order
+- disable/archive tag
+- delete tag only when safe or after confirmation
+- create category page from a tag or tag query
+- pin/unpin featured markets
+- pin/unpin featured category pages
+
+Deletion requires safety guardrails:
+
+- require confirmation
+- show count of markets using the tag
+- prefer archive/disable over destructive delete
+- prevent deletion if market references exist unless a migration/removal path is explicit
+
+## Persistence Shape Candidate
+
+Candidate tables:
+
+- `market_tags`: admin-owned tag definitions.
+- `market_tag_assignments`: many-to-many relation between markets and tags.
+- `market_discovery_pages`: top/secondary page definitions.
+- `market_discovery_pins`: pinned markets and pinned category pages, ordered by admin.
+
+Important design choice: use additive timestamped Go migrations under `backend/migration/migrations`, following the existing migration convention.
+
+## Search And Recommendation
+
+Search should remain familiar.
+
+Baseline behavior:
+
+- existing market search continues to support text query and lifecycle/public status
+- add optional tag/category filter
+- tag-filtered search should use the same text matching semantics as unfiltered search
+- category pages pass their tag filter automatically
+
+Recommendation fallback can start simple:
+
+- random active markets on top-level page
+- random active markets matching the category tag on secondary pages
+- limit 20 when no pinned content exists
+- limit 5 when pinned content exists
+
+This should be backend-owned enough that frontend does not invent recommendation rules independently.
+
+## Design-Agent Cross-Reference
+
+Evans/domain posture:
+
+- Treat taxonomy terms as ubiquitous language before schema work.
+- Separate tags, category pages, featured markets, and recommendations because each has a different business meaning.
+- Do not let React route structure define the domain taxonomy.
+
+Fowler/evolutionary posture:
+
+- Start with tags and page read models before building a large CMS platform.
+- Prefer reversible admin curation tables and simple random recommendations before a real recommender system.
+- Keep a path from flat `/markets` to hierarchical pages without breaking the existing search/status tabs.
+
+Martin/clean-architecture posture:
+
+- Domain/use-case services own tag policy, page composition, and market filtering.
+- Handlers adapt HTTP to use cases; frontend consumes read models.
+- Database tables and React components are details around the taxonomy/navigation policy.
+
+## Acceptance Criteria
+
+Planning-level acceptance criteria:
+
+- Feature docs define tags, category pages, featured markets, and recommendations distinctly.
+- Database migration plan is additive and timestamped.
+- Admin ownership of tag creation/deletion is explicit.
+- Moderator tag selection is constrained to existing admin-managed tags.
+- Admin review includes tag visibility and correction path.
+- Top-level and secondary pages preserve search-first behavior.
+- Empty CMS pages remain useful through recommendation fallback.
+- Pinned content changes page layout but does not remove search.
+- Tag chips appear in relevant market display surfaces.
+
+## Out Of Scope For First Pass
+
+- Machine-learning recommendation system.
+- User-personalized recommendations.
+- Public user-created tags.
+- Tag moderation by non-admins.
+- Full drag-and-drop CMS builder.
+- SEO/URL slug migration strategy beyond basic category page slugs.
+- Analytics-driven auto pinning.

--- a/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
@@ -1,0 +1,293 @@
+---
+title: Market Taxonomy And Hierarchical Navigation Design
+document_type: feature-design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-04T00:00:00Z
+updated_at_display: "Thursday, June 4, 2026"
+update_reason: "Define backend-first taxonomy, CMS, search, recommendation, and page-composition design before implementation."
+status: draft
+---
+
+# Market Taxonomy And Hierarchical Navigation Design
+
+## Design Position
+
+Market taxonomy is a discovery and curation capability. It is not just UI decoration.
+
+Tags affect market creation, admin review, search filtering, page composition, public navigation, and future CMS layout. The backend should own tag definitions, tag assignments, page definitions, pinning, and recommendation/fallback policy. The frontend should render backend-owned read models and provide admin/moderator workflows.
+
+## Design Inputs
+
+Primary inputs:
+
+- [09-market-taxonomy-navigation.md](./09-market-taxonomy-navigation.md)
+- Canonical design plan: `/Users/patrick/Projects/spec-socialpredict-tasks/lib/design/design-plan.json`
+- Designer-agent postures from `/Users/patrick/Projects/spec-socialpredict-tasks/.codex/agents/`
+- Existing `/markets` search/status-tab behavior
+- Existing moderator create and admin review flows
+
+## Problem Framing
+
+The flat `/markets` page works as an early discovery surface because search is easy and status tabs are simple. It does not scale well once the platform has many markets across themes, leagues, geographies, communities, or product areas.
+
+The next design step is a taxonomy and page-composition model that preserves search-first discovery while allowing admins to curate market discovery pages.
+
+## Business Outcomes
+
+- Users can quickly search all markets from the top-level page.
+- Users can browse meaningful categories without knowing exact search terms.
+- Admins can curate featured markets and category pages.
+- Moderators can tag proposed markets using a controlled vocabulary.
+- Admins can review and correct tags before publication.
+- The platform can grow toward CMS-driven market pages without a large rewrite.
+
+## Boundary Alignment
+
+| Boundary | Responsibility |
+| --- | --- |
+| Prediction Market Context | Owns market-tag assignment policy and public market filtering by tags. |
+| CMS / Content Context | Owns discovery pages, page copy, pinning, and layout order. |
+| Participant Account Context | Owns admin/moderator authority facts used by taxonomy management and tag assignment workflows. |
+| API And Auth Boundary | Owns admin taxonomy endpoints, moderator create/review payloads, public page/search endpoints, and OpenAPI schemas. |
+| Frontend Experience Context | Owns top-level and secondary page presentation, tag chips, admin taxonomy UI, and moderator tag selection UI. |
+| Repository And Migration Boundary | Owns additive tag/page/pin tables and timestamped Go migrations. |
+
+## Core Domain Model
+
+### Tag
+
+Admin-managed label attached to markets.
+
+Candidate fields:
+
+- `id`
+- `slug`
+- `display_name`
+- `description`
+- `color_key` or `style_key`
+- `sort_order`
+- `is_active`
+- `created_by`
+- `created_at`
+- `updated_at`
+
+Rules:
+
+- slugs are unique and stable enough for URLs
+- display names can change
+- inactive tags remain attached historically but cannot be newly selected unless admin reactivates them
+- hard delete should be restricted when assignments exist
+
+### Market Tag Assignment
+
+Many-to-many relation between market and tag.
+
+Candidate fields:
+
+- `market_id`
+- `tag_id`
+- `assigned_by`
+- `assigned_at`
+- `source`: moderator_proposed, admin_adjusted, migration, system
+
+Rules:
+
+- assignments should be unique per market/tag
+- admin can adjust during review
+- moderator can propose only active tags
+
+### Discovery Page
+
+CMS-managed navigation page.
+
+Candidate fields:
+
+- `id`
+- `slug`
+- `title`
+- `description`
+- `page_type`: top, category
+- `primary_tag_id` nullable
+- `query_mode`: tag, tag_set, custom, all
+- `sort_order`
+
+Rules:
+
+- top page can be represented as one special page or as a conventional read model for `/markets`
+- secondary pages usually have a primary tag
+- page edits publish immediately in the current CMS model
+
+### Pin
+
+Manual CMS curation of a market or category page.
+
+Candidate fields:
+
+- `id`
+- `scope_type`: page
+- `scope_id`
+- `pin_type`: market, discovery_page
+- `market_id` nullable
+- `target_page_id` nullable
+- `sort_order`
+- `label` nullable
+- `created_by`
+- `created_at`
+
+Rules:
+
+- pinned markets must be visible/tradable or explicitly allowed by policy
+- pinned category pages must be published
+- pins are ordered manually
+- pins should degrade gracefully if a target market is cancelled/resolved/hidden
+
+## Page Composition Read Model
+
+The backend should expose a composed read model for discovery pages instead of making React assemble the taxonomy from many unrelated calls.
+
+Candidate response shape:
+
+```json
+{
+  "page": {
+    "slug": "markets",
+    "title": "Markets",
+    "description": "Browse and search markets"
+  },
+  "search": {
+    "defaultTagSlug": null,
+    "statusFilters": ["active", "closed", "resolved", "all"]
+  },
+  "recommendations": {
+    "mode": "random_active",
+    "limit": 5,
+    "markets": []
+  },
+  "featuredPages": [],
+  "featuredMarkets": []
+}
+```
+
+Frontend pages should render this read model and call search endpoints with `tag` or `page` filters.
+
+## Search Design
+
+Search remains the primary entry point.
+
+Rules:
+
+- top-level search defaults to all public markets unless status tab narrows it
+- secondary page search defaults to that page's primary tag/category
+- users can still switch Active/Closed/Resolved/All within the scoped search
+- search results include tags as chips
+- empty query falls back to recommendation/page composition, not a failed search state
+
+## Recommendation Design
+
+Initial recommendation is intentionally simple.
+
+Recommended baseline:
+
+- random active markets
+- filtered by page tag on secondary pages
+- limit 20 when no pinned content exists
+- limit 5 when pinned content exists
+
+This is a fallback/recommendation seam, not a personalized recommendation platform. Keep it small and replaceable.
+
+## Moderator And Admin Workflows
+
+### Moderator Create
+
+The create-market use case should accept tag IDs/slugs as proposed market metadata.
+
+Backend rules:
+
+- validate tags exist and are active
+- persist assignments with source `moderator_proposed`
+- reject invalid tag IDs/slugs with a public validation reason
+
+### Admin Review
+
+Admin review should display proposed tags and allow correction.
+
+Backend rules:
+
+- admin can add/remove tags while proposal is pending
+- approved market carries final tag assignments into publication
+- tag changes should be auditable or reconstructable
+
+### Admin CMS
+
+Admin taxonomy management should be separate from ordinary market review.
+
+Admin can manage:
+
+- tags
+- discovery pages
+- pins
+
+## Migration Design
+
+Use additive timestamped Go migrations under `backend/migration/migrations`.
+
+Candidate migration slices:
+
+1. Tag definitions and assignments.
+2. Market create/review/read payload support for tags.
+3. Discovery pages .
+4. Pins and page composition read model.
+
+Avoid combining all tables and all UI behavior in one PR unless the migration is purely schema-only and low-risk.
+
+## Designer Lens Review
+
+Evans/domain lens:
+
+- The domain language must distinguish tag, category page, pin, featured market, and recommendation.
+- Taxonomy is shared language between moderators, admins, and market browsers.
+- CMS curation and market lifecycle are related but not the same bounded context.
+
+Fowler/evolutionary lens:
+
+- Keep the first implementation narrow: tags plus chips, then page composition, then CMS pinning.
+- Avoid committing to a recommendation platform; random active markets are a reversible seam.
+- Composed read models reduce frontend churn while preserving an evolutionary backend path.
+
+Martin/clean-architecture lens:
+
+- Tag validation and page composition are use cases, not React conditionals.
+- Database tables are details; use cases should expose simple request/response models.
+- Admin/moderator authority is an input to use cases, not a UI-only permission flag.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| CMS scope creep | Start with tags and simple page composition; defer full page builder. |
+| Tag deletion breaks history | Prefer archive/disable; restrict delete with references. |
+| Frontend invents taxonomy rules | Backend composed read model and API contracts. |
+| Search performance degrades | Add indexes on tag assignments, slug, lifecycle/status, and consider query plans before large datasets. |
+| Confusing page/category/tag terms | Maintain glossary and display language in docs/API. |
+| Migration ordering conflicts | Stack from #734 and use timestamped additive migrations later. |
+
+## Open Questions
+
+- Should tags be single-level only, or should parent/child tag hierarchy exist?
+- Should secondary category pages always map to one tag, or support tag queries?
+- Should moderators be required to select at least one tag?
+- Can admins add tags during approval that moderators did not propose?
+- Should tags have colors from a fixed style guide or arbitrary admin-selected colors?
+- Should public users ever see inactive tags on historical markets?
+- Should cancelled/yanked markets be excluded from pins automatically?
+- Should recommendation randomness be stable per day/session or fully random per request?
+
+## Design Exit Criteria
+
+- Tag, page, pin, and recommendation language is stable enough for API names.
+- Database migration slices are chosen.
+- Backend-first API contracts are drafted before frontend UI implementation.
+- Admin tag deletion policy is decided.
+- Empty-page fallback behavior is decided.
+- Category search semantics are decided.

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -1,0 +1,181 @@
+---
+title: Market Taxonomy And Hierarchical Navigation Plan
+document_type: feature-plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-04T00:00:00Z
+updated_at_display: "Thursday, June 4, 2026"
+update_reason: "Track implementation slices for tag persistence, market discovery layout persistence, page-level CMS pins, secondary routes, and tag-scoped discovery."
+status: in-progress
+---
+
+# Market Taxonomy And Hierarchical Navigation Plan
+
+## Purpose
+
+This plan turns [09-market-taxonomy-navigation.md](./09-market-taxonomy-navigation.md) and [DESIGN.md](./DESIGN.md) into a backend-first implementation sequence.
+
+Agents implementing this feature should mark checklist items as they complete them and leave deferred work unchecked.
+
+## Planning Principles
+
+- Search stays first on top-level and secondary market pages.
+- Tags and CMS page composition are backend-owned policy/read models.
+- Admins manage tag vocabulary; moderators select from active tags.
+- Additive timestamped migrations come before UI dependencies.
+- Start with simple random active recommendations before a recommendation platform.
+- Keep pinned content manual and auditable.
+- Keep every PR independently reviewable.
+
+## 01. Feature Artifact And Design Alignment
+
+Checklist:
+
+- [x] Create `README/PRODUCTION-NOTES/FEATURES/09/`.
+- [x] Add feature overview.
+- [x] Add design artifact.
+- [x] Add implementation plan.
+- [x] Cross-reference canonical design plan and designer-agent postures.
+- [ ] Review final design with product/user-facing terminology before implementation.
+
+## 02. Tag Persistence And Domain Model
+
+Service ownership: prediction market context and repository/migration boundary.
+
+Checklist:
+
+- [x] Add timestamped migration for `market_tags`.
+- [x] Add timestamped migration for `market_tag_assignments`.
+- [x] Add indexes for tag slug and market/tag assignment lookup.
+- [x] Add domain models for tag and assignment.
+- [x] Add repository mapping tests.
+- [x] Add service policy for active tag validation.
+- [x] Prefer archive/disable over destructive delete when assignments exist.
+
+## 03. Market Create And Admin Review Tag Flow
+
+Service ownership: market creation/review use cases and API boundary.
+
+Checklist:
+
+- [x] Add tag IDs/slugs to create-market request.
+- [x] Validate moderator-selected tags exist and are active.
+- [x] Persist moderator-proposed tag assignments.
+- [x] Include tag chips/data in admin market review payloads.
+- [ ] Allow admin adjustment of tags during proposal review if policy approves.
+- [x] Include tags in published market payloads.
+- [x] Update `backend/docs/openapi.yaml`.
+- [x] Add handler/domain tests.
+- [ ] Run schemathesis/go-kin validation once OpenAPI is updated.
+
+## 04. Admin Tag Management
+
+Service ownership: CMS/content context plus API/auth boundary.
+
+Checklist:
+
+- [x] Add admin list/create/update/archive tag APIs.
+- [x] Add guarded delete or archive-only policy.
+- [ ] Show market count before destructive tag action.
+- [x] Require confirmation for delete/archive.
+- [x] Add admin dashboard tag management UI.
+- [x] Add tests for admin-only access and validation.
+
+## 05. Search And Tag Filtering
+
+Service ownership: market search/read model.
+
+Checklist:
+
+- [x] Add optional tag filter to public market search.
+- [x] Add optional tag filter to status-based market listing.
+- [x] Include tags in search/list result DTOs.
+- [x] Keep Active/Closed/Resolved/All behavior compatible.
+- [x] Add query/index tests for tag-filtered search.
+- [ ] Verify performance posture for many tags/markets.
+
+## 06. Discovery Pages
+
+Service ownership: CMS/content context and composed read model.
+
+Checklist:
+
+- [x] Add admin CMS scaffold for TOP and SECONDARY market discovery layout options.
+- [x] Add migration for `market_discovery_pages`.
+- [x] Remove unused `market_discovery_sections` scaffold.
+- [x] Add domain/read models for top-level and secondary category pages.
+- [x] Keep implicit All behavior through normal page search/status tabs.
+- [x] Add public page composition endpoint.
+- [x] Add admin page layout management API.
+- [x] Remove unused admin section management APIs.
+- [x] Add tests for page composition ordering.
+
+## 07. Pins And Featured Content
+
+Service ownership: CMS/content context.
+
+Checklist:
+
+- [x] Add migration for `market_discovery_pins`.
+- [x] Support page-level pinned markets.
+- [x] Support pinned secondary category pages on top-level page.
+- [x] Add ordering controls.
+- [ ] Define behavior for cancelled/resolved/hidden pinned targets.
+- [x] Add admin pin/unpin APIs.
+- [x] Add tests for ordering and target validation.
+
+## 08. Recommendation Fallback
+
+Service ownership: market read model and page composition use case.
+
+Checklist:
+
+- [ ] Implement random active market fallback for top-level page.
+- [ ] Implement tag-scoped random active fallback for secondary pages.
+- [ ] Use limit 20 when no pinned content exists.
+- [ ] Use limit 5 when pinned content exists.
+- [ ] Decide stable daily/session randomization versus per-request randomization.
+- [ ] Add tests for empty CMS fallback behavior.
+
+## 09. Frontend Market Discovery UX
+
+Service ownership: frontend experience context.
+
+Checklist:
+
+- [x] Add admin CMS panel that distinguishes Home Page, Market Discovery Layout, and Social Share settings.
+- [x] Update `/markets` to consume composed top-level page model.
+- [x] Preserve search-first layout.
+- [x] Render compact recommendations when pinned content exists.
+- [x] Render featured category cards.
+- [x] Render featured market cards.
+- [x] Render tag chips in search/list cards.
+- [x] Add secondary category page route/layout.
+- [x] Scope secondary-page search to page tag/category by default.
+- [x] Keep status tabs familiar across top-level and secondary pages.
+
+## 10. Moderator And Admin Frontend UX
+
+Service ownership: frontend moderator/admin workflows.
+
+Checklist:
+
+- [x] Add tag selector to moderator create market form.
+- [ ] Use typeahead/search when tags exceed a small number.
+- [x] Show selected tags before submit.
+- [x] Show proposed tags in admin review table/details.
+- [ ] Allow admin correction if backend policy supports it.
+- [x] Add tag chips on market detail page.
+- [x] Add tag chips on profile/admin lifecycle tables where useful.
+
+## Exit Criteria
+
+- Tags are durable and admin-managed.
+- Moderators can only select active existing tags.
+- Admin review surfaces proposed tags.
+- Search can be filtered by tag/category.
+- Top-level `/markets` remains useful with or without CMS pinning.
+- Secondary category pages reuse familiar search/status behavior.
+- Pinned markets/pages  are CMS-managed and ordered.
+- Empty pages fall back to recommendation content.
+- OpenAPI and tests are updated before frontend depends on new endpoints.

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -81,6 +81,8 @@ Current feature specs:
 4. **Load Testing And Release Dossier Evidence** - [`FEATURES/04/04-load-testing.md`](./FEATURES/04/04-load-testing.md), [`FEATURES/04/DESIGN.md`](./FEATURES/04/DESIGN.md), [`FEATURES/04/PLAN.md`](./FEATURES/04/PLAN.md)
 5. **Runtime Rate Limit Policy** - [`FEATURES/05/05-runtime-rate-limit-policy.md`](./FEATURES/05/05-runtime-rate-limit-policy.md), [`FEATURES/05/DESIGN.md`](./FEATURES/05/DESIGN.md), [`FEATURES/05/PLAN.md`](./FEATURES/05/PLAN.md)
 6. **Temporary Load-Test Droplets** - [`FEATURES/06/06-temporary-loadtest-droplets.md`](./FEATURES/06/06-temporary-loadtest-droplets.md), [`FEATURES/06/DESIGN.md`](./FEATURES/06/DESIGN.md), [`FEATURES/06/PLAN.md`](./FEATURES/06/PLAN.md)
+7. **Market Stewardship** - [`FEATURES/07/07-market-stewardship.md`](./FEATURES/07/07-market-stewardship.md), [`FEATURES/07/DESIGN.md`](./FEATURES/07/DESIGN.md), [`FEATURES/07/PLAN.md`](./FEATURES/07/PLAN.md)
+9. **Market Taxonomy And Hierarchical Navigation** - [`FEATURES/09/09-market-taxonomy-navigation.md`](./FEATURES/09/09-market-taxonomy-navigation.md), [`FEATURES/09/DESIGN.md`](./FEATURES/09/DESIGN.md), [`FEATURES/09/PLAN.md`](./FEATURES/09/PLAN.md)
 
 ## Implementation Priority
 

--- a/backend/cmd/devbootstrap/main.go
+++ b/backend/cmd/devbootstrap/main.go
@@ -67,6 +67,7 @@ func run() error {
 		return err
 	}
 	initialBalance := config.Economics().User.InitialAccountBalance
+	maximumDebtAllowed := config.Economics().User.MaximumDebtAllowed
 
 	users := []bootstrapUser{
 		{
@@ -83,7 +84,7 @@ func run() error {
 		username := fmt.Sprintf("%s%02d", prefix, i)
 		users = append(users, bootstrapUser{
 			username:    username,
-			displayName: fmt.Sprintf("Dev Test User %02d", i),
+			displayName: fmt.Sprintf("Dev %s User %02d", prefix, i),
 			email:       fmt.Sprintf("%s%02d@example.com", prefix, i),
 			apiKey:      fmt.Sprintf("dev-%s%02d-api-key", prefix, i),
 			userType:    "REGULAR",
@@ -102,6 +103,8 @@ func run() error {
 	fmt.Printf("Password: %s\n", password)
 	fmt.Printf("Admin: admin\n")
 	fmt.Printf("Users: %s01 through %s%02d\n", prefix, prefix, count)
+	fmt.Printf("InitialAccountBalance: %d\n", initialBalance)
+	fmt.Printf("CreditAvailableBeforeBets: %d\n", initialBalance+maximumDebtAllowed)
 	fmt.Printf("MustChangePassword: false\n")
 	return nil
 }
@@ -135,6 +138,9 @@ func upsertBootstrapUser(db *gorm.DB, seed bootstrapUser, password string, initi
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		if err := db.Create(&user).Error; err != nil {
 			return fmt.Errorf("create %s: %w", seed.username, err)
+		}
+		if err := db.Model(&models.User{}).Where("username = ?", seed.username).Update("must_change_password", false).Error; err != nil {
+			return fmt.Errorf("clear password-change flag for %s: %w", seed.username, err)
 		}
 		fmt.Printf("created %s (%s)\n", seed.username, seed.userType)
 		return nil

--- a/backend/cmd/devbootstrap/main_test.go
+++ b/backend/cmd/devbootstrap/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestUpsertBootstrapUserCreatesLoginReadyUser(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	seed := bootstrapUser{
+		username:    "testuser01",
+		displayName: "Dev Test User 01",
+		email:       "testuser01@example.com",
+		apiKey:      "dev-testuser01-api-key",
+		userType:    "REGULAR",
+		emoji:       "NONE",
+		description: "Development test user",
+	}
+
+	if err := upsertBootstrapUser(db, seed, defaultPassword, 500); err != nil {
+		t.Fatalf("upsertBootstrapUser create returned error: %v", err)
+	}
+
+	var user models.User
+	if err := db.Where("username = ?", seed.username).First(&user).Error; err != nil {
+		t.Fatalf("load bootstrapped user: %v", err)
+	}
+	if user.MustChangePassword {
+		t.Fatalf("created bootstrap user must be login-ready with must_change_password=false")
+	}
+	if !user.CheckPasswordHash(defaultPassword) {
+		t.Fatalf("created bootstrap user password should be %q", defaultPassword)
+	}
+	if user.InitialAccountBalance != 500 || user.AccountBalance != 500 {
+		t.Fatalf("created bootstrap user balances = initial %d account %d, want 500/500", user.InitialAccountBalance, user.AccountBalance)
+	}
+}
+
+func TestUpsertBootstrapUserUpdatesLoginReadyUser(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	seed := bootstrapUser{
+		username:    "testuser01",
+		displayName: "Dev Test User 01",
+		email:       "testuser01@example.com",
+		apiKey:      "dev-testuser01-api-key",
+		userType:    "REGULAR",
+		emoji:       "NONE",
+		description: "Development test user",
+	}
+	existing := modelstesting.GenerateUser(seed.username, 0)
+	existing.MustChangePassword = true
+	if err := existing.HashPassword("old-password"); err != nil {
+		t.Fatalf("hash existing password: %v", err)
+	}
+	if err := db.Create(&existing).Error; err != nil {
+		t.Fatalf("create existing user: %v", err)
+	}
+
+	if err := upsertBootstrapUser(db, seed, defaultPassword, 500); err != nil {
+		t.Fatalf("upsertBootstrapUser update returned error: %v", err)
+	}
+
+	var user models.User
+	if err := db.Where("username = ?", seed.username).First(&user).Error; err != nil {
+		t.Fatalf("load bootstrapped user: %v", err)
+	}
+	if user.MustChangePassword {
+		t.Fatalf("updated bootstrap user must be login-ready with must_change_password=false")
+	}
+	if !user.CheckPasswordHash(defaultPassword) {
+		t.Fatalf("updated bootstrap user password should be reset to %q", defaultPassword)
+	}
+	if user.InitialAccountBalance != 500 || user.AccountBalance != 500 {
+		t.Fatalf("updated bootstrap user balances = initial %d account %d, want 500/500", user.InitialAccountBalance, user.AccountBalance)
+	}
+}

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -3389,7 +3389,7 @@ components:
 
     LoginResult:
       type: object
-      required: [token, username, usertype, mustChangePassword]
+      required: [token, username, usertype, moderatorStatus, mustChangePassword]
       properties:
         token:
           type: string
@@ -3397,6 +3397,9 @@ components:
           type: string
         usertype:
           type: string
+        moderatorStatus:
+          type: string
+          enum: [none, active, suspended]
         mustChangePassword:
           type: boolean
 
@@ -3803,6 +3806,9 @@ components:
           type: string
         usertype:
           type: string
+        moderatorStatus:
+          type: string
+          enum: [none, active, suspended]
         initialAccountBalance:
           type: integer
           format: int64

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -153,6 +153,7 @@ x-route-family-migration-matrix:
         - /v0/markets/{id}/resolve
         - /v0/markets/{id}/leaderboard
         - /v0/markets/{id}/projection
+        - /v0/market-tags
         - /v0/marketprojection/{marketId}/{amount}/{outcome}
         - /v0/marketprojection/{marketId}/{amount}/{outcome}/
       success_contract: mixed raw JSON DTO, no-content action, and selected envelope results
@@ -221,8 +222,15 @@ x-route-family-migration-matrix:
         - /v0/admin/markets
         - /v0/admin/markets/{id}/approve
         - /v0/admin/markets/{id}/reject
+        - /v0/admin/markets/{id}/steward
+        - /v0/admin/markets/{id}/tags
+        - /v0/admin/market-tags
+        - /v0/admin/market-tags/{slug}
         - /v0/content/home
         - /v0/admin/content/home
+        - /v0/content/market-discovery/{slug}
+        - /v0/admin/content/market-discovery/{slug}
+        - /v0/admin/content/market-discovery/{slug}/pins
         - /v0/content/social-share
         - /v0/content/social-share/image
         - /v0/admin/content/social-share
@@ -498,6 +506,12 @@ paths:
           schema:
             type: string
         - in: query
+          name: tagSlug
+          required: false
+          description: Only include markets assigned to the given market tag slug.
+          schema:
+            type: string
+        - in: query
           name: limit
           required: false
           description: Maximum number of markets to return.
@@ -598,6 +612,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReasonResponse'
 
+  /v0/market-tags:
+    get:
+      tags: [Markets]
+      operationId: listMarketTags
+      summary: List active market tags
+      description: Returns active admin-managed market taxonomy tags available for moderator market creation and public display.
+      responses:
+        '200':
+          description: Active market tags returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagsEnvelopeResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected server error while listing tags.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
   /v0/markets/search:
     get:
       tags: [Markets]
@@ -631,6 +671,12 @@ paths:
           schema:
             type: string
             enum: [active, closed, resolved, all]
+        - in: query
+          name: tagSlug
+          required: false
+          description: Only search markets assigned to the given market tag slug.
+          schema:
+            type: string
         - in: query
           name: limit
           required: false
@@ -2186,6 +2232,11 @@ paths:
           schema:
             type: string
             enum: [ADMIN, REGULAR, MODERATOR]
+        - in: query
+          name: query
+          schema:
+            type: string
+          description: Optional case-insensitive search across username, display name, and email.
       responses:
         '200':
           description: Admin user queue returned.
@@ -2448,6 +2499,7 @@ paths:
           schema:
             type: integer
             format: int64
+            minimum: 1
       requestBody:
         required: true
         content:
@@ -2519,6 +2571,7 @@ paths:
           schema:
             type: integer
             format: int64
+            minimum: 1
       requestBody:
         required: true
         content:
@@ -2570,6 +2623,305 @@ paths:
                 $ref: '#/components/schemas/ReasonResponse'
         '500':
           description: Unexpected rejection failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/markets/{id}/steward:
+    patch:
+      tags: [Markets]
+      operationId: reassignMarketSteward
+      summary: Reassign market steward
+      description: Admin-only endpoint that assigns operational market stewardship to an active moderator without changing immutable creator attribution.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminReassignMarketStewardRequest'
+      responses:
+        '200':
+          description: Market steward reassigned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketReviewEnvelopeResponse'
+        '400':
+          description: Invalid market ID, malformed request, missing steward, or missing reason.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required or target steward is not an active moderator.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '404':
+          description: Market or target steward user was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected stewardship reassignment failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/markets/{id}/tags:
+    patch:
+      tags: [Markets]
+      operationId: updateAdminMarketTags
+      summary: Update market tag assignments
+      description: >
+        Admin-only endpoint that rewrites active tag assignments for proposed
+        or published markets. This adjusts market taxonomy without changing the
+        tag vocabulary itself.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminUpdateMarketTagsRequest'
+      responses:
+        '200':
+          description: Market tag assignments updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketReviewEnvelopeResponse'
+        '400':
+          description: Invalid market ID, malformed request, unknown tag, inactive tag, or too many tags.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '404':
+          description: Market was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '409':
+          description: Market is not proposed or published.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag assignment update failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/market-tags:
+    get:
+      tags: [Markets]
+      operationId: listAdminMarketTags
+      summary: List admin market tags
+      description: Admin-only endpoint for listing active and inactive market taxonomy tags.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: includeInactive
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Market tags returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagsEnvelopeResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag listing failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+    post:
+      tags: [Markets]
+      operationId: createAdminMarketTag
+      summary: Create market tag
+      description: Admin-only endpoint for creating a market taxonomy tag.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminMarketTagRequest'
+      responses:
+        '201':
+          description: Market tag created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagEnvelopeResponse'
+        '400':
+          description: Invalid tag fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag creation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/market-tags/{slug}:
+    patch:
+      tags: [Markets]
+      operationId: updateAdminMarketTag
+      summary: Update or archive market tag
+      description: >
+        Admin-only endpoint for updating tag metadata or archiving/reactivating
+        a tag. Deactivation requires `confirmDeactivate: true`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminMarketTagRequest'
+      responses:
+        '200':
+          description: Market tag updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagEnvelopeResponse'
+        '400':
+          description: Invalid tag fields or missing deactivation confirmation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag update failure.
           content:
             application/json:
               schema:
@@ -2783,6 +3135,139 @@ paths:
                 $ref: '#/components/schemas/HomeContentEnvelopeResponse'
         '400':
           description: Invalid request body or update failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required or password change is still required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/content/market-discovery/{slug}:
+    get:
+      tags: [Content]
+      operationId: getMarketDiscoveryPage
+      summary: Get public market discovery page layout
+      description: Retrieves CMS-configured TOP or SECONDARY market discovery layout settings.
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          description: "`markets` for the TOP page, `topic-template` for the default secondary layout, or any topic/tag slug for a secondary page."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Market discovery page layout returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
+        '400':
+          description: Invalid page slug.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/content/market-discovery/{slug}:
+    put:
+      tags: [Content]
+      operationId: updateMarketDiscoveryPage
+      summary: Update market discovery page layout
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            enum: [markets, topic-template]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketDiscoveryPageUpdateRequest'
+      responses:
+        '200':
+          description: Market discovery page layout updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
+        '400':
+          description: Invalid request body or update failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required or password change is still required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+
+  /v0/admin/content/market-discovery/{slug}/pins:
+    put:
+      tags: [Content]
+      operationId: replaceMarketDiscoveryPins
+      summary: Replace market discovery page pins
+      description: Replaces ordered page-level featured market and featured topic pins for a market discovery page.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            enum: [markets, topic-template]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketDiscoveryPinsUpdateRequest'
+      responses:
+        '200':
+          description: Market discovery pins updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
+        '400':
+          description: Invalid request body or pin validation failure.
           content:
             application/json:
               schema:
@@ -3259,6 +3744,16 @@ components:
           $ref: '#/components/schemas/HomeContent'
       required: [ok, result]
 
+    MarketDiscoveryPageEnvelopeResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        result:
+          $ref: '#/components/schemas/MarketDiscoveryPage'
+      required: [ok, result]
+
     SocialShareSettingsEnvelopeResponse:
       type: object
       properties:
@@ -3424,6 +3919,90 @@ components:
         noLabel:
           type: string
           maxLength: 20
+        tagSlugs:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+            pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+
+    AdminMarketTagRequest:
+      type: object
+      properties:
+        slug:
+          type: string
+          maxLength: 64
+          pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+        displayName:
+          type: string
+          maxLength: 120
+        description:
+          type: string
+          maxLength: 500
+        colorKey:
+          type: string
+          maxLength: 40
+          pattern: '^[a-z0-9_-]*$'
+        sortOrder:
+          type: integer
+        isActive:
+          type: boolean
+        confirmDeactivate:
+          type: boolean
+          description: Required as true when setting `isActive` to false.
+
+    MarketTagResponse:
+      type: object
+      required: [id, slug, displayName, sortOrder, isActive]
+      properties:
+        id:
+          type: integer
+          format: int64
+        slug:
+          type: string
+        displayName:
+          type: string
+        description:
+          type: string
+        colorKey:
+          type: string
+        sortOrder:
+          type: integer
+        isActive:
+          type: boolean
+        createdBy:
+          type: string
+
+    MarketTagsResponse:
+      type: object
+      required: [tags, total]
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
+        total:
+          type: integer
+
+    MarketTagsEnvelopeResponse:
+      type: object
+      required: [ok, result]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        result:
+          $ref: '#/components/schemas/MarketTagsResponse'
+
+    MarketTagEnvelopeResponse:
+      type: object
+      required: [ok, result]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        result:
+          $ref: '#/components/schemas/MarketTagResponse'
 
     MarketResponse:
       type: object
@@ -3441,6 +4020,8 @@ components:
           type: string
           format: date-time
         creatorUsername:
+          type: string
+        stewardUsername:
           type: string
         yesLabel:
           type: string
@@ -3478,6 +4059,10 @@ components:
         updatedAt:
           type: string
           format: date-time
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
 
     CreatorResponse:
       type: object
@@ -3567,6 +4152,8 @@ components:
           format: float
         creatorUsername:
           type: string
+        stewardUsername:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -3574,6 +4161,10 @@ components:
           type: string
         noLabel:
           type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
 
     ProbabilityChange:
       type: object
@@ -4027,6 +4618,31 @@ components:
           minLength: 1
           description: Admin-visible reason for rejecting the proposal.
 
+    AdminReassignMarketStewardRequest:
+      type: object
+      required: [stewardUsername, reason]
+      properties:
+        stewardUsername:
+          type: string
+          minLength: 1
+          description: Active moderator username that should steward the market.
+        reason:
+          type: string
+          minLength: 1
+          description: Admin-visible audit reason for stewardship reassignment.
+
+    AdminUpdateMarketTagsRequest:
+      type: object
+      required: [tagSlugs]
+      properties:
+        tagSlugs:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+            pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+          description: Active market tag slugs to assign; an empty list removes all tag assignments.
+
     MarketReviewResponse:
       type: object
       required: [id, status, lifecycleStatus]
@@ -4039,6 +4655,8 @@ components:
         description:
           type: string
         creatorUsername:
+          type: string
+        stewardUsername:
           type: string
         yesLabel:
           type: string
@@ -4076,6 +4694,10 @@ components:
         resolutionDateTime:
           type: string
           format: date-time
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
 
     MarketLifecycleListResponse:
       type: object
@@ -4419,6 +5041,115 @@ components:
         version:
           type: integer
           format: int64
+
+    MarketDiscoveryPage:
+      type: object
+      properties:
+        slug:
+          type: string
+        title:
+          type: string
+          maxLength: 160
+        description:
+          type: string
+          maxLength: 500
+        pageType:
+          type: string
+          enum: [top, secondary]
+        primaryTagSlug:
+          type: string
+        searchScope:
+          type: string
+          enum: [all, tag]
+        featuredTopicsEnabled:
+          type: boolean
+        featuredMarketsEnabled:
+          type: boolean
+        defaultRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        curatedRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        recommendationLimit:
+          type: integer
+          description: Effective fallback market list size for the current layout.
+        version:
+          type: integer
+          format: int64
+        updatedAt:
+          type: string
+          format: date-time
+        pins:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketDiscoveryPin'
+
+    MarketDiscoveryPin:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        pinType:
+          type: string
+          enum: [market, discovery_page]
+        marketId:
+          type: integer
+          format: int64
+        targetPageSlug:
+          type: string
+          maxLength: 96
+        label:
+          type: string
+          maxLength: 160
+        sortOrder:
+          type: integer
+
+    MarketDiscoveryPageUpdateRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          maxLength: 160
+        description:
+          type: string
+          maxLength: 500
+        pageType:
+          type: string
+          enum: [top, secondary]
+        primaryTagSlug:
+          type: string
+        searchScope:
+          type: string
+          enum: [all, tag]
+        featuredTopicsEnabled:
+          type: boolean
+        featuredMarketsEnabled:
+          type: boolean
+        defaultRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        curatedRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        version:
+          type: integer
+          format: int64
+
+    MarketDiscoveryPinsUpdateRequest:
+      type: object
+      properties:
+        pins:
+          type: array
+          maxItems: 48
+          items:
+            $ref: '#/components/schemas/MarketDiscoveryPin'
+      required: [pins]
 
     SocialShareSettings:
       type: object

--- a/backend/handlers/admin/market_review.go
+++ b/backend/handlers/admin/market_review.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -26,6 +27,14 @@ type marketReviewLister interface {
 	ListLifecycleMarkets(ctx context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error)
 }
 
+type marketStewardReassigner interface {
+	ReassignMarketSteward(ctx context.Context, marketID int64, newStewardUsername string, actorUsername string, reason string) (*dmarkets.Market, error)
+}
+
+type marketTagAdjuster interface {
+	UpdateMarketTags(ctx context.Context, marketID int64, tagSlugs []string, actorUsername string) (*dmarkets.Market, error)
+}
+
 type approveMarketRequest struct {
 	Confirm bool `json:"confirm"`
 }
@@ -34,24 +43,46 @@ type rejectMarketRequest struct {
 	Reason string `json:"reason"`
 }
 
+type reassignMarketStewardRequest struct {
+	StewardUsername string `json:"stewardUsername"`
+	Reason          string `json:"reason"`
+}
+
+type updateMarketTagsRequest struct {
+	TagSlugs []string `json:"tagSlugs"`
+}
+
 type marketReviewResponse struct {
-	ID                 int64      `json:"id"`
-	QuestionTitle      string     `json:"questionTitle,omitempty"`
-	Description        string     `json:"description,omitempty"`
-	CreatorUsername    string     `json:"creatorUsername,omitempty"`
-	YesLabel           string     `json:"yesLabel,omitempty"`
-	NoLabel            string     `json:"noLabel,omitempty"`
-	Status             string     `json:"status"`
-	LifecycleStatus    string     `json:"lifecycleStatus"`
-	ApprovedBy         string     `json:"approvedBy,omitempty"`
-	ApprovedAt         *time.Time `json:"approvedAt,omitempty"`
-	RejectedBy         string     `json:"rejectedBy,omitempty"`
-	RejectedAt         *time.Time `json:"rejectedAt,omitempty"`
-	RejectionReason    string     `json:"rejectionReason,omitempty"`
-	ProposalCost       int64      `json:"proposalCost,omitempty"`
-	CreatedAt          time.Time  `json:"createdAt,omitempty"`
-	UpdatedAt          time.Time  `json:"updatedAt,omitempty"`
-	ResolutionDateTime time.Time  `json:"resolutionDateTime,omitempty"`
+	ID                 int64                            `json:"id"`
+	QuestionTitle      string                           `json:"questionTitle,omitempty"`
+	Description        string                           `json:"description,omitempty"`
+	CreatorUsername    string                           `json:"creatorUsername,omitempty"`
+	StewardUsername    string                           `json:"stewardUsername,omitempty"`
+	YesLabel           string                           `json:"yesLabel,omitempty"`
+	NoLabel            string                           `json:"noLabel,omitempty"`
+	Status             string                           `json:"status"`
+	LifecycleStatus    string                           `json:"lifecycleStatus"`
+	ApprovedBy         string                           `json:"approvedBy,omitempty"`
+	ApprovedAt         *time.Time                       `json:"approvedAt,omitempty"`
+	RejectedBy         string                           `json:"rejectedBy,omitempty"`
+	RejectedAt         *time.Time                       `json:"rejectedAt,omitempty"`
+	RejectionReason    string                           `json:"rejectionReason,omitempty"`
+	ProposalCost       int64                            `json:"proposalCost,omitempty"`
+	StewardshipAudits  []marketStewardshipAuditResponse `json:"stewardshipAudits,omitempty"`
+	Tags               []marketTagResponse              `json:"tags,omitempty"`
+	CreatedAt          time.Time                        `json:"createdAt,omitempty"`
+	UpdatedAt          time.Time                        `json:"updatedAt,omitempty"`
+	ResolutionDateTime time.Time                        `json:"resolutionDateTime,omitempty"`
+}
+
+type marketStewardshipAuditResponse struct {
+	ID                  int64     `json:"id,omitempty"`
+	MarketID            int64     `json:"marketId"`
+	FromStewardUsername string    `json:"fromStewardUsername,omitempty"`
+	ToStewardUsername   string    `json:"toStewardUsername"`
+	ActorUsername       string    `json:"actorUsername"`
+	Reason              string    `json:"reason,omitempty"`
+	CreatedAt           time.Time `json:"createdAt,omitempty"`
 }
 
 type marketReviewListResponse struct {
@@ -160,6 +191,72 @@ func RejectMarketHandler(svc marketReviewer, auth authsvc.Authenticator) http.Ha
 	}
 }
 
+func ReassignMarketStewardHandler(svc marketStewardReassigner, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		admin, ok := requireAdminForMarketReview(w, r, auth)
+		if !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		marketID, ok := marketIDFromRequest(w, r)
+		if !ok {
+			return
+		}
+		var req reassignMarketStewardRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+			return
+		}
+
+		market, err := svc.ReassignMarketSteward(r.Context(), marketID, req.StewardUsername, admin.Username, req.Reason)
+		if err != nil {
+			writeMarketReviewError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, marketReviewResponseFromMarket(market))
+	}
+}
+
+func UpdateMarketTagsHandler(svc marketTagAdjuster, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		admin, ok := requireAdminForMarketReview(w, r, auth)
+		if !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		marketID, ok := marketIDFromRequest(w, r)
+		if !ok {
+			return
+		}
+		var req updateMarketTagsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+			return
+		}
+
+		market, err := svc.UpdateMarketTags(r.Context(), marketID, req.TagSlugs, admin.Username)
+		if err != nil {
+			writeMarketReviewError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, marketReviewResponseFromMarket(market))
+	}
+}
+
 func requireAdminForMarketReview(w http.ResponseWriter, r *http.Request, auth authsvc.Authenticator) (*dusers.User, bool) {
 	if auth == nil {
 		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
@@ -186,6 +283,8 @@ func writeMarketReviewError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, dmarkets.ErrMarketNotFound):
 		_ = handlers.WriteFailure(w, http.StatusNotFound, handlers.ReasonMarketNotFound)
+	case errors.Is(err, dmarkets.ErrUserNotFound):
+		_ = handlers.WriteFailure(w, http.StatusNotFound, handlers.ReasonUserNotFound)
 	case errors.Is(err, dmarkets.ErrUnauthorized):
 		_ = handlers.WriteFailure(w, http.StatusForbidden, handlers.ReasonAuthorizationDenied)
 	case errors.Is(err, dmarkets.ErrInvalidState):
@@ -206,6 +305,7 @@ func marketReviewResponseFromMarket(market *dmarkets.Market) marketReviewRespons
 		QuestionTitle:      market.QuestionTitle,
 		Description:        market.Description,
 		CreatorUsername:    market.CreatorUsername,
+		StewardUsername:    market.CurrentStewardUsername(),
 		YesLabel:           market.YesLabel,
 		NoLabel:            market.NoLabel,
 		Status:             market.Status,
@@ -216,10 +316,31 @@ func marketReviewResponseFromMarket(market *dmarkets.Market) marketReviewRespons
 		RejectedAt:         market.RejectedAt,
 		RejectionReason:    market.RejectionReason,
 		ProposalCost:       market.ProposalCost,
+		StewardshipAudits:  marketStewardshipAuditResponsesFromRecords(market.StewardshipAudits),
+		Tags:               marketTagResponses(market.Tags),
 		CreatedAt:          market.CreatedAt,
 		UpdatedAt:          market.UpdatedAt,
 		ResolutionDateTime: market.ResolutionDateTime,
 	}
+}
+
+func marketStewardshipAuditResponsesFromRecords(records []dmarkets.MarketStewardshipAuditRecord) []marketStewardshipAuditResponse {
+	if len(records) == 0 {
+		return nil
+	}
+	responses := make([]marketStewardshipAuditResponse, 0, len(records))
+	for _, record := range records {
+		responses = append(responses, marketStewardshipAuditResponse{
+			ID:                  record.ID,
+			MarketID:            record.MarketID,
+			FromStewardUsername: record.FromStewardUsername,
+			ToStewardUsername:   record.ToStewardUsername,
+			ActorUsername:       record.ActorUsername,
+			Reason:              record.Reason,
+			CreatedAt:           record.CreatedAt,
+		})
+	}
+	return responses
 }
 
 func parseAdminReviewMarketFilters(w http.ResponseWriter, r *http.Request) (dmarkets.ListFilters, bool) {
@@ -229,14 +350,21 @@ func parseAdminReviewMarketFilters(w http.ResponseWriter, r *http.Request) (dmar
 		status = dmarkets.MarketLifecycleProposed
 	}
 	switch status {
-	case dmarkets.MarketLifecycleProposed, dmarkets.MarketLifecyclePublished, dmarkets.MarketLifecycleRejected:
+	case dmarkets.MarketStatusAll, dmarkets.MarketLifecycleProposed, dmarkets.MarketLifecyclePublished, dmarkets.MarketLifecycleRejected, dmarkets.MarketLifecycleClosed, dmarkets.MarketLifecycleResolved:
 	default:
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return dmarkets.ListFilters{}, false
+	}
+
+	searchQuery := strings.TrimSpace(query.Get("query"))
+	if len(searchQuery) > 100 {
 		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
 		return dmarkets.ListFilters{}, false
 	}
 
 	return dmarkets.ListFilters{
 		Status: status,
+		Query:  searchQuery,
 		Limit:  boundedAdminReviewInt(query.Get("limit"), 50, 1, 100),
 		Offset: boundedAdminReviewInt(query.Get("offset"), 0, 0, 100000),
 	}, true

--- a/backend/handlers/admin/market_review_test.go
+++ b/backend/handlers/admin/market_review_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -17,9 +18,11 @@ import (
 )
 
 type marketReviewServiceMock struct {
-	approveFn func(context.Context, int64, string, bool) (*dmarkets.Market, error)
-	rejectFn  func(context.Context, int64, string, string) (*dmarkets.Market, error)
-	listFn    func(context.Context, dmarkets.ListFilters) ([]*dmarkets.Market, error)
+	approveFn  func(context.Context, int64, string, bool) (*dmarkets.Market, error)
+	rejectFn   func(context.Context, int64, string, string) (*dmarkets.Market, error)
+	listFn     func(context.Context, dmarkets.ListFilters) ([]*dmarkets.Market, error)
+	reassignFn func(context.Context, int64, string, string, string) (*dmarkets.Market, error)
+	tagsFn     func(context.Context, int64, []string, string) (*dmarkets.Market, error)
 }
 
 func (m marketReviewServiceMock) ApproveProposedMarket(ctx context.Context, marketID int64, actorUsername string, confirmed bool) (*dmarkets.Market, error) {
@@ -32,6 +35,14 @@ func (m marketReviewServiceMock) RejectProposedMarket(ctx context.Context, marke
 
 func (m marketReviewServiceMock) ListLifecycleMarkets(ctx context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error) {
 	return m.listFn(ctx, filters)
+}
+
+func (m marketReviewServiceMock) ReassignMarketSteward(ctx context.Context, marketID int64, newStewardUsername string, actorUsername string, reason string) (*dmarkets.Market, error) {
+	return m.reassignFn(ctx, marketID, newStewardUsername, actorUsername, reason)
+}
+
+func (m marketReviewServiceMock) UpdateMarketTags(ctx context.Context, marketID int64, tagSlugs []string, actorUsername string) (*dmarkets.Market, error) {
+	return m.tagsFn(ctx, marketID, tagSlugs, actorUsername)
 }
 
 type marketReviewAuthMock struct {
@@ -106,6 +117,7 @@ func TestRejectMarketHandlerRejectsProposal(t *testing.T) {
 }
 
 func TestListReviewMarketsHandlerReturnsQueue(t *testing.T) {
+	changedAt := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	svc := marketReviewServiceMock{
 		listFn: func(_ context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error) {
 			if filters.Status != dmarkets.MarketLifecycleProposed || filters.Limit != 25 || filters.Offset != 5 {
@@ -115,10 +127,20 @@ func TestListReviewMarketsHandlerReturnsQueue(t *testing.T) {
 				ID:              44,
 				QuestionTitle:   "Queue item",
 				CreatorUsername: "moderator",
+				StewardUsername: "backup",
 				YesLabel:        "BIG",
 				NoLabel:         "SMALL",
 				Status:          dmarkets.MarketLifecycleProposed,
 				LifecycleStatus: dmarkets.MarketLifecycleProposed,
+				StewardshipAudits: []dmarkets.MarketStewardshipAuditRecord{{
+					ID:                  9,
+					MarketID:            44,
+					FromStewardUsername: "moderator",
+					ToStewardUsername:   "backup",
+					ActorUsername:       "admin",
+					Reason:              "moderator inactive",
+					CreatedAt:           changedAt,
+				}},
 			}}, nil
 		},
 	}
@@ -138,8 +160,129 @@ func TestListReviewMarketsHandlerReturnsQueue(t *testing.T) {
 	if !envelope.OK || envelope.Result.Total != 1 || envelope.Result.Markets[0].CreatorUsername != "moderator" {
 		t.Fatalf("unexpected response: %+v", envelope)
 	}
+	if envelope.Result.Markets[0].StewardUsername != "backup" {
+		t.Fatalf("expected steward in admin queue response, got %+v", envelope.Result.Markets[0])
+	}
 	if envelope.Result.Markets[0].YesLabel != "BIG" || envelope.Result.Markets[0].NoLabel != "SMALL" {
 		t.Fatalf("expected custom labels in admin queue response, got %+v", envelope.Result.Markets[0])
+	}
+	audits := envelope.Result.Markets[0].StewardshipAudits
+	if len(audits) != 1 || audits[0].Reason != "moderator inactive" || audits[0].FromStewardUsername != "moderator" || audits[0].ToStewardUsername != "backup" || !audits[0].CreatedAt.Equal(changedAt) {
+		t.Fatalf("expected stewardship audit in admin queue response, got %+v", audits)
+	}
+}
+
+func TestListReviewMarketsHandlerSupportsAllStatusSearch(t *testing.T) {
+	svc := marketReviewServiceMock{
+		listFn: func(_ context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error) {
+			if filters.Status != dmarkets.MarketStatusAll || filters.Query != "orchard" || filters.Limit != 100 || filters.Offset != 0 {
+				t.Fatalf("unexpected filters: %+v", filters)
+			}
+			return []*dmarkets.Market{{
+				ID:              45,
+				QuestionTitle:   "Orchard market",
+				CreatorUsername: "moderator",
+				Status:          dmarkets.MarketStatusResolved,
+				LifecycleStatus: dmarkets.MarketLifecycleResolved,
+			}}, nil
+		},
+	}
+	handler := ListReviewMarketsHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := httptest.NewRequest(http.MethodGet, "/v0/admin/markets?status=all&query=orchard&limit=100", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope handlers.SuccessEnvelope[marketReviewListResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.OK || envelope.Result.Total != 1 || envelope.Result.Markets[0].LifecycleStatus != dmarkets.MarketLifecycleResolved {
+		t.Fatalf("unexpected response: %+v", envelope)
+	}
+}
+
+func TestReassignMarketStewardHandlerReassignsSteward(t *testing.T) {
+	changedAt := time.Date(2026, 6, 4, 13, 0, 0, 0, time.UTC)
+	svc := marketReviewServiceMock{
+		reassignFn: func(_ context.Context, marketID int64, newStewardUsername string, actorUsername string, reason string) (*dmarkets.Market, error) {
+			if marketID != 45 || newStewardUsername != "backup" || actorUsername != "admin" || reason != "moderator inactive" {
+				t.Fatalf("unexpected reassign args: id=%d steward=%q actor=%q reason=%q", marketID, newStewardUsername, actorUsername, reason)
+			}
+			return &dmarkets.Market{
+				ID:              marketID,
+				CreatorUsername: "moderator",
+				StewardUsername: newStewardUsername,
+				Status:          dmarkets.MarketStatusActive,
+				LifecycleStatus: dmarkets.MarketLifecyclePublished,
+				StewardshipAudits: []dmarkets.MarketStewardshipAuditRecord{{
+					MarketID:            marketID,
+					FromStewardUsername: "moderator",
+					ToStewardUsername:   newStewardUsername,
+					ActorUsername:       actorUsername,
+					Reason:              reason,
+					CreatedAt:           changedAt,
+				}},
+			}, nil
+		},
+	}
+	handler := ReassignMarketStewardHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodPatch, "/v0/admin/markets/45/steward", bytes.NewBufferString(`{"stewardUsername":"backup","reason":"moderator inactive"}`)), map[string]string{"id": "45"})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope handlers.SuccessEnvelope[marketReviewResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.OK || envelope.Result.StewardUsername != "backup" || envelope.Result.CreatorUsername != "moderator" {
+		t.Fatalf("unexpected response: %+v", envelope)
+	}
+	if len(envelope.Result.StewardshipAudits) != 1 || envelope.Result.StewardshipAudits[0].Reason != "moderator inactive" {
+		t.Fatalf("expected stewardship audit in response, got %+v", envelope.Result.StewardshipAudits)
+	}
+}
+
+func TestUpdateMarketTagsHandlerRewritesMarketTags(t *testing.T) {
+	svc := marketReviewServiceMock{
+		tagsFn: func(_ context.Context, marketID int64, tagSlugs []string, actorUsername string) (*dmarkets.Market, error) {
+			if marketID != 46 || actorUsername != "admin" || len(tagSlugs) != 2 || tagSlugs[0] != "sports" || tagSlugs[1] != "policy" {
+				t.Fatalf("unexpected tag update args: id=%d actor=%q slugs=%+v", marketID, actorUsername, tagSlugs)
+			}
+			return &dmarkets.Market{
+				ID:              marketID,
+				QuestionTitle:   "Tagged market",
+				Status:          dmarkets.MarketStatusActive,
+				LifecycleStatus: dmarkets.MarketLifecyclePublished,
+				Tags: []dmarkets.MarketTag{
+					{ID: 1, Slug: "policy", DisplayName: "Policy", IsActive: true},
+					{ID: 2, Slug: "sports", DisplayName: "Sports", IsActive: true},
+				},
+			}, nil
+		},
+	}
+	handler := UpdateMarketTagsHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodPatch, "/v0/admin/markets/46/tags", bytes.NewBufferString(`{"tagSlugs":["sports","policy"]}`)), map[string]string{"id": "46"})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope handlers.SuccessEnvelope[marketReviewResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.OK || len(envelope.Result.Tags) != 2 || envelope.Result.Tags[0].Slug != "policy" {
+		t.Fatalf("unexpected response: %+v", envelope)
 	}
 }
 

--- a/backend/handlers/admin/market_tags.go
+++ b/backend/handlers/admin/market_tags.go
@@ -1,0 +1,177 @@
+package adminhandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"socialpredict/handlers"
+	dmarkets "socialpredict/internal/domain/markets"
+	authsvc "socialpredict/internal/service/auth"
+)
+
+type marketTagManager interface {
+	ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error)
+	CreateMarketTag(ctx context.Context, req dmarkets.MarketTagRequest, actorUsername string) (*dmarkets.MarketTag, error)
+	UpdateMarketTag(ctx context.Context, slug string, req dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error)
+}
+
+type adminMarketTagRequest struct {
+	Slug              string `json:"slug"`
+	DisplayName       string `json:"displayName"`
+	Description       string `json:"description"`
+	ColorKey          string `json:"colorKey"`
+	SortOrder         int    `json:"sortOrder"`
+	IsActive          *bool  `json:"isActive"`
+	ConfirmDeactivate bool   `json:"confirmDeactivate"`
+}
+
+type marketTagResponse struct {
+	ID          int64  `json:"id"`
+	Slug        string `json:"slug"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description,omitempty"`
+	ColorKey    string `json:"colorKey,omitempty"`
+	SortOrder   int    `json:"sortOrder"`
+	IsActive    bool   `json:"isActive"`
+	CreatedBy   string `json:"createdBy,omitempty"`
+}
+
+type marketTagsResponse struct {
+	Tags  []marketTagResponse `json:"tags"`
+	Total int                 `json:"total"`
+}
+
+func ListAdminMarketTagsHandler(svc marketTagManager, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		if _, ok := requireAdminForMarketReview(w, r, auth); !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+
+		includeInactive, _ := strconv.ParseBool(r.URL.Query().Get("includeInactive"))
+		tags, err := svc.ListMarketTags(r.Context(), includeInactive)
+		if err != nil {
+			writeMarketTagError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, marketTagsResponse{
+			Tags:  marketTagResponses(tags),
+			Total: len(tags),
+		})
+	}
+}
+
+func CreateAdminMarketTagHandler(svc marketTagManager, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		admin, ok := requireAdminForMarketReview(w, r, auth)
+		if !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+
+		var req adminMarketTagRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+			return
+		}
+		tag, err := svc.CreateMarketTag(r.Context(), marketTagRequestFromAdmin(req), admin.Username)
+		if err != nil {
+			writeMarketTagError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusCreated, marketTagResponseFromDomain(*tag))
+	}
+}
+
+func UpdateAdminMarketTagHandler(svc marketTagManager, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		if _, ok := requireAdminForMarketReview(w, r, auth); !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+
+		var req adminMarketTagRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+			return
+		}
+		if req.IsActive != nil && !*req.IsActive && !req.ConfirmDeactivate {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+			return
+		}
+
+		tag, err := svc.UpdateMarketTag(r.Context(), mux.Vars(r)["slug"], marketTagRequestFromAdmin(req))
+		if err != nil {
+			writeMarketTagError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, marketTagResponseFromDomain(*tag))
+	}
+}
+
+func writeMarketTagError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, dmarkets.ErrInvalidInput):
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+	default:
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+	}
+}
+
+func marketTagRequestFromAdmin(req adminMarketTagRequest) dmarkets.MarketTagRequest {
+	return dmarkets.MarketTagRequest{
+		Slug:        req.Slug,
+		DisplayName: req.DisplayName,
+		Description: req.Description,
+		ColorKey:    req.ColorKey,
+		SortOrder:   req.SortOrder,
+		IsActive:    req.IsActive,
+	}
+}
+
+func marketTagResponses(tags []dmarkets.MarketTag) []marketTagResponse {
+	responses := make([]marketTagResponse, 0, len(tags))
+	for _, tag := range tags {
+		responses = append(responses, marketTagResponseFromDomain(tag))
+	}
+	return responses
+}
+
+func marketTagResponseFromDomain(tag dmarkets.MarketTag) marketTagResponse {
+	return marketTagResponse{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+		CreatedBy:   tag.CreatedBy,
+	}
+}

--- a/backend/handlers/admin/market_tags_test.go
+++ b/backend/handlers/admin/market_tags_test.go
@@ -1,0 +1,113 @@
+package adminhandlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"socialpredict/handlers"
+	dmarkets "socialpredict/internal/domain/markets"
+	dusers "socialpredict/internal/domain/users"
+)
+
+type marketTagServiceMock struct {
+	listFn   func(context.Context, bool) ([]dmarkets.MarketTag, error)
+	createFn func(context.Context, dmarkets.MarketTagRequest, string) (*dmarkets.MarketTag, error)
+	updateFn func(context.Context, string, dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error)
+}
+
+func (m marketTagServiceMock) ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error) {
+	return m.listFn(ctx, includeInactive)
+}
+
+func (m marketTagServiceMock) CreateMarketTag(ctx context.Context, req dmarkets.MarketTagRequest, actorUsername string) (*dmarkets.MarketTag, error) {
+	return m.createFn(ctx, req, actorUsername)
+}
+
+func (m marketTagServiceMock) UpdateMarketTag(ctx context.Context, slug string, req dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+	return m.updateFn(ctx, slug, req)
+}
+
+func TestListAdminMarketTagsHandlerReturnsTags(t *testing.T) {
+	svc := marketTagServiceMock{
+		listFn: func(_ context.Context, includeInactive bool) ([]dmarkets.MarketTag, error) {
+			if !includeInactive {
+				t.Fatalf("expected includeInactive")
+			}
+			return []dmarkets.MarketTag{{ID: 1, Slug: "sports", DisplayName: "Sports", IsActive: true}}, nil
+		},
+	}
+	handler := ListAdminMarketTagsHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := httptest.NewRequest(http.MethodGet, "/v0/admin/market-tags?includeInactive=true", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope handlers.SuccessEnvelope[marketTagsResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.OK || envelope.Result.Total != 1 || envelope.Result.Tags[0].Slug != "sports" {
+		t.Fatalf("unexpected response: %+v", envelope)
+	}
+}
+
+func TestCreateAdminMarketTagHandlerPassesActor(t *testing.T) {
+	svc := marketTagServiceMock{
+		createFn: func(_ context.Context, req dmarkets.MarketTagRequest, actorUsername string) (*dmarkets.MarketTag, error) {
+			if req.DisplayName != "Sports" || actorUsername != "admin" {
+				t.Fatalf("unexpected create args req=%+v actor=%q", req, actorUsername)
+			}
+			return &dmarkets.MarketTag{ID: 2, Slug: "sports", DisplayName: req.DisplayName, IsActive: true, CreatedBy: actorUsername}, nil
+		},
+	}
+	handler := CreateAdminMarketTagHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := httptest.NewRequest(http.MethodPost, "/v0/admin/market-tags", bytes.NewBufferString(`{"displayName":"Sports"}`))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateAdminMarketTagHandlerRequiresDeactivateConfirmation(t *testing.T) {
+	svc := marketTagServiceMock{
+		updateFn: func(context.Context, string, dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+			t.Fatalf("update should not be called without deactivate confirmation")
+			return nil, nil
+		},
+	}
+	handler := UpdateAdminMarketTagHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodPatch, "/v0/admin/market-tags/sports", bytes.NewBufferString(`{"isActive":false}`)), map[string]string{"slug": "sports"})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assertAdminFailure(t, rec, http.StatusBadRequest, handlers.ReasonValidationFailed)
+
+	svc.updateFn = func(_ context.Context, slug string, req dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+		if slug != "sports" || req.IsActive == nil || *req.IsActive {
+			t.Fatalf("unexpected update args slug=%q req=%+v", slug, req)
+		}
+		return &dmarkets.MarketTag{ID: 2, Slug: slug, DisplayName: "Sports", IsActive: false}, nil
+	}
+	handler = UpdateAdminMarketTagHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req = mux.SetURLVars(httptest.NewRequest(http.MethodPatch, "/v0/admin/market-tags/sports", bytes.NewBufferString(`{"isActive":false,"confirmDeactivate":true}`)), map[string]string{"slug": "sports"})
+	rec = httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/handlers/admin/users.go
+++ b/backend/handlers/admin/users.go
@@ -207,6 +207,7 @@ func adminUserListFiltersFromRequest(w http.ResponseWriter, r *http.Request) (du
 
 	return dusers.ListFilters{
 		UserType: strings.TrimSpace(query.Get("usertype")),
+		Query:    strings.TrimSpace(query.Get("query")),
 		Limit:    limit,
 		Offset:   offset,
 	}, true

--- a/backend/handlers/admin/users_test.go
+++ b/backend/handlers/admin/users_test.go
@@ -41,7 +41,7 @@ func (m adminUserManagerMock) UnsuspendModerator(ctx context.Context, username, 
 func TestListAdminUsersHandlerReturnsUserQueue(t *testing.T) {
 	svc := adminUserManagerMock{
 		listFn: func(_ context.Context, filters dusers.ListFilters) ([]*dusers.User, error) {
-			if filters.Limit != 50 || filters.Offset != 10 {
+			if filters.Limit != 50 || filters.Offset != 10 || filters.UserType != string(dusers.UserTypeModerator) || filters.Query != "mod" {
 				t.Fatalf("unexpected filters: %+v", filters)
 			}
 			return []*dusers.User{
@@ -51,7 +51,7 @@ func TestListAdminUsersHandlerReturnsUserQueue(t *testing.T) {
 		},
 	}
 	handler := ListAdminUsersHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
-	req := httptest.NewRequest(http.MethodGet, "/v0/admin/users?limit=50&offset=10", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/admin/users?limit=50&offset=10&usertype=MODERATOR&query=mod", nil)
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)

--- a/backend/handlers/cms/marketdiscovery/http/handler.go
+++ b/backend/handlers/cms/marketdiscovery/http/handler.go
@@ -1,0 +1,219 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"socialpredict/handlers"
+	"socialpredict/handlers/authhttp"
+	"socialpredict/handlers/cms/marketdiscovery"
+	dusers "socialpredict/internal/domain/users"
+	authsvc "socialpredict/internal/service/auth"
+	"socialpredict/models"
+)
+
+type Handler struct {
+	svc  *marketdiscovery.Service
+	auth authsvc.Authenticator
+}
+
+func NewHandler(svc *marketdiscovery.Service, auth authsvc.Authenticator) *Handler {
+	return &Handler{svc: svc, auth: auth}
+}
+
+type updateReq struct {
+	Title                      string `json:"title"`
+	Description                string `json:"description"`
+	PageType                   string `json:"pageType"`
+	PrimaryTagSlug             string `json:"primaryTagSlug"`
+	SearchScope                string `json:"searchScope"`
+	FeaturedTopicsEnabled      bool   `json:"featuredTopicsEnabled"`
+	FeaturedMarketsEnabled     bool   `json:"featuredMarketsEnabled"`
+	DefaultRecommendationLimit int    `json:"defaultRecommendationLimit"`
+	CuratedRecommendationLimit int    `json:"curatedRecommendationLimit"`
+	Version                    uint   `json:"version"`
+}
+
+type replacePinsReq struct {
+	Pins []pinReq `json:"pins"`
+}
+
+type pinReq struct {
+	PinType        string `json:"pinType"`
+	MarketID       int64  `json:"marketId"`
+	TargetPageSlug string `json:"targetPageSlug"`
+	Label          string `json:"label"`
+	SortOrder      int    `json:"sortOrder"`
+}
+
+type pageResponse struct {
+	Slug                       string        `json:"slug"`
+	Title                      string        `json:"title"`
+	Description                string        `json:"description"`
+	PageType                   string        `json:"pageType"`
+	PrimaryTagSlug             string        `json:"primaryTagSlug"`
+	SearchScope                string        `json:"searchScope"`
+	FeaturedTopicsEnabled      bool          `json:"featuredTopicsEnabled"`
+	FeaturedMarketsEnabled     bool          `json:"featuredMarketsEnabled"`
+	DefaultRecommendationLimit int           `json:"defaultRecommendationLimit"`
+	CuratedRecommendationLimit int           `json:"curatedRecommendationLimit"`
+	RecommendationLimit        int           `json:"recommendationLimit"`
+	Version                    uint          `json:"version"`
+	UpdatedAt                  string        `json:"updatedAt,omitempty"`
+	Pins                       []pinResponse `json:"pins"`
+}
+
+type pinResponse struct {
+	ID             uint   `json:"id,omitempty"`
+	PinType        string `json:"pinType"`
+	MarketID       int64  `json:"marketId,omitempty"`
+	TargetPageSlug string `json:"targetPageSlug,omitempty"`
+	Label          string `json:"label,omitempty"`
+	SortOrder      int    `json:"sortOrder"`
+}
+
+func (h *Handler) PublicGet(w http.ResponseWriter, r *http.Request) {
+	composition, err := h.svc.GetComposition(mux.Vars(r)["slug"])
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
+}
+
+func (h *Handler) AdminUpdate(w http.ResponseWriter, r *http.Request) {
+	if h.auth == nil {
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+		return
+	}
+	admin, authErr := h.auth.RequireAdmin(r)
+	if authErr != nil {
+		_ = authhttp.WriteFailure(w, authErr)
+		return
+	}
+
+	var in updateReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return
+	}
+	page, err := h.svc.UpdatePage(mux.Vars(r)["slug"], marketdiscovery.UpdateInput{
+		Title:                      in.Title,
+		Description:                in.Description,
+		PageType:                   in.PageType,
+		PrimaryTagSlug:             in.PrimaryTagSlug,
+		SearchScope:                in.SearchScope,
+		FeaturedTopicsEnabled:      in.FeaturedTopicsEnabled,
+		FeaturedMarketsEnabled:     in.FeaturedMarketsEnabled,
+		DefaultRecommendationLimit: in.DefaultRecommendationLimit,
+		CuratedRecommendationLimit: in.CuratedRecommendationLimit,
+		Version:                    in.Version,
+		UpdatedBy:                  admin.Username,
+	})
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+		return
+	}
+	composition, err := h.svc.GetComposition(page.Slug)
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
+}
+
+func (h *Handler) AdminReplacePins(w http.ResponseWriter, r *http.Request) {
+	admin, ok := h.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	var in replacePinsReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return
+	}
+	composition, err := h.svc.ReplacePins(mux.Vars(r)["slug"], pinInputsFromRequest(in.Pins), admin.Username)
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
+}
+
+func (h *Handler) requireAdmin(w http.ResponseWriter, r *http.Request) (*dusers.User, bool) {
+	if h.auth == nil {
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+		return nil, false
+	}
+	admin, authErr := h.auth.RequireAdmin(r)
+	if authErr != nil {
+		_ = authhttp.WriteFailure(w, authErr)
+		return nil, false
+	}
+	return admin, true
+}
+
+func responseFromComposition(composition *marketdiscovery.PageComposition) pageResponse {
+	return responseFromPage(composition.Page, composition.Pins)
+}
+
+func responseFromPage(page *models.MarketDiscoveryPage, pins []models.MarketDiscoveryPin) pageResponse {
+	response := pageResponse{
+		Slug:                       page.Slug,
+		Title:                      page.Title,
+		Description:                page.Description,
+		PageType:                   page.PageType,
+		PrimaryTagSlug:             page.PrimaryTagSlug,
+		SearchScope:                page.SearchScope,
+		FeaturedTopicsEnabled:      page.FeaturedTopicsEnabled,
+		FeaturedMarketsEnabled:     page.FeaturedMarketsEnabled,
+		DefaultRecommendationLimit: page.DefaultRecommendationLimit,
+		CuratedRecommendationLimit: page.CuratedRecommendationLimit,
+		Version:                    page.Version,
+		Pins:                       pinResponses(pins),
+	}
+	if page.UpdatedAt.IsZero() {
+		response.UpdatedAt = ""
+	} else {
+		response.UpdatedAt = page.UpdatedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	response.RecommendationLimit = response.DefaultRecommendationLimit
+	if page.FeaturedTopicsEnabled || page.FeaturedMarketsEnabled {
+		response.RecommendationLimit = response.CuratedRecommendationLimit
+	}
+	return response
+}
+
+func pinInputsFromRequest(pins []pinReq) []marketdiscovery.PinInput {
+	inputs := make([]marketdiscovery.PinInput, 0, len(pins))
+	for _, pin := range pins {
+		inputs = append(inputs, marketdiscovery.PinInput{
+			PinType:        pin.PinType,
+			MarketID:       pin.MarketID,
+			TargetPageSlug: pin.TargetPageSlug,
+			Label:          pin.Label,
+			SortOrder:      pin.SortOrder,
+		})
+	}
+	return inputs
+}
+
+func pinResponses(pins []models.MarketDiscoveryPin) []pinResponse {
+	responses := make([]pinResponse, 0, len(pins))
+	for _, pin := range pins {
+		response := pinResponse{
+			ID:             pin.ID,
+			PinType:        pin.PinType,
+			TargetPageSlug: pin.TargetPageSlug,
+			Label:          pin.Label,
+			SortOrder:      pin.SortOrder,
+		}
+		if pin.MarketID != nil {
+			response.MarketID = *pin.MarketID
+		}
+		responses = append(responses, response)
+	}
+	return responses
+}

--- a/backend/handlers/cms/marketdiscovery/repo.go
+++ b/backend/handlers/cms/marketdiscovery/repo.go
@@ -1,0 +1,58 @@
+package marketdiscovery
+
+import (
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+type Repository interface {
+	GetPageBySlug(slug string) (*models.MarketDiscoveryPage, error)
+	SavePage(page *models.MarketDiscoveryPage) error
+	ListPins(pageID uint) ([]models.MarketDiscoveryPin, error)
+	ReplacePins(pageID uint, pins []models.MarketDiscoveryPin) error
+}
+
+type GormRepository struct {
+	db *gorm.DB
+}
+
+func NewGormRepository(db *gorm.DB) *GormRepository {
+	return &GormRepository{db: db}
+}
+
+func (r *GormRepository) GetPageBySlug(slug string) (*models.MarketDiscoveryPage, error) {
+	var page models.MarketDiscoveryPage
+	if err := r.db.Where("slug = ?", slug).First(&page).Error; err != nil {
+		return nil, err
+	}
+	return &page, nil
+}
+
+func (r *GormRepository) SavePage(page *models.MarketDiscoveryPage) error {
+	return r.db.Save(page).Error
+}
+
+func (r *GormRepository) ListPins(pageID uint) ([]models.MarketDiscoveryPin, error) {
+	var pins []models.MarketDiscoveryPin
+	if err := r.db.Where("scope_type = ? AND scope_id = ?", "page", pageID).Order("sort_order ASC, id ASC").Find(&pins).Error; err != nil {
+		return nil, err
+	}
+	return pins, nil
+}
+
+func (r *GormRepository) ReplacePins(pageID uint, pins []models.MarketDiscoveryPin) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("scope_type = ? AND scope_id = ?", "page", pageID).Delete(&models.MarketDiscoveryPin{}).Error; err != nil {
+			return err
+		}
+		for index := range pins {
+			pins[index].ScopeType = "page"
+			pins[index].ScopeID = pageID
+			if err := tx.Create(&pins[index]).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/backend/handlers/cms/marketdiscovery/service.go
+++ b/backend/handlers/cms/marketdiscovery/service.go
@@ -1,0 +1,323 @@
+package marketdiscovery
+
+import (
+	"errors"
+	"strings"
+
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+const (
+	PageSlugMarkets       = "markets"
+	PageSlugTopicTemplate = "topic-template"
+
+	PageTypeTop       = "top"
+	PageTypeSecondary = "secondary"
+
+	SearchScopeAll = "all"
+	SearchScopeTag = "tag"
+
+	MaxTitleLength       = 160
+	MaxDescriptionLength = 500
+	MaxSlugLength        = 96
+	MaxPinsPerPage       = 48
+	MinRecommendation    = 1
+	MaxRecommendation    = 50
+
+	ScopeTypePage        = "page"
+	PinTypeMarket        = "market"
+	PinTypeDiscoveryPage = "discovery_page"
+)
+
+type Service struct {
+	repo Repository
+}
+
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+type UpdateInput struct {
+	Title                      string
+	Description                string
+	PageType                   string
+	PrimaryTagSlug             string
+	SearchScope                string
+	FeaturedTopicsEnabled      bool
+	FeaturedMarketsEnabled     bool
+	DefaultRecommendationLimit int
+	CuratedRecommendationLimit int
+	UpdatedBy                  string
+	Version                    uint
+}
+
+type PinInput struct {
+	PinType        string
+	MarketID       int64
+	TargetPageSlug string
+	Label          string
+	SortOrder      int
+}
+
+type PageComposition struct {
+	Page *models.MarketDiscoveryPage
+	Pins []models.MarketDiscoveryPin
+}
+
+func (s *Service) GetPage(slug string) (*models.MarketDiscoveryPage, error) {
+	slug = normalizeSlug(slug)
+	if slug == "" {
+		return nil, errors.New("page slug is required")
+	}
+	page, err := s.repo.GetPageBySlug(slug)
+	if err == nil {
+		return page, nil
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return DefaultPage(slug), nil
+	}
+	return nil, err
+}
+
+func (s *Service) GetComposition(slug string) (*PageComposition, error) {
+	page, err := s.GetPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	if page.ID == 0 {
+		return &PageComposition{Page: page, Pins: []models.MarketDiscoveryPin{}}, nil
+	}
+	pins, err := s.repo.ListPins(page.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &PageComposition{Page: page, Pins: pins}, nil
+}
+
+func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscoveryPage, error) {
+	slug = normalizeSlug(slug)
+	if slug == "" {
+		return nil, errors.New("page slug is required")
+	}
+	page, err := s.GetPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	if in.Version != 0 && page.ID != 0 && in.Version != page.Version {
+		return nil, errors.New("version mismatch")
+	}
+
+	title, description, pageType, primaryTagSlug, searchScope, defaultLimit, curatedLimit, err := validateInput(slug, in)
+	if err != nil {
+		return nil, err
+	}
+
+	page.Slug = slug
+	page.Title = title
+	page.Description = description
+	page.PageType = pageType
+	page.PrimaryTagSlug = primaryTagSlug
+	page.SearchScope = searchScope
+	page.FeaturedTopicsEnabled = in.FeaturedTopicsEnabled
+	page.FeaturedMarketsEnabled = in.FeaturedMarketsEnabled
+	page.DefaultRecommendationLimit = defaultLimit
+	page.CuratedRecommendationLimit = curatedLimit
+	page.UpdatedBy = strings.TrimSpace(in.UpdatedBy)
+	if page.ID == 0 {
+		page.Version = 1
+	} else {
+		page.Version = page.Version + 1
+	}
+
+	if err := s.repo.SavePage(page); err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+func (s *Service) ReplacePins(slug string, inputs []PinInput, actorUsername string) (*PageComposition, error) {
+	if len(inputs) > MaxPinsPerPage {
+		return nil, errors.New("too many pins")
+	}
+	page, err := s.ensurePersistedPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	pins := make([]models.MarketDiscoveryPin, 0, len(inputs))
+	for index, input := range inputs {
+		pin, err := pinFromInput(input, index, actorUsername)
+		if err != nil {
+			return nil, err
+		}
+		pins = append(pins, pin)
+	}
+	if err := s.repo.ReplacePins(page.ID, pins); err != nil {
+		return nil, err
+	}
+	return s.GetComposition(page.Slug)
+}
+
+func (s *Service) ensurePersistedPage(slug string) (*models.MarketDiscoveryPage, error) {
+	page, err := s.GetPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	if page.ID != 0 {
+		return page, nil
+	}
+	if err := s.repo.SavePage(page); err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+func DefaultPage(slug string) *models.MarketDiscoveryPage {
+	slug = normalizeSlug(slug)
+	page := &models.MarketDiscoveryPage{
+		Slug:                       slug,
+		Title:                      "Markets",
+		Description:                "Browse and search prediction markets.",
+		PageType:                   PageTypeTop,
+		SearchScope:                SearchScopeAll,
+		FeaturedTopicsEnabled:      false,
+		FeaturedMarketsEnabled:     false,
+		DefaultRecommendationLimit: 20,
+		CuratedRecommendationLimit: 5,
+		Version:                    1,
+	}
+	if slug == PageSlugTopicTemplate {
+		page.Title = "Topic Markets"
+		page.Description = "Browse and search markets in this topic."
+		page.PageType = PageTypeSecondary
+		page.SearchScope = SearchScopeTag
+		page.FeaturedMarketsEnabled = true
+	} else if slug != PageSlugMarkets {
+		page.Title = titleFromSlug(slug)
+		page.Description = "Browse and search markets in this topic."
+		page.PageType = PageTypeSecondary
+		page.PrimaryTagSlug = slug
+		page.SearchScope = SearchScopeTag
+		page.FeaturedMarketsEnabled = true
+	}
+	return page
+}
+
+func pinFromInput(input PinInput, index int, actorUsername string) (models.MarketDiscoveryPin, error) {
+	pinType := strings.ToLower(strings.TrimSpace(input.PinType))
+	if pinType == "" {
+		pinType = PinTypeMarket
+	}
+	if pinType != PinTypeMarket && pinType != PinTypeDiscoveryPage {
+		return models.MarketDiscoveryPin{}, errors.New("invalid pin type")
+	}
+	label := strings.Join(strings.Fields(strings.TrimSpace(input.Label)), " ")
+	if len([]rune(label)) > MaxTitleLength {
+		return models.MarketDiscoveryPin{}, errors.New("pin label is too long")
+	}
+	sortOrder := input.SortOrder
+	if sortOrder == 0 {
+		sortOrder = index + 1
+	}
+	pin := models.MarketDiscoveryPin{
+		ScopeType: ScopeTypePage,
+		PinType:   pinType,
+		Label:     label,
+		SortOrder: sortOrder,
+		CreatedBy: strings.TrimSpace(actorUsername),
+	}
+	switch pinType {
+	case PinTypeMarket:
+		if input.MarketID <= 0 {
+			return models.MarketDiscoveryPin{}, errors.New("market pin requires market id")
+		}
+		pin.MarketID = &input.MarketID
+	case PinTypeDiscoveryPage:
+		targetPageSlug := normalizeSlug(input.TargetPageSlug)
+		if targetPageSlug == "" {
+			return models.MarketDiscoveryPin{}, errors.New("discovery page pin requires target page slug")
+		}
+		pin.TargetPageSlug = targetPageSlug
+	}
+	return pin, nil
+}
+
+func validateInput(slug string, in UpdateInput) (string, string, string, string, string, int, int, error) {
+	title := strings.Join(strings.Fields(strings.TrimSpace(in.Title)), " ")
+	if title == "" {
+		title = DefaultPage(slug).Title
+	}
+	if len([]rune(title)) > MaxTitleLength {
+		return "", "", "", "", "", 0, 0, errors.New("title is too long")
+	}
+	description := strings.Join(strings.Fields(strings.TrimSpace(in.Description)), " ")
+	if len([]rune(description)) > MaxDescriptionLength {
+		return "", "", "", "", "", 0, 0, errors.New("description is too long")
+	}
+	pageType := strings.ToLower(strings.TrimSpace(in.PageType))
+	if pageType == "" {
+		pageType = DefaultPage(slug).PageType
+	}
+	if pageType != PageTypeTop && pageType != PageTypeSecondary {
+		return "", "", "", "", "", 0, 0, errors.New("invalid page type")
+	}
+	searchScope := strings.ToLower(strings.TrimSpace(in.SearchScope))
+	if searchScope == "" {
+		searchScope = DefaultPage(slug).SearchScope
+	}
+	if searchScope != SearchScopeAll && searchScope != SearchScopeTag {
+		return "", "", "", "", "", 0, 0, errors.New("invalid search scope")
+	}
+	defaultLimit := clampRecommendationLimit(in.DefaultRecommendationLimit, DefaultPage(slug).DefaultRecommendationLimit)
+	curatedLimit := clampRecommendationLimit(in.CuratedRecommendationLimit, DefaultPage(slug).CuratedRecommendationLimit)
+	return title, description, pageType, normalizeSlug(in.PrimaryTagSlug), searchScope, defaultLimit, curatedLimit, nil
+}
+
+func clampRecommendationLimit(value int, fallback int) int {
+	if value == 0 {
+		value = fallback
+	}
+	if value < MinRecommendation {
+		return MinRecommendation
+	}
+	if value > MaxRecommendation {
+		return MaxRecommendation
+	}
+	return value
+}
+
+func normalizeSlug(value string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(value)), "-")
+}
+
+func slugFromTitle(title string) string {
+	title = strings.ToLower(strings.TrimSpace(title))
+	var builder strings.Builder
+	lastHyphen := false
+	for _, r := range title {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen {
+			builder.WriteRune('-')
+			lastHyphen = true
+		}
+	}
+	return normalizeSlug(builder.String())
+}
+
+func titleFromSlug(slug string) string {
+	parts := strings.Fields(strings.ReplaceAll(normalizeSlug(slug), "-", " "))
+	for i, part := range parts {
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	if len(parts) == 0 {
+		return "Topic Markets"
+	}
+	return strings.Join(parts, " ")
+}

--- a/backend/handlers/cms/marketdiscovery/service_test.go
+++ b/backend/handlers/cms/marketdiscovery/service_test.go
@@ -1,0 +1,143 @@
+package marketdiscovery
+
+import (
+	"errors"
+	"testing"
+
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+type mockRepository struct {
+	page    *models.MarketDiscoveryPage
+	pins    []models.MarketDiscoveryPin
+	saveErr error
+	getErr  error
+}
+
+func (m *mockRepository) GetPageBySlug(string) (*models.MarketDiscoveryPage, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if m.page == nil {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return m.page, nil
+}
+
+func (m *mockRepository) SavePage(page *models.MarketDiscoveryPage) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	if page.ID == 0 {
+		page.ID = 1
+	}
+	m.page = page
+	return nil
+}
+
+func (m *mockRepository) ListPins(uint) ([]models.MarketDiscoveryPin, error) {
+	return m.pins, nil
+}
+
+func (m *mockRepository) ReplacePins(_ uint, pins []models.MarketDiscoveryPin) error {
+	m.pins = pins
+	return nil
+}
+
+func TestGetPageReturnsDefaultWhenMissing(t *testing.T) {
+	svc := NewService(&mockRepository{})
+
+	page, err := svc.GetPage(PageSlugMarkets)
+	if err != nil {
+		t.Fatalf("GetPage returned error: %v", err)
+	}
+	if page.Slug != PageSlugMarkets || page.PageType != PageTypeTop || page.DefaultRecommendationLimit != 20 {
+		t.Fatalf("unexpected default page: %+v", page)
+	}
+}
+
+func TestUpdatePagePersistsLayout(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo)
+
+	page, err := svc.UpdatePage(PageSlugMarkets, UpdateInput{
+		Title:                      "Forecast Markets",
+		Description:                "Curated markets.",
+		PageType:                   PageTypeTop,
+		SearchScope:                SearchScopeAll,
+		FeaturedTopicsEnabled:      true,
+		FeaturedMarketsEnabled:     true,
+		DefaultRecommendationLimit: 30,
+		CuratedRecommendationLimit: 7,
+		UpdatedBy:                  "admin",
+	})
+	if err != nil {
+		t.Fatalf("UpdatePage returned error: %v", err)
+	}
+	if page.Title != "Forecast Markets" || !page.FeaturedTopicsEnabled || page.CuratedRecommendationLimit != 7 {
+		t.Fatalf("unexpected saved page: %+v", page)
+	}
+	if repo.page == nil || repo.page.UpdatedBy != "admin" {
+		t.Fatalf("expected saved page with UpdatedBy admin, got %+v", repo.page)
+	}
+}
+
+func TestUpdatePageRejectsInvalidSearchScope(t *testing.T) {
+	svc := NewService(&mockRepository{})
+
+	_, err := svc.UpdatePage(PageSlugMarkets, UpdateInput{
+		Title:       "Markets",
+		PageType:    PageTypeTop,
+		SearchScope: "everywhere",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestUpdatePagePropagatesRepositoryError(t *testing.T) {
+	wantErr := errors.New("database unavailable")
+	svc := NewService(&mockRepository{saveErr: wantErr})
+
+	_, err := svc.UpdatePage(PageSlugMarkets, UpdateInput{
+		Title:       "Markets",
+		PageType:    PageTypeTop,
+		SearchScope: SearchScopeAll,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("UpdatePage error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestReplacePinsPersistsMarketAndTopicPins(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo)
+
+	composition, err := svc.ReplacePins(PageSlugMarkets, []PinInput{
+		{PinType: PinTypeMarket, MarketID: 42, Label: "Featured market"},
+		{PinType: PinTypeDiscoveryPage, TargetPageSlug: "politics", Label: "Politics"},
+	}, "admin")
+	if err != nil {
+		t.Fatalf("ReplacePins returned error: %v", err)
+	}
+	if len(composition.Pins) != 2 {
+		t.Fatalf("expected two pins, got %+v", composition.Pins)
+	}
+	if composition.Pins[0].MarketID == nil || *composition.Pins[0].MarketID != 42 {
+		t.Fatalf("expected market pin, got %+v", composition.Pins[0])
+	}
+	if composition.Pins[1].TargetPageSlug != "politics" || composition.Pins[1].CreatedBy != "admin" {
+		t.Fatalf("expected topic pin, got %+v", composition.Pins[1])
+	}
+}
+
+func TestReplacePinsRejectsInvalidMarketPin(t *testing.T) {
+	svc := NewService(&mockRepository{})
+
+	_, err := svc.ReplacePins(PageSlugMarkets, []PinInput{{PinType: PinTypeMarket}}, "admin")
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+}

--- a/backend/handlers/marketpublicresponse/publicresponsemarket.go
+++ b/backend/handlers/marketpublicresponse/publicresponsemarket.go
@@ -21,6 +21,7 @@ type PublicResponseMarket struct {
 	ResolutionResult        string    `json:"resolutionResult"`
 	InitialProbability      float64   `json:"initialProbability"`
 	CreatorUsername         string    `json:"creatorUsername"`
+	StewardUsername         string    `json:"stewardUsername"`
 	CreatedAt               time.Time `json:"createdAt"`
 	YesLabel                string    `json:"yesLabel"`
 	NoLabel                 string    `json:"noLabel"`
@@ -49,6 +50,7 @@ func GetPublicResponseMarket(ctx context.Context, svc dmarkets.ServiceInterface,
 		ResolutionResult:        market.ResolutionResult,
 		InitialProbability:      market.InitialProbability,
 		CreatorUsername:         market.CreatorUsername,
+		StewardUsername:         market.StewardUsername,
 		CreatedAt:               market.CreatedAt,
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,

--- a/backend/handlers/markets/createmarket.go
+++ b/backend/handlers/markets/createmarket.go
@@ -207,6 +207,7 @@ func toDomainCreateRequest(req dto.CreateMarketRequest) dmarkets.MarketCreateReq
 		ResolutionDateTime: req.ResolutionDateTime,
 		YesLabel:           req.YesLabel,
 		NoLabel:            req.NoLabel,
+		TagSlugs:           req.TagSlugs,
 	}
 }
 
@@ -218,12 +219,14 @@ func toCreateMarketResponse(market *dmarkets.Market) dto.CreateMarketResponse {
 		OutcomeType:        market.OutcomeType,
 		ResolutionDateTime: market.ResolutionDateTime,
 		CreatorUsername:    market.CreatorUsername,
+		StewardUsername:    market.CurrentStewardUsername(),
 		YesLabel:           market.YesLabel,
 		NoLabel:            market.NoLabel,
 		Status:             market.Status,
 		LifecycleStatus:    market.LifecycleStatus,
 		ProposalCost:       market.ProposalCost,
 		CreatedAt:          market.CreatedAt,
+		Tags:               marketTagResponsesFromDomain(market.Tags),
 	}
 }
 

--- a/backend/handlers/markets/dto/requests.go
+++ b/backend/handlers/markets/dto/requests.go
@@ -12,6 +12,7 @@ type CreateMarketRequest struct {
 	ResolutionDateTime time.Time `json:"resolutionDateTime" validate:"required"`
 	YesLabel           string    `json:"yesLabel" validate:"omitempty,max=20"`
 	NoLabel            string    `json:"noLabel" validate:"omitempty,max=20"`
+	TagSlugs           []string  `json:"tagSlugs" validate:"omitempty,max=5"`
 }
 
 // UpdateLabelsRequest represents the HTTP request body for updating market labels

--- a/backend/handlers/markets/dto/responses.go
+++ b/backend/handlers/markets/dto/responses.go
@@ -6,42 +6,61 @@ import (
 
 // MarketResponse represents the HTTP response for a market
 type MarketResponse struct {
-	ID                 int64      `json:"id"`
-	QuestionTitle      string     `json:"questionTitle"`
-	Description        string     `json:"description"`
-	OutcomeType        string     `json:"outcomeType"`
-	ResolutionDateTime time.Time  `json:"resolutionDateTime"`
-	CreatorUsername    string     `json:"creatorUsername"`
-	YesLabel           string     `json:"yesLabel"`
-	NoLabel            string     `json:"noLabel"`
-	Status             string     `json:"status"`
-	LifecycleStatus    string     `json:"lifecycleStatus,omitempty"`
-	ApprovedBy         string     `json:"approvedBy,omitempty"`
-	ApprovedAt         *time.Time `json:"approvedAt,omitempty"`
-	RejectedBy         string     `json:"rejectedBy,omitempty"`
-	RejectedAt         *time.Time `json:"rejectedAt,omitempty"`
-	RejectionReason    string     `json:"rejectionReason,omitempty"`
-	ProposalCost       int64      `json:"proposalCost,omitempty"`
-	IsResolved         bool       `json:"isResolved"`
-	ResolutionResult   string     `json:"resolutionResult"`
-	CreatedAt          time.Time  `json:"createdAt"`
-	UpdatedAt          time.Time  `json:"updatedAt"`
+	ID                 int64               `json:"id"`
+	QuestionTitle      string              `json:"questionTitle"`
+	Description        string              `json:"description"`
+	OutcomeType        string              `json:"outcomeType"`
+	ResolutionDateTime time.Time           `json:"resolutionDateTime"`
+	CreatorUsername    string              `json:"creatorUsername"`
+	StewardUsername    string              `json:"stewardUsername"`
+	YesLabel           string              `json:"yesLabel"`
+	NoLabel            string              `json:"noLabel"`
+	Status             string              `json:"status"`
+	LifecycleStatus    string              `json:"lifecycleStatus,omitempty"`
+	ApprovedBy         string              `json:"approvedBy,omitempty"`
+	ApprovedAt         *time.Time          `json:"approvedAt,omitempty"`
+	RejectedBy         string              `json:"rejectedBy,omitempty"`
+	RejectedAt         *time.Time          `json:"rejectedAt,omitempty"`
+	RejectionReason    string              `json:"rejectionReason,omitempty"`
+	ProposalCost       int64               `json:"proposalCost,omitempty"`
+	IsResolved         bool                `json:"isResolved"`
+	ResolutionResult   string              `json:"resolutionResult"`
+	CreatedAt          time.Time           `json:"createdAt"`
+	UpdatedAt          time.Time           `json:"updatedAt"`
+	Tags               []MarketTagResponse `json:"tags,omitempty"`
 }
 
 // CreateMarketResponse represents the HTTP response after creating a market
 type CreateMarketResponse struct {
-	ID                 int64     `json:"id"`
-	QuestionTitle      string    `json:"questionTitle"`
-	Description        string    `json:"description"`
-	OutcomeType        string    `json:"outcomeType"`
-	ResolutionDateTime time.Time `json:"resolutionDateTime"`
-	CreatorUsername    string    `json:"creatorUsername"`
-	YesLabel           string    `json:"yesLabel"`
-	NoLabel            string    `json:"noLabel"`
-	Status             string    `json:"status"`
-	LifecycleStatus    string    `json:"lifecycleStatus,omitempty"`
-	ProposalCost       int64     `json:"proposalCost,omitempty"`
-	CreatedAt          time.Time `json:"createdAt"`
+	ID                 int64               `json:"id"`
+	QuestionTitle      string              `json:"questionTitle"`
+	Description        string              `json:"description"`
+	OutcomeType        string              `json:"outcomeType"`
+	ResolutionDateTime time.Time           `json:"resolutionDateTime"`
+	CreatorUsername    string              `json:"creatorUsername"`
+	StewardUsername    string              `json:"stewardUsername"`
+	YesLabel           string              `json:"yesLabel"`
+	NoLabel            string              `json:"noLabel"`
+	Status             string              `json:"status"`
+	LifecycleStatus    string              `json:"lifecycleStatus,omitempty"`
+	ProposalCost       int64               `json:"proposalCost,omitempty"`
+	CreatedAt          time.Time           `json:"createdAt"`
+	Tags               []MarketTagResponse `json:"tags,omitempty"`
+}
+
+type MarketTagResponse struct {
+	ID          int64  `json:"id"`
+	Slug        string `json:"slug"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description,omitempty"`
+	ColorKey    string `json:"colorKey,omitempty"`
+	SortOrder   int    `json:"sortOrder"`
+	IsActive    bool   `json:"isActive"`
+}
+
+type MarketTagsResponse struct {
+	Tags  []MarketTagResponse `json:"tags"`
+	Total int                 `json:"total"`
 }
 
 // CreatorResponse represents the creator information for frontend display
@@ -63,20 +82,22 @@ type MarketOverviewResponse struct {
 
 // PublicMarketResponse represents the legacy public market payload.
 type PublicMarketResponse struct {
-	ID                      int64     `json:"id"`
-	QuestionTitle           string    `json:"questionTitle"`
-	Description             string    `json:"description"`
-	OutcomeType             string    `json:"outcomeType"`
-	ResolutionDateTime      time.Time `json:"resolutionDateTime"`
-	FinalResolutionDateTime time.Time `json:"finalResolutionDateTime"`
-	UTCOffset               int       `json:"utcOffset"`
-	IsResolved              bool      `json:"isResolved"`
-	ResolutionResult        string    `json:"resolutionResult"`
-	InitialProbability      float64   `json:"initialProbability"`
-	CreatorUsername         string    `json:"creatorUsername"`
-	CreatedAt               time.Time `json:"createdAt"`
-	YesLabel                string    `json:"yesLabel"`
-	NoLabel                 string    `json:"noLabel"`
+	ID                      int64               `json:"id"`
+	QuestionTitle           string              `json:"questionTitle"`
+	Description             string              `json:"description"`
+	OutcomeType             string              `json:"outcomeType"`
+	ResolutionDateTime      time.Time           `json:"resolutionDateTime"`
+	FinalResolutionDateTime time.Time           `json:"finalResolutionDateTime"`
+	UTCOffset               int                 `json:"utcOffset"`
+	IsResolved              bool                `json:"isResolved"`
+	ResolutionResult        string              `json:"resolutionResult"`
+	InitialProbability      float64             `json:"initialProbability"`
+	CreatorUsername         string              `json:"creatorUsername"`
+	StewardUsername         string              `json:"stewardUsername"`
+	CreatedAt               time.Time           `json:"createdAt"`
+	YesLabel                string              `json:"yesLabel"`
+	NoLabel                 string              `json:"noLabel"`
+	Tags                    []MarketTagResponse `json:"tags,omitempty"`
 }
 
 // ProbabilityChangeResponse represents WPAM probability history.

--- a/backend/handlers/markets/handler.go
+++ b/backend/handlers/markets/handler.go
@@ -90,6 +90,7 @@ func (h *Handler) CreateMarket(w http.ResponseWriter, r *http.Request) {
 		ResolutionDateTime: req.ResolutionDateTime,
 		YesLabel:           req.YesLabel,
 		NoLabel:            req.NoLabel,
+		TagSlugs:           req.TagSlugs,
 	}
 
 	market, err := h.service.CreateMarket(r.Context(), createReq, user.Username)
@@ -190,7 +191,7 @@ func (h *Handler) ListMarkets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var markets []*dmarkets.Market
-	if params.status != "" && params.filters.CreatedBy == "" {
+	if params.status != "" && params.filters.CreatedBy == "" && params.filters.TagSlug == "" {
 		page := dmarkets.Page{Limit: params.limit, Offset: params.offset}
 		markets, err = h.service.ListByStatus(r.Context(), params.status, page)
 	} else {

--- a/backend/handlers/markets/handler_contract_test.go
+++ b/backend/handlers/markets/handler_contract_test.go
@@ -270,6 +270,60 @@ func TestHandlerListMarkets_UsesCreatedByFilterWhenStatusProvided(t *testing.T) 
 	}
 }
 
+func TestHandlerListMarkets_UsesTagFilterWhenStatusProvided(t *testing.T) {
+	now := time.Now().UTC()
+	market := &dmarkets.Market{
+		ID:                 12,
+		QuestionTitle:      "Tagged active market",
+		Description:        "desc",
+		OutcomeType:        "BINARY",
+		ResolutionDateTime: now.Add(time.Hour),
+		CreatorUsername:    "alice",
+		YesLabel:           "YES",
+		NoLabel:            "NO",
+		Status:             "active",
+		CreatedAt:          now.Add(-24 * time.Hour),
+		UpdatedAt:          now,
+		Tags: []dmarkets.MarketTag{
+			{Slug: "one", DisplayName: "One", IsActive: true},
+		},
+	}
+
+	service := &contractServiceMock{
+		listFn: func(ctx context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error) {
+			want := dmarkets.ListFilters{Status: "active", TagSlug: "one", Limit: 5, Offset: 2}
+			if filters != want {
+				t.Fatalf("expected filters %+v, got %+v", want, filters)
+			}
+			return []*dmarkets.Market{market}, nil
+		},
+		listByStatusFn: func(ctx context.Context, status string, p dmarkets.Page) ([]*dmarkets.Market, error) {
+			t.Fatalf("expected status+tag request to use ListMarkets, got ListByStatus(%q, %+v)", status, p)
+			return nil, nil
+		},
+		detailsFn: func(ctx context.Context, marketID int64) (*dmarkets.MarketOverview, error) {
+			return newOverview(market), nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/markets?status=active&tagSlug=one&limit=5&offset=2", nil)
+	rr := httptest.NewRecorder()
+
+	newContractHandler(service, nil).ListMarkets(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp dto.ListMarketsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Markets) != 1 || resp.Markets[0].Market.ID != 12 {
+		t.Fatalf("unexpected list response: %+v", resp)
+	}
+}
+
 func TestHandlerSearchMarkets_SupportsLegacyQAndInvalidRequestFailure(t *testing.T) {
 	now := time.Now().UTC()
 	market := &dmarkets.Market{

--- a/backend/handlers/markets/listmarkets.go
+++ b/backend/handlers/markets/listmarkets.go
@@ -40,6 +40,7 @@ func parseListMarketsParams(r *http.Request) (listMarketsParams, error) {
 		filters: dmarkets.ListFilters{
 			Status:    status,
 			CreatedBy: strings.TrimSpace(r.URL.Query().Get("created_by")),
+			TagSlug:   normalizeTagSlugParam(r.URL.Query().Get("tagSlug")),
 			Limit:     page.Limit,
 			Offset:    page.Offset,
 		},
@@ -77,6 +78,9 @@ func parseListPage(r *http.Request) dmarkets.Page {
 }
 
 func fetchMarketsByStatus(r *http.Request, svc dmarkets.ServiceInterface, params listMarketsParams) ([]*dmarkets.Market, error) {
+	if params.filters.TagSlug != "" || params.filters.CreatedBy != "" {
+		return svc.ListMarkets(r.Context(), params.filters)
+	}
 	return svc.ListByStatus(r.Context(), params.filters.Status, params.page)
 }
 

--- a/backend/handlers/markets/market_tags.go
+++ b/backend/handlers/markets/market_tags.go
@@ -1,0 +1,57 @@
+package marketshandlers
+
+import (
+	"context"
+	"net/http"
+
+	"socialpredict/handlers"
+	"socialpredict/handlers/markets/dto"
+	dmarkets "socialpredict/internal/domain/markets"
+)
+
+type marketTagLister interface {
+	ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error)
+}
+
+func ListMarketTagsHandler(svc marketTagLister) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		tags, err := svc.ListMarketTags(r.Context(), false)
+		if err != nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		response := dto.MarketTagsResponse{
+			Tags:  marketTagResponsesFromDomain(tags),
+			Total: len(tags),
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, response)
+	}
+}
+
+func marketTagResponsesFromDomain(tags []dmarkets.MarketTag) []dto.MarketTagResponse {
+	responses := make([]dto.MarketTagResponse, 0, len(tags))
+	for _, tag := range tags {
+		responses = append(responses, marketTagResponseFromDomain(tag))
+	}
+	return responses
+}
+
+func marketTagResponseFromDomain(tag dmarkets.MarketTag) dto.MarketTagResponse {
+	return dto.MarketTagResponse{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+	}
+}

--- a/backend/handlers/markets/overview_helpers.go
+++ b/backend/handlers/markets/overview_helpers.go
@@ -56,6 +56,7 @@ func marketToResponse(market *dmarkets.Market) *dto.MarketResponse {
 		OutcomeType:        market.OutcomeType,
 		ResolutionDateTime: market.ResolutionDateTime,
 		CreatorUsername:    market.CreatorUsername,
+		StewardUsername:    market.CurrentStewardUsername(),
 		YesLabel:           market.YesLabel,
 		NoLabel:            market.NoLabel,
 		Status:             market.Status,
@@ -70,6 +71,7 @@ func marketToResponse(market *dmarkets.Market) *dto.MarketResponse {
 		ResolutionResult:   market.ResolutionResult,
 		CreatedAt:          market.CreatedAt,
 		UpdatedAt:          market.UpdatedAt,
+		Tags:               marketTagResponsesFromDomain(market.Tags),
 	}
 }
 
@@ -100,9 +102,11 @@ func publicMarketResponseFromDomain(market *dmarkets.Market) dto.PublicMarketRes
 		ResolutionResult:        market.ResolutionResult,
 		InitialProbability:      market.InitialProbability,
 		CreatorUsername:         market.CreatorUsername,
+		StewardUsername:         market.CurrentStewardUsername(),
 		CreatedAt:               market.CreatedAt,
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,
+		Tags:                    marketTagResponsesFromDomain(market.Tags),
 	}
 }
 

--- a/backend/handlers/markets/searchmarkets.go
+++ b/backend/handlers/markets/searchmarkets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"socialpredict/handlers"
 	"socialpredict/handlers/markets/dto"
@@ -120,10 +121,15 @@ func parseSearchFilters(r *http.Request) (dmarkets.SearchFilters, *httpError) {
 	}
 
 	return dmarkets.SearchFilters{
-		Status: status,
-		Limit:  parseLimit(r.URL.Query().Get("limit")),
-		Offset: parseOffset(r.URL.Query().Get("offset")),
+		Status:  status,
+		TagSlug: normalizeTagSlugParam(r.URL.Query().Get("tagSlug")),
+		Limit:   parseLimit(r.URL.Query().Get("limit")),
+		Offset:  parseOffset(r.URL.Query().Get("offset")),
 	}, nil
+}
+
+func normalizeTagSlugParam(value string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(value)), "-")
 }
 
 func searchMarkets(ctx context.Context, svc dmarkets.ServiceInterface, params searchRequestParams) (*dmarkets.SearchResults, error) {

--- a/backend/handlers/users/dto/dto_test.go
+++ b/backend/handlers/users/dto/dto_test.go
@@ -36,6 +36,7 @@ func TestPrivateUserResponseJSONRoundTrip(t *testing.T) {
 		Username:              "tester",
 		DisplayName:           "Tester",
 		UserType:              "REGULAR",
+		ModeratorStatus:       "none",
 		InitialAccountBalance: 1000,
 		AccountBalance:        900,
 		PersonalEmoji:         "😀",

--- a/backend/handlers/users/dto/profile.go
+++ b/backend/handlers/users/dto/profile.go
@@ -35,6 +35,7 @@ type PrivateUserResponse struct {
 	Username              string `json:"username"`
 	DisplayName           string `json:"displayname"`
 	UserType              string `json:"usertype"`
+	ModeratorStatus       string `json:"moderatorStatus"`
 	InitialAccountBalance int64  `json:"initialAccountBalance"`
 	AccountBalance        int64  `json:"accountBalance"`
 	PersonalEmoji         string `json:"personalEmoji,omitempty"`

--- a/backend/handlers/users/privateuser/privateuser.go
+++ b/backend/handlers/users/privateuser/privateuser.go
@@ -41,6 +41,7 @@ func privateProfileResponse(profile *dusers.PrivateProfile) dto.PrivateUserRespo
 		Username:              profile.Username,
 		DisplayName:           profile.DisplayName,
 		UserType:              profile.UserType,
+		ModeratorStatus:       string(profile.ModeratorStatus),
 		InitialAccountBalance: profile.InitialAccountBalance,
 		AccountBalance:        profile.AccountBalance,
 		PersonalEmoji:         profile.PersonalEmoji,

--- a/backend/handlers/users/privateuser/privateuser_test.go
+++ b/backend/handlers/users/privateuser/privateuser_test.go
@@ -19,6 +19,8 @@ func TestGetPrivateProfileUserResponse_Success(t *testing.T) {
 	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
 
 	user := modelstesting.GenerateUser("alice", 0)
+	user.UserType = "MODERATOR"
+	user.ModeratorStatus = "suspended"
 	if err := db.Create(&user).Error; err != nil {
 		t.Fatalf("failed to create user: %v", err)
 	}
@@ -53,6 +55,9 @@ func TestGetPrivateProfileUserResponse_Success(t *testing.T) {
 	}
 	if resp.Email != user.PrivateUser.Email {
 		t.Fatalf("expected email %q, got %q", user.PrivateUser.Email, resp.Email)
+	}
+	if resp.ModeratorStatus != "suspended" {
+		t.Fatalf("expected moderator status suspended, got %q", resp.ModeratorStatus)
 	}
 }
 

--- a/backend/handlers/users/profile_helpers.go
+++ b/backend/handlers/users/profile_helpers.go
@@ -34,6 +34,7 @@ func toPrivateUserResponse(user *dusers.User) dto.PrivateUserResponse {
 		Username:              user.Username,
 		DisplayName:           user.DisplayName,
 		UserType:              user.UserType,
+		ModeratorStatus:       string(dusers.NormalizeModeratorStatus(user.UserType, string(user.ModeratorStatus))),
 		InitialAccountBalance: user.InitialAccountBalance,
 		AccountBalance:        user.AccountBalance,
 		PersonalEmoji:         user.PersonalEmoji,

--- a/backend/internal/app/container_test.go
+++ b/backend/internal/app/container_test.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	dmarkets "socialpredict/internal/domain/markets"
+	dusers "socialpredict/internal/domain/users"
 	configsvc "socialpredict/internal/service/config"
 	"socialpredict/models/modelstesting"
 )
@@ -97,5 +99,42 @@ func TestBuildApplicationPassesGameModeToMarketsService(t *testing.T) {
 	}
 	if market.Status != dmarkets.MarketLifecycleProposed || market.LifecycleStatus != dmarkets.MarketLifecycleProposed {
 		t.Fatalf("expected proposed market from container wiring, got %+v", market)
+	}
+}
+
+func TestSuspendedModeratorCannotCreateMarketUntilReinstated(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	config := modelstesting.GenerateEconomicConfig()
+	config.Game.Mode = configsvc.GameModeModerator
+	config.Game.Moderation.MarketApprovalRequired = true
+
+	container := BuildApplicationWithConfigService(db, configsvc.NewStaticService(config))
+	user := modelstesting.GenerateUser("moderator", 1000)
+	user.UserType = string(dusers.UserTypeModerator)
+	user.ModeratorStatus = string(dusers.ModeratorStatusSuspended)
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create suspended moderator: %v", err)
+	}
+
+	createReq := dmarkets.MarketCreateRequest{
+		QuestionTitle:      "Can suspended moderators create?",
+		Description:        "Suspended moderator policy regression test",
+		OutcomeType:        "BINARY",
+		ResolutionDateTime: container.clock.Now().Add(48 * time.Hour),
+	}
+	_, err := container.GetMarketsService().CreateMarket(context.Background(), createReq, user.Username)
+	if !errors.Is(err, dmarkets.ErrUnauthorized) {
+		t.Fatalf("CreateMarket for suspended moderator error = %v, want ErrUnauthorized", err)
+	}
+
+	if _, err := container.GetUsersService().UnsuspendModerator(context.Background(), user.Username, "admin", "reinstated"); err != nil {
+		t.Fatalf("unsuspend moderator: %v", err)
+	}
+	market, err := container.GetMarketsService().CreateMarket(context.Background(), createReq, user.Username)
+	if err != nil {
+		t.Fatalf("CreateMarket after reinstatement returned error: %v", err)
+	}
+	if market.LifecycleStatus != dmarkets.MarketLifecycleProposed {
+		t.Fatalf("expected reinstated moderator proposal, got %+v", market)
 	}
 }

--- a/backend/internal/domain/analytics/market_resolution_postgres_test.go
+++ b/backend/internal/domain/analytics/market_resolution_postgres_test.go
@@ -35,6 +35,9 @@ func TestResolveMarketDistributesAllBetVolumePostgres(t *testing.T) {
 		modelstesting.GenerateUser("pg_yes_winner", 0),
 		modelstesting.GenerateUser("pg_yes_second", 0),
 	}
+	users[0].UserType = "MODERATOR"
+	users[0].ModeratorStatus = "active"
+
 	for i := range users {
 		if err := db.Create(&users[i]).Error; err != nil {
 			t.Fatalf("create user %s: %v", users[i].Username, err)
@@ -43,6 +46,7 @@ func TestResolveMarketDistributesAllBetVolumePostgres(t *testing.T) {
 
 	market := modelstesting.GenerateMarket(time.Now().UnixNano()%1_000_000, users[0].Username)
 	market.IsResolved = false
+	market.StewardUsername = market.CreatorUsername
 	if err := db.Create(&market).Error; err != nil {
 		t.Fatalf("create market: %v", err)
 	}

--- a/backend/internal/domain/analytics/systemmetrics_integration_test.go
+++ b/backend/internal/domain/analytics/systemmetrics_integration_test.go
@@ -82,6 +82,9 @@ func TestComputeSystemMetrics_BalancedAfterFinalLockedBet(t *testing.T) {
 		modelstesting.GenerateUser("bob", 0),
 		modelstesting.GenerateUser("carol", 0),
 	}
+	users[0].UserType = "MODERATOR"
+	users[0].ModeratorStatus = "active"
+
 	for i := range users {
 		if err := db.Create(&users[i]).Error; err != nil {
 			t.Fatalf("create user: %v", err)
@@ -90,6 +93,7 @@ func TestComputeSystemMetrics_BalancedAfterFinalLockedBet(t *testing.T) {
 
 	market := modelstesting.GenerateMarket(7001, users[0].Username)
 	market.IsResolved = false
+	market.StewardUsername = market.CreatorUsername
 	if err := db.Create(&market).Error; err != nil {
 		t.Fatalf("create market: %v", err)
 	}
@@ -185,6 +189,9 @@ func TestResolveMarket_DistributesAllBetVolume(t *testing.T) {
 		modelstesting.GenerateUser("jyron", 0),
 		modelstesting.GenerateUser("testuser03", 0),
 	}
+	users[0].UserType = "MODERATOR"
+	users[0].ModeratorStatus = "active"
+
 	for i := range users {
 		if err := db.Create(&users[i]).Error; err != nil {
 			t.Fatalf("create user: %v", err)
@@ -193,6 +200,7 @@ func TestResolveMarket_DistributesAllBetVolume(t *testing.T) {
 
 	market := modelstesting.GenerateMarket(8002, users[0].Username)
 	market.IsResolved = false
+	market.StewardUsername = market.CreatorUsername
 	if err := db.Create(&market).Error; err != nil {
 		t.Fatalf("create market: %v", err)
 	}

--- a/backend/internal/domain/boundary/types.go
+++ b/backend/internal/domain/boundary/types.go
@@ -35,6 +35,7 @@ type User struct {
 type AuthenticatedUser struct {
 	Username           string
 	UserType           string
+	ModeratorStatus    string
 	PasswordHash       string
 	MustChangePassword bool
 }

--- a/backend/internal/domain/markets/market_creation.go
+++ b/backend/internal/domain/markets/market_creation.go
@@ -20,6 +20,10 @@ func (s *Service) CreateMarket(ctx context.Context, req MarketCreateRequest, cre
 	}
 
 	labels := s.creationPolicy.NormalizeLabels(req.YesLabel, req.NoLabel)
+	tagSlugs, err := s.validateCreateTagSlugs(ctx, req.TagSlugs)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := s.userService.ValidateUserExists(ctx, creatorUsername); err != nil {
 		return nil, ErrUserNotFound
@@ -40,6 +44,10 @@ func (s *Service) CreateMarket(ctx context.Context, req MarketCreateRequest, cre
 	}
 
 	if err := s.repo.Create(ctx, market); err != nil {
+		return nil, err
+	}
+
+	if err := s.assignTagsToMarket(ctx, market, tagSlugs, creatorUsername); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/domain/markets/market_creation.go
+++ b/backend/internal/domain/markets/market_creation.go
@@ -50,11 +50,6 @@ func (s *Service) applyCreationLifecycle(ctx context.Context, market *Market, cr
 	if market == nil {
 		return ErrInvalidInput
 	}
-	if !s.moderatorModeEnabled() {
-		market.LifecycleStatus = MarketLifecyclePublished
-		market.Status = MarketStatusActive
-		return nil
-	}
 	if s.userService == nil {
 		return ErrUnauthorized
 	}
@@ -63,9 +58,23 @@ func (s *Service) applyCreationLifecycle(ctx context.Context, market *Market, cr
 	if err != nil {
 		return ErrUserNotFound
 	}
-	if creator == nil ||
-		users.NormalizeUserType(creator.UserType) != users.UserTypeModerator ||
-		creator.ModeratorStatus != users.ModeratorStatusActive {
+	if creator == nil {
+		return ErrUnauthorized
+	}
+
+	userType := users.NormalizeUserType(creator.UserType)
+	moderatorStatus := users.NormalizeModeratorStatus(creator.UserType, string(creator.ModeratorStatus))
+	if userType == users.UserTypeModerator && moderatorStatus == users.ModeratorStatusSuspended {
+		return ErrUnauthorized
+	}
+
+	if !s.moderatorModeEnabled() {
+		market.LifecycleStatus = MarketLifecyclePublished
+		market.Status = MarketStatusActive
+		return nil
+	}
+
+	if userType != users.UserTypeModerator || moderatorStatus != users.ModeratorStatusActive {
 		return ErrUnauthorized
 	}
 

--- a/backend/internal/domain/markets/market_overview.go
+++ b/backend/internal/domain/markets/market_overview.go
@@ -23,7 +23,7 @@ func (s *Service) ListMarkets(ctx context.Context, filters ListFilters) ([]*Mark
 func (s *Service) ListLifecycleMarkets(ctx context.Context, filters ListFilters) ([]*Market, error) {
 	status := NormalizeLifecycleStatus(filters.Status)
 	switch status {
-	case MarketLifecycleProposed, MarketLifecyclePublished, MarketLifecycleRejected:
+	case MarketStatusAll, MarketLifecycleProposed, MarketLifecyclePublished, MarketLifecycleRejected, MarketLifecycleClosed, MarketLifecycleResolved, MarketLifecycleCancelled:
 	default:
 		return nil, ErrInvalidInput
 	}

--- a/backend/internal/domain/markets/market_resolution.go
+++ b/backend/internal/domain/markets/market_resolution.go
@@ -21,7 +21,15 @@ func (s *Service) ResolveMarket(ctx context.Context, marketID int64, resolution 
 		return ErrMarketNotFound
 	}
 
-	if err := s.resolutionPolicy.ValidateResolutionRequest(market, username); err != nil {
+	if err := s.ensureMarketGovernanceActor(ctx, market, username); err != nil {
+		return err
+	}
+
+	resolverUsername := username
+	if !market.StewardedBy(username) {
+		resolverUsername = market.CurrentStewardUsername()
+	}
+	if err := s.resolutionPolicy.ValidateResolutionRequest(market, resolverUsername); err != nil {
 		return err
 	}
 

--- a/backend/internal/domain/markets/market_stewardship.go
+++ b/backend/internal/domain/markets/market_stewardship.go
@@ -1,0 +1,123 @@
+package markets
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	users "socialpredict/internal/domain/users"
+)
+
+// MarketStewardshipRepository persists steward reassignment and audit facts.
+type MarketStewardshipRepository interface {
+	ReassignMarketSteward(ctx context.Context, marketID int64, fromStewardUsername string, toStewardUsername string, actorUsername string, reason string, changedAt time.Time) error
+}
+
+// MarketStewardshipAuditRecord captures a market stewardship reassignment fact.
+type MarketStewardshipAuditRecord struct {
+	ID                  int64
+	MarketID            int64
+	FromStewardUsername string
+	ToStewardUsername   string
+	ActorUsername       string
+	Reason              string
+	CreatedAt           time.Time
+}
+
+func (s *Service) ReassignMarketSteward(ctx context.Context, marketID int64, newStewardUsername string, actorUsername string, reason string) (*Market, error) {
+	newStewardUsername = strings.TrimSpace(newStewardUsername)
+	actorUsername = strings.TrimSpace(actorUsername)
+	reason = strings.TrimSpace(reason)
+	if marketID <= 0 || newStewardUsername == "" || actorUsername == "" || reason == "" {
+		return nil, ErrInvalidInput
+	}
+
+	market, err := s.GetMarket(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.validateAssignableSteward(ctx, newStewardUsername); err != nil {
+		return nil, err
+	}
+
+	fromSteward := market.CurrentStewardUsername()
+	if strings.EqualFold(fromSteward, newStewardUsername) {
+		return market, nil
+	}
+
+	repo, err := s.stewardshipRepository()
+	if err != nil {
+		return nil, err
+	}
+
+	now := s.clock.Now()
+	if err := repo.ReassignMarketSteward(ctx, marketID, fromSteward, newStewardUsername, actorUsername, reason, now); err != nil {
+		return nil, err
+	}
+	market.StewardUsername = newStewardUsername
+	market.UpdatedAt = now
+	market.StewardshipAudits = append(market.StewardshipAudits, MarketStewardshipAuditRecord{
+		MarketID:            marketID,
+		FromStewardUsername: fromSteward,
+		ToStewardUsername:   newStewardUsername,
+		ActorUsername:       actorUsername,
+		Reason:              reason,
+		CreatedAt:           now,
+	})
+	return market, nil
+}
+
+func (s *Service) validateAssignableSteward(ctx context.Context, username string) error {
+	if s.userService == nil {
+		return ErrUnauthorized
+	}
+	user, err := s.userService.GetPublicUser(ctx, username)
+	if err != nil {
+		return ErrUserNotFound
+	}
+	if user == nil || users.NormalizeUserType(user.UserType) != users.UserTypeModerator || users.NormalizeModeratorStatus(user.UserType, string(user.ModeratorStatus)) != users.ModeratorStatusActive {
+		return ErrUnauthorized
+	}
+	return nil
+}
+
+func (s *Service) ensureMarketGovernanceActor(ctx context.Context, market *Market, username string) error {
+	username = strings.TrimSpace(username)
+	if market == nil || username == "" || s.userService == nil {
+		return ErrUnauthorized
+	}
+	actor, err := s.userService.GetPublicUser(ctx, username)
+	if err != nil {
+		return ErrUserNotFound
+	}
+	if actor == nil {
+		return ErrUnauthorized
+	}
+
+	userType := users.NormalizeUserType(actor.UserType)
+	moderatorStatus := users.NormalizeModeratorStatus(actor.UserType, string(actor.ModeratorStatus))
+	if userType == users.UserTypeAdmin {
+		return nil
+	}
+	if userType == users.UserTypeModerator && moderatorStatus == users.ModeratorStatusSuspended {
+		return ErrUnauthorized
+	}
+	if market.StewardedBy(username) {
+		if !s.moderatorModeEnabled() || (userType == users.UserTypeModerator && moderatorStatus == users.ModeratorStatusActive) {
+			return nil
+		}
+	}
+	return ErrUnauthorized
+}
+
+func (s *Service) stewardshipRepository() (MarketStewardshipRepository, error) {
+	if s == nil || s.repo == nil {
+		return nil, ErrInvalidInput
+	}
+	repo, ok := s.repo.(MarketStewardshipRepository)
+	if !ok {
+		return nil, ErrInvalidInput
+	}
+	return repo, nil
+}

--- a/backend/internal/domain/markets/market_tags.go
+++ b/backend/internal/domain/markets/market_tags.go
@@ -1,0 +1,287 @@
+package markets
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	MaxMarketTagSlugLength          = 64
+	MaxMarketTagDisplayNameLength   = 120
+	MaxMarketTagDescriptionLength   = 500
+	MaxMarketTagColorKeyLength      = 40
+	MaxMarketTagsPerMarket          = 5
+	MarketTagAssignmentSourceCreate = "moderator_create"
+	MarketTagAssignmentSourceAdmin  = "admin_adjust"
+)
+
+var (
+	marketTagSlugPattern     = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	marketTagColorKeyPattern = regexp.MustCompile(`^[a-z0-9_-]*$`)
+)
+
+// MarketTag is an admin-managed taxonomy label that can be attached to markets.
+type MarketTag struct {
+	ID          int64
+	Slug        string
+	DisplayName string
+	Description string
+	ColorKey    string
+	SortOrder   int
+	IsActive    bool
+	CreatedBy   string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// MarketTagRequest captures create/update input for a tag.
+type MarketTagRequest struct {
+	Slug        string
+	DisplayName string
+	Description string
+	ColorKey    string
+	SortOrder   int
+	IsActive    *bool
+}
+
+// MarketTagRepository persists market taxonomy tags and assignments.
+type MarketTagRepository interface {
+	ListMarketTags(ctx context.Context, includeInactive bool) ([]MarketTag, error)
+	CreateMarketTag(ctx context.Context, tag MarketTag) (*MarketTag, error)
+	UpdateMarketTag(ctx context.Context, slug string, update MarketTagRequest) (*MarketTag, error)
+	SetMarketTags(ctx context.Context, marketID int64, tagSlugs []string, assignedBy string, source string, assignedAt time.Time) ([]MarketTag, error)
+}
+
+func (s *Service) ListMarketTags(ctx context.Context, includeInactive bool) ([]MarketTag, error) {
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	return repo.ListMarketTags(ctx, includeInactive)
+}
+
+func (s *Service) CreateMarketTag(ctx context.Context, req MarketTagRequest, actorUsername string) (*MarketTag, error) {
+	tag, err := normalizeMarketTagRequest(req, actorUsername)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	return repo.CreateMarketTag(ctx, tag)
+}
+
+func (s *Service) UpdateMarketTag(ctx context.Context, slug string, req MarketTagRequest) (*MarketTag, error) {
+	slug = NormalizeMarketTagSlug(slug)
+	if slug == "" {
+		return nil, ErrInvalidInput
+	}
+	if err := validateMarketTagRequest(req, false); err != nil {
+		return nil, err
+	}
+	req.Slug = NormalizeMarketTagSlug(req.Slug)
+	if req.Slug != "" && req.Slug != slug {
+		return nil, ErrInvalidInput
+	}
+	req.Description = strings.TrimSpace(req.Description)
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
+	req.ColorKey = strings.TrimSpace(strings.ToLower(req.ColorKey))
+
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	return repo.UpdateMarketTag(ctx, slug, req)
+}
+
+func (s *Service) UpdateMarketTags(ctx context.Context, marketID int64, tagSlugs []string, actorUsername string) (*Market, error) {
+	if marketID <= 0 || strings.TrimSpace(actorUsername) == "" {
+		return nil, ErrInvalidInput
+	}
+
+	market, err := s.GetMarket(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch NormalizeLifecycleStatus(market.LifecycleStatus) {
+	case MarketLifecycleProposed, MarketLifecyclePublished:
+	default:
+		return nil, ErrInvalidState
+	}
+
+	normalized, err := s.validateCreateTagSlugs(ctx, tagSlugs)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	tags, err := repo.SetMarketTags(ctx, marketID, normalized, actorUsername, MarketTagAssignmentSourceAdmin, s.clock.Now())
+	if err != nil {
+		return nil, err
+	}
+	market.Tags = tags
+	return market, nil
+}
+
+func (s *Service) assignTagsToMarket(ctx context.Context, market *Market, tagSlugs []string, assignedBy string) error {
+	normalized, err := NormalizeMarketTagSlugs(tagSlugs)
+	if err != nil {
+		return err
+	}
+	if len(normalized) == 0 {
+		market.Tags = []MarketTag{}
+		return nil
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return err
+	}
+	tags, err := repo.SetMarketTags(ctx, market.ID, normalized, assignedBy, MarketTagAssignmentSourceCreate, s.clock.Now())
+	if err != nil {
+		return err
+	}
+	market.Tags = tags
+	return nil
+}
+
+func (s *Service) validateCreateTagSlugs(ctx context.Context, tagSlugs []string) ([]string, error) {
+	normalized, err := NormalizeMarketTagSlugs(tagSlugs)
+	if err != nil {
+		return nil, err
+	}
+	if len(normalized) == 0 {
+		return []string{}, nil
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	activeTags, err := repo.ListMarketTags(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	activeBySlug := make(map[string]bool, len(activeTags))
+	for _, tag := range activeTags {
+		activeBySlug[tag.Slug] = tag.IsActive
+	}
+	for _, slug := range normalized {
+		if !activeBySlug[slug] {
+			return nil, ErrInvalidInput
+		}
+	}
+	return normalized, nil
+}
+
+func (s *Service) marketTagRepository() (MarketTagRepository, error) {
+	if s == nil || s.repo == nil {
+		return nil, ErrInvalidInput
+	}
+	repo, ok := s.repo.(MarketTagRepository)
+	if !ok {
+		return nil, ErrInvalidInput
+	}
+	return repo, nil
+}
+
+func normalizeMarketTagRequest(req MarketTagRequest, actorUsername string) (MarketTag, error) {
+	if req.Slug == "" {
+		req.Slug = slugFromDisplayName(req.DisplayName)
+	}
+	if err := validateMarketTagRequest(req, true); err != nil {
+		return MarketTag{}, err
+	}
+	active := true
+	if req.IsActive != nil {
+		active = *req.IsActive
+	}
+	return MarketTag{
+		Slug:        NormalizeMarketTagSlug(req.Slug),
+		DisplayName: strings.TrimSpace(req.DisplayName),
+		Description: strings.TrimSpace(req.Description),
+		ColorKey:    strings.TrimSpace(strings.ToLower(req.ColorKey)),
+		SortOrder:   req.SortOrder,
+		IsActive:    active,
+		CreatedBy:   strings.TrimSpace(actorUsername),
+	}, nil
+}
+
+func validateMarketTagRequest(req MarketTagRequest, requireDisplayName bool) error {
+	slug := NormalizeMarketTagSlug(req.Slug)
+	displayName := strings.TrimSpace(req.DisplayName)
+	description := strings.TrimSpace(req.Description)
+	colorKey := strings.TrimSpace(strings.ToLower(req.ColorKey))
+
+	if slug != "" && (len(slug) > MaxMarketTagSlugLength || !marketTagSlugPattern.MatchString(slug)) {
+		return ErrInvalidInput
+	}
+	if requireDisplayName && displayName == "" {
+		return ErrInvalidInput
+	}
+	if displayName != "" && len(displayName) > MaxMarketTagDisplayNameLength {
+		return ErrInvalidInput
+	}
+	if len(description) > MaxMarketTagDescriptionLength {
+		return ErrInvalidInput
+	}
+	if len(colorKey) > MaxMarketTagColorKeyLength || !marketTagColorKeyPattern.MatchString(colorKey) {
+		return ErrInvalidInput
+	}
+	return nil
+}
+
+// NormalizeMarketTagSlug canonicalizes a tag slug for storage and comparisons.
+func NormalizeMarketTagSlug(slug string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(slug)), "-")
+}
+
+// NormalizeMarketTagSlugs canonicalizes, validates, de-duplicates, and sorts tag slugs.
+func NormalizeMarketTagSlugs(slugs []string) ([]string, error) {
+	if len(slugs) == 0 {
+		return []string{}, nil
+	}
+	seen := make(map[string]bool, len(slugs))
+	normalized := make([]string, 0, len(slugs))
+	for _, raw := range slugs {
+		slug := NormalizeMarketTagSlug(raw)
+		if slug == "" {
+			continue
+		}
+		if len(slug) > MaxMarketTagSlugLength || !marketTagSlugPattern.MatchString(slug) {
+			return nil, ErrInvalidInput
+		}
+		if !seen[slug] {
+			seen[slug] = true
+			normalized = append(normalized, slug)
+		}
+	}
+	if len(normalized) > MaxMarketTagsPerMarket {
+		return nil, ErrInvalidInput
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func slugFromDisplayName(displayName string) string {
+	displayName = strings.ToLower(strings.TrimSpace(displayName))
+	var builder strings.Builder
+	lastHyphen := false
+	for _, r := range displayName {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen {
+			builder.WriteRune('-')
+			lastHyphen = true
+		}
+	}
+	return NormalizeMarketTagSlug(builder.String())
+}

--- a/backend/internal/domain/markets/models.go
+++ b/backend/internal/domain/markets/models.go
@@ -17,6 +17,7 @@ type Market struct {
 	FinalResolutionDateTime time.Time
 	ResolutionResult        string
 	CreatorUsername         string
+	StewardUsername         string
 	YesLabel                string
 	NoLabel                 string
 	Status                  string
@@ -31,6 +32,8 @@ type Market struct {
 	UpdatedAt               time.Time
 	InitialProbability      float64
 	UTCOffset               int
+	StewardshipAudits       []MarketStewardshipAuditRecord
+	Tags                    []MarketTag
 }
 
 // CreatedBy reports whether the market belongs to the supplied creator username.
@@ -39,6 +42,26 @@ func (m *Market) CreatedBy(username string) bool {
 		return false
 	}
 	return strings.TrimSpace(m.CreatorUsername) == strings.TrimSpace(username)
+}
+
+// CurrentStewardUsername returns the current market steward, falling back to
+// creator for legacy rows created before stewardship existed.
+func (m *Market) CurrentStewardUsername() string {
+	if m == nil {
+		return ""
+	}
+	if steward := strings.TrimSpace(m.StewardUsername); steward != "" {
+		return steward
+	}
+	return strings.TrimSpace(m.CreatorUsername)
+}
+
+// StewardedBy reports whether username is the current market steward.
+func (m *Market) StewardedBy(username string) bool {
+	if m == nil {
+		return false
+	}
+	return m.CurrentStewardUsername() == strings.TrimSpace(username)
 }
 
 // IsResolved reports whether the market is in the resolved state.
@@ -65,6 +88,7 @@ type MarketCreateRequest struct {
 	ResolutionDateTime time.Time
 	YesLabel           string
 	NoLabel            string
+	TagSlugs           []string
 }
 
 // HasCustomLabels reports whether the create request includes either custom label.
@@ -166,11 +190,13 @@ type PublicMarket struct {
 	ResolutionResult        string
 	InitialProbability      float64
 	CreatorUsername         string
+	StewardUsername         string
 	CreatedAt               time.Time
 	YesLabel                string
 	NoLabel                 string
 	Status                  string
 	LifecycleStatus         string
+	Tags                    []MarketTag
 }
 
 // Resolved reports whether the public market already has a terminal resolution.
@@ -199,11 +225,13 @@ func copyPublicMarket(target *PublicMarket, market *Market) *PublicMarket {
 		ResolutionResult:        market.ResolutionResult,
 		InitialProbability:      market.InitialProbability,
 		CreatorUsername:         market.CreatorUsername,
+		StewardUsername:         market.CurrentStewardUsername(),
 		CreatedAt:               market.CreatedAt,
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,
 		Status:                  market.Status,
 		LifecycleStatus:         market.LifecycleStatus,
+		Tags:                    append([]MarketTag(nil), market.Tags...),
 	}
 
 	return target

--- a/backend/internal/domain/markets/service.go
+++ b/backend/internal/domain/markets/service.go
@@ -164,16 +164,19 @@ type StatusPolicy interface {
 // ListFilters represents filters for listing markets.
 type ListFilters struct {
 	Status    string
+	Query     string
 	CreatedBy string
+	TagSlug   string
 	Limit     int
 	Offset    int
 }
 
 // SearchFilters represents filters for searching markets.
 type SearchFilters struct {
-	Status string
-	Limit  int
-	Offset int
+	Status  string
+	TagSlug string
+	Limit   int
+	Offset  int
 }
 
 // SearchResults represents the result of a market search with fallback.

--- a/backend/internal/domain/markets/service_creation_lifecycle_test.go
+++ b/backend/internal/domain/markets/service_creation_lifecycle_test.go
@@ -29,7 +29,16 @@ func TestCreateMarketOpenModeCreatesPublishedActiveMarket(t *testing.T) {
 			return nil
 		}
 	})
-	service := markets.NewService(repo, newNoopUserService(), newFixedClock(now), markets.Config{})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*dusers.PublicUser, error) {
+			return &dusers.PublicUser{
+				Username:        username,
+				UserType:        string(dusers.UserTypeRegular),
+				ModeratorStatus: dusers.ModeratorStatusNone,
+			}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{})
 
 	market, err := service.CreateMarket(context.Background(), validCreateRequest(now), "alice")
 	if err != nil {
@@ -105,6 +114,14 @@ func TestCreateMarketModeratorModeRejectsRegularAndSuspendedModerators(t *testin
 				service.getPublicUserFunc = func(context.Context, string) (*dusers.PublicUser, error) {
 					return tt.user, nil
 				}
+				service.validateUserBalanceFunc = func(context.Context, string, int64, int64) error {
+					t.Fatalf("balance validation should not run for unauthorized creator")
+					return nil
+				}
+				service.deductBalanceFunc = func(context.Context, string, int64) error {
+					t.Fatalf("balance deduction should not run for unauthorized creator")
+					return nil
+				}
 			})
 			service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{GameMode: "moderator", MarketApprovalRequired: true})
 
@@ -113,6 +130,39 @@ func TestCreateMarketModeratorModeRejectsRegularAndSuspendedModerators(t *testin
 				t.Fatalf("CreateMarket error = %v, want ErrUnauthorized", err)
 			}
 		})
+	}
+}
+
+func TestCreateMarketRejectsSuspendedModeratorOutsideModeratorMode(t *testing.T) {
+	now := marketsTestTime()
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.createFunc = func(context.Context, *markets.Market) error {
+			t.Fatalf("repository create should not be called")
+			return nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(context.Context, string) (*dusers.PublicUser, error) {
+			return &dusers.PublicUser{
+				Username:        "moderator",
+				UserType:        string(dusers.UserTypeModerator),
+				ModeratorStatus: dusers.ModeratorStatusSuspended,
+			}, nil
+		}
+		service.validateUserBalanceFunc = func(context.Context, string, int64, int64) error {
+			t.Fatalf("balance validation should not run for suspended moderator")
+			return nil
+		}
+		service.deductBalanceFunc = func(context.Context, string, int64) error {
+			t.Fatalf("balance deduction should not run for suspended moderator")
+			return nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{})
+
+	_, err := service.CreateMarket(context.Background(), validCreateRequest(now), "moderator")
+	if !errors.Is(err, markets.ErrUnauthorized) {
+		t.Fatalf("CreateMarket error = %v, want ErrUnauthorized", err)
 	}
 }
 

--- a/backend/internal/domain/markets/service_policies.go
+++ b/backend/internal/domain/markets/service_policies.go
@@ -81,6 +81,7 @@ func (p defaultCreationPolicy) BuildMarketEntity(now time.Time, req MarketCreate
 		OutcomeType:        req.OutcomeType,
 		ResolutionDateTime: req.ResolutionDateTime,
 		CreatorUsername:    creatorUsername,
+		StewardUsername:    creatorUsername,
 		YesLabel:           labels.yes,
 		NoLabel:            labels.no,
 		Status:             MarketStatusActive,
@@ -104,7 +105,7 @@ func (defaultResolutionPolicy) NormalizeResolution(resolution string) (string, e
 }
 
 func (defaultResolutionPolicy) ValidateResolutionRequest(market *Market, username string) error {
-	if market.CreatorUsername != username {
+	if !market.StewardedBy(username) {
 		return ErrUnauthorized
 	}
 
@@ -234,9 +235,10 @@ func (defaultSearchPolicy) NewSearchResults(query string, status string, primary
 
 func (defaultSearchPolicy) BuildFallbackFilters(primary SearchFilters) SearchFilters {
 	return SearchFilters{
-		Status: "",
-		Limit:  primary.Limit * 2,
-		Offset: 0,
+		Status:  "",
+		TagSlug: primary.TagSlug,
+		Limit:   primary.Limit * 2,
+		Offset:  0,
 	}
 }
 

--- a/backend/internal/domain/markets/service_probability_test.go
+++ b/backend/internal/domain/markets/service_probability_test.go
@@ -27,6 +27,11 @@ type projectionRepo struct {
 	getPublicMarketFunc          func(context.Context, int64) (*markets.PublicMarket, error)
 	approveMarketFunc            func(context.Context, int64, string, time.Time) error
 	rejectMarketFunc             func(context.Context, int64, string, time.Time, string) error
+	reassignMarketStewardFunc    func(context.Context, int64, string, string, string, string, time.Time) error
+	listMarketTagsFunc           func(context.Context, bool) ([]markets.MarketTag, error)
+	createMarketTagFunc          func(context.Context, markets.MarketTag) (*markets.MarketTag, error)
+	updateMarketTagFunc          func(context.Context, string, markets.MarketTagRequest) (*markets.MarketTag, error)
+	setMarketTagsFunc            func(context.Context, int64, []string, string, string, time.Time) ([]markets.MarketTag, error)
 }
 
 func newProjectionRepo(opts ...func(*projectionRepo)) *projectionRepo {
@@ -67,6 +72,21 @@ func newProjectionRepo(opts ...func(*projectionRepo)) *projectionRepo {
 		},
 		rejectMarketFunc: func(context.Context, int64, string, time.Time, string) error {
 			return errUnexpectedMarketsTestCall
+		},
+		reassignMarketStewardFunc: func(context.Context, int64, string, string, string, string, time.Time) error {
+			return errUnexpectedMarketsTestCall
+		},
+		listMarketTagsFunc: func(context.Context, bool) ([]markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
+		},
+		createMarketTagFunc: func(context.Context, markets.MarketTag) (*markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
+		},
+		updateMarketTagFunc: func(context.Context, string, markets.MarketTagRequest) (*markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
+		},
+		setMarketTagsFunc: func(context.Context, int64, []string, string, string, time.Time) ([]markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
 		},
 	}
 	for _, opt := range opts {
@@ -150,6 +170,42 @@ func (r *projectionRepo) RejectMarket(ctx context.Context, id int64, actorUserna
 	}
 	return r.rejectMarketFunc(ctx, id, actorUsername, rejectedAt, reason)
 }
+
+func (r *projectionRepo) ReassignMarketSteward(ctx context.Context, id int64, fromStewardUsername string, toStewardUsername string, actorUsername string, reason string, changedAt time.Time) error {
+	if r.reassignMarketStewardFunc == nil {
+		return errUnexpectedMarketsTestCall
+	}
+	return r.reassignMarketStewardFunc(ctx, id, fromStewardUsername, toStewardUsername, actorUsername, reason, changedAt)
+}
+
+func (r *projectionRepo) ListMarketTags(ctx context.Context, includeInactive bool) ([]markets.MarketTag, error) {
+	if r.listMarketTagsFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.listMarketTagsFunc(ctx, includeInactive)
+}
+
+func (r *projectionRepo) CreateMarketTag(ctx context.Context, tag markets.MarketTag) (*markets.MarketTag, error) {
+	if r.createMarketTagFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.createMarketTagFunc(ctx, tag)
+}
+
+func (r *projectionRepo) UpdateMarketTag(ctx context.Context, slug string, update markets.MarketTagRequest) (*markets.MarketTag, error) {
+	if r.updateMarketTagFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.updateMarketTagFunc(ctx, slug, update)
+}
+
+func (r *projectionRepo) SetMarketTags(ctx context.Context, marketID int64, tagSlugs []string, assignedBy string, source string, assignedAt time.Time) ([]markets.MarketTag, error) {
+	if r.setMarketTagsFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.setMarketTagsFunc(ctx, marketID, tagSlugs, assignedBy, source, assignedAt)
+}
+
 func (r *projectionRepo) GetUserPosition(ctx context.Context, marketID int64, username string) (*markets.UserPosition, error) {
 	if r.getUserPositionFunc == nil {
 		return nil, errUnexpectedMarketsTestCall

--- a/backend/internal/domain/markets/service_resolve_test.go
+++ b/backend/internal/domain/markets/service_resolve_test.go
@@ -210,7 +210,9 @@ func newResolveUserService(opts ...func(*resolveUserService)) *resolveUserServic
 		validateUserBalanceFunc: func(context.Context, string, int64, int64) error { return nil },
 		deductBalanceFunc:       func(context.Context, string, int64) error { return nil },
 		applyTransactionFunc:    func(context.Context, string, int64, string) error { return nil },
-		getPublicUserFunc:       func(context.Context, string) (*users.PublicUser, error) { return nil, nil },
+		getPublicUserFunc: func(_ context.Context, username string) (*users.PublicUser, error) {
+			return &users.PublicUser{Username: username, UserType: string(users.UserTypeRegular), ModeratorStatus: users.ModeratorStatusNone}, nil
+		},
 	}
 	for _, opt := range opts {
 		opt(service)

--- a/backend/internal/domain/markets/service_search_test.go
+++ b/backend/internal/domain/markets/service_search_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	markets "socialpredict/internal/domain/markets"
+	"socialpredict/models"
 	"socialpredict/models/modelstesting"
 
 	"gorm.io/gorm"
@@ -27,6 +28,27 @@ func seedSearchMarkets(t *testing.T, db *gorm.DB, username string) {
 		if err := db.Create(market).Error; err != nil {
 			t.Fatalf("seed market: %v", err)
 		}
+	}
+}
+
+func assignSearchMarketTag(t *testing.T, db *gorm.DB, marketID int64, slug string) {
+	t.Helper()
+
+	tag := models.MarketTag{
+		Slug:        slug,
+		DisplayName: slug,
+		IsActive:    true,
+	}
+	if err := db.Create(&tag).Error; err != nil {
+		t.Fatalf("create market tag: %v", err)
+	}
+	assignment := models.MarketTagAssignment{
+		MarketID: marketID,
+		TagID:    tag.ID,
+		Source:   markets.MarketTagAssignmentSourceAdmin,
+	}
+	if err := db.Create(&assignment).Error; err != nil {
+		t.Fatalf("create market tag assignment: %v", err)
 	}
 }
 
@@ -125,6 +147,43 @@ func TestServiceSearchMarketsFiltersByStatus(t *testing.T) {
 				t.Fatalf("expected fallback results, got none")
 			}
 		})
+	}
+}
+
+func TestServiceSearchAndListMarketsFilterByTagSlug(t *testing.T) {
+	service, db, _ := setupServiceWithDB(t)
+
+	user := modelstesting.GenerateUser("tag_filter_user", 0)
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	seedSearchMarkets(t, db, user.Username)
+	assignSearchMarketTag(t, db, 1, "bitcoin")
+	assignSearchMarketTag(t, db, 4, "stocks")
+
+	searchResult, err := service.SearchMarkets(context.Background(), "bitcoin", markets.SearchFilters{
+		Status:  "all",
+		TagSlug: "bitcoin",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMarkets returned error: %v", err)
+	}
+	if len(searchResult.PrimaryResults) != 1 || searchResult.PrimaryResults[0].ID != 1 {
+		t.Fatalf("expected only bitcoin-tagged search result, got %+v", searchResult.PrimaryResults)
+	}
+
+	listResult, err := service.ListMarkets(context.Background(), markets.ListFilters{
+		Status:  "active",
+		TagSlug: "stocks",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListMarkets returned error: %v", err)
+	}
+	if len(listResult) != 1 || listResult[0].ID != 4 {
+		t.Fatalf("expected only stocks-tagged list result, got %+v", listResult)
 	}
 }
 

--- a/backend/internal/domain/markets/service_stewardship_test.go
+++ b/backend/internal/domain/markets/service_stewardship_test.go
@@ -1,0 +1,110 @@
+package markets_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	markets "socialpredict/internal/domain/markets"
+	users "socialpredict/internal/domain/users"
+)
+
+func TestReassignMarketStewardRequiresActiveModerator(t *testing.T) {
+	now := marketsTestTime()
+	market := &markets.Market{ID: 10, CreatorUsername: "creator", StewardUsername: "creator", Status: markets.MarketStatusActive, LifecycleStatus: markets.MarketLifecyclePublished}
+	reassigned := false
+	repo := newProjectionRepo(withProjectionRepoMarket(market), func(repo *projectionRepo) {
+		repo.reassignMarketStewardFunc = func(_ context.Context, marketID int64, from string, to string, actor string, reason string, changedAt time.Time) error {
+			if marketID != market.ID || from != "creator" || to != "backup" || actor != "admin" || reason != "creator inactive" || !changedAt.Equal(now) {
+				t.Fatalf("unexpected reassign args: id=%d from=%q to=%q actor=%q reason=%q at=%s", marketID, from, to, actor, reason, changedAt)
+			}
+			reassigned = true
+			return nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*users.PublicUser, error) {
+			return &users.PublicUser{Username: username, UserType: string(users.UserTypeModerator), ModeratorStatus: users.ModeratorStatusActive}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{GameMode: "moderator"})
+
+	updated, err := service.ReassignMarketSteward(context.Background(), market.ID, "backup", "admin", "creator inactive")
+	if err != nil {
+		t.Fatalf("ReassignMarketSteward returned error: %v", err)
+	}
+	if !reassigned || updated.CurrentStewardUsername() != "backup" {
+		t.Fatalf("expected steward reassignment, reassigned=%v updated=%+v", reassigned, updated)
+	}
+}
+
+func TestReassignMarketStewardRejectsSuspendedModerator(t *testing.T) {
+	market := &markets.Market{ID: 11, CreatorUsername: "creator", StewardUsername: "creator"}
+	repo := newProjectionRepo(withProjectionRepoMarket(market), func(repo *projectionRepo) {
+		repo.reassignMarketStewardFunc = func(context.Context, int64, string, string, string, string, time.Time) error {
+			t.Fatalf("repository reassign should not be called")
+			return nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*users.PublicUser, error) {
+			return &users.PublicUser{Username: username, UserType: string(users.UserTypeModerator), ModeratorStatus: users.ModeratorStatusSuspended}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(marketsTestTime()), markets.Config{GameMode: "moderator"})
+
+	_, err := service.ReassignMarketSteward(context.Background(), market.ID, "suspended", "admin", "coverage gap")
+	if !errors.Is(err, markets.ErrUnauthorized) {
+		t.Fatalf("ReassignMarketSteward error = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestResolveMarketUsesCurrentStewardAndBlocksFormerCreator(t *testing.T) {
+	market := &markets.Market{ID: 12, CreatorUsername: "creator", StewardUsername: "backup", Status: markets.MarketStatusActive, LifecycleStatus: markets.MarketLifecyclePublished, ResolutionDateTime: marketsTestTime().Add(time.Hour)}
+	repo := newResolveRepo(
+		withResolveRepoMarket(market),
+		withResolveRepoBets([]*markets.Bet{}),
+		withResolveRepoPayouts([]*markets.PayoutPosition{}),
+		withResolveRepoResolve(func(_ context.Context, marketID int64, outcome string) error {
+			if marketID != market.ID || outcome != "YES" {
+				t.Fatalf("unexpected resolve args: id=%d outcome=%q", marketID, outcome)
+			}
+			return nil
+		}),
+	)
+	usersSvc := newResolveUserService(func(service *resolveUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*users.PublicUser, error) {
+			return &users.PublicUser{Username: username, UserType: string(users.UserTypeModerator), ModeratorStatus: users.ModeratorStatusActive}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newNopClock(marketsTestTime()), markets.Config{GameMode: "moderator"})
+
+	if err := service.ResolveMarket(context.Background(), market.ID, "YES", "creator"); !errors.Is(err, markets.ErrUnauthorized) {
+		t.Fatalf("creator resolve error = %v, want ErrUnauthorized", err)
+	}
+	if err := service.ResolveMarket(context.Background(), market.ID, "YES", "backup"); err != nil {
+		t.Fatalf("steward ResolveMarket returned error: %v", err)
+	}
+}
+
+func TestResolveMarketBlocksSuspendedSteward(t *testing.T) {
+	market := &markets.Market{ID: 13, CreatorUsername: "creator", StewardUsername: "backup", Status: markets.MarketStatusActive, LifecycleStatus: markets.MarketLifecyclePublished, ResolutionDateTime: marketsTestTime().Add(time.Hour)}
+	repo := newResolveRepo(
+		withResolveRepoMarket(market),
+		withResolveRepoResolve(func(context.Context, int64, string) error {
+			t.Fatalf("repository resolve should not be called")
+			return nil
+		}),
+	)
+	usersSvc := newResolveUserService(func(service *resolveUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*users.PublicUser, error) {
+			return &users.PublicUser{Username: username, UserType: string(users.UserTypeModerator), ModeratorStatus: users.ModeratorStatusSuspended}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newNopClock(marketsTestTime()), markets.Config{GameMode: "moderator"})
+
+	if err := service.ResolveMarket(context.Background(), market.ID, "YES", "backup"); !errors.Is(err, markets.ErrUnauthorized) {
+		t.Fatalf("suspended steward resolve error = %v, want ErrUnauthorized", err)
+	}
+}

--- a/backend/internal/domain/markets/service_tags_test.go
+++ b/backend/internal/domain/markets/service_tags_test.go
@@ -1,0 +1,207 @@
+package markets_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	markets "socialpredict/internal/domain/markets"
+	dusers "socialpredict/internal/domain/users"
+)
+
+func TestCreateMarketAssignsValidatedActiveTags(t *testing.T) {
+	now := marketsTestTime()
+	var assignedMarketID int64
+	var assignedSlugs []string
+	var assignedBy string
+	var assignmentSource string
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.listMarketTagsFunc = func(_ context.Context, includeInactive bool) ([]markets.MarketTag, error) {
+			if includeInactive {
+				t.Fatalf("create validation should request active tags only")
+			}
+			return []markets.MarketTag{
+				{ID: 1, Slug: "politics", DisplayName: "Politics", IsActive: true},
+				{ID: 2, Slug: "sports", DisplayName: "Sports", IsActive: true},
+			}, nil
+		}
+		repo.createFunc = func(_ context.Context, market *markets.Market) error {
+			market.ID = 123
+			return nil
+		}
+		repo.setMarketTagsFunc = func(_ context.Context, marketID int64, tagSlugs []string, by string, source string, assignedAt time.Time) ([]markets.MarketTag, error) {
+			assignedMarketID = marketID
+			assignedSlugs = append([]string(nil), tagSlugs...)
+			assignedBy = by
+			assignmentSource = source
+			if !assignedAt.Equal(now) {
+				t.Fatalf("assignedAt = %s, want %s", assignedAt, now)
+			}
+			return []markets.MarketTag{{ID: 1, Slug: "politics", DisplayName: "Politics", IsActive: true}}, nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*dusers.PublicUser, error) {
+			return &dusers.PublicUser{Username: username, UserType: string(dusers.UserTypeModerator), ModeratorStatus: dusers.ModeratorStatusActive}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{GameMode: "moderator", MarketApprovalRequired: true})
+
+	req := validCreateRequest(now)
+	req.TagSlugs = []string{"Politics", "sports", "politics"}
+	market, err := service.CreateMarket(context.Background(), req, "moderator")
+	if err != nil {
+		t.Fatalf("CreateMarket returned error: %v", err)
+	}
+	if assignedMarketID != 123 || assignedBy != "moderator" || assignmentSource != markets.MarketTagAssignmentSourceCreate {
+		t.Fatalf("unexpected assignment metadata id=%d by=%q source=%q", assignedMarketID, assignedBy, assignmentSource)
+	}
+	if !reflect.DeepEqual(assignedSlugs, []string{"politics", "sports"}) {
+		t.Fatalf("assigned slugs = %+v", assignedSlugs)
+	}
+	if len(market.Tags) != 1 || market.Tags[0].Slug != "politics" {
+		t.Fatalf("expected returned market tags, got %+v", market.Tags)
+	}
+}
+
+func TestCreateMarketRejectsUnknownOrInactiveTagBeforeCreate(t *testing.T) {
+	now := marketsTestTime()
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.listMarketTagsFunc = func(context.Context, bool) ([]markets.MarketTag, error) {
+			return []markets.MarketTag{{ID: 1, Slug: "active", DisplayName: "Active", IsActive: true}}, nil
+		}
+		repo.createFunc = func(context.Context, *markets.Market) error {
+			t.Fatalf("market should not be created when tags are invalid")
+			return nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*dusers.PublicUser, error) {
+			return &dusers.PublicUser{Username: username, UserType: string(dusers.UserTypeModerator), ModeratorStatus: dusers.ModeratorStatusActive}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{GameMode: "moderator", MarketApprovalRequired: true})
+
+	req := validCreateRequest(now)
+	req.TagSlugs = []string{"missing"}
+	_, err := service.CreateMarket(context.Background(), req, "moderator")
+	if !errors.Is(err, markets.ErrInvalidInput) {
+		t.Fatalf("CreateMarket error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestCreateAndUpdateMarketTagNormalizeAndValidate(t *testing.T) {
+	now := marketsTestTime()
+	var createdBy string
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.createMarketTagFunc = func(_ context.Context, tag markets.MarketTag) (*markets.MarketTag, error) {
+			createdBy = tag.CreatedBy
+			if tag.Slug != "public-health" || tag.DisplayName != "Public Health" || !tag.IsActive {
+				t.Fatalf("unexpected create tag: %+v", tag)
+			}
+			tag.ID = 7
+			return &tag, nil
+		}
+		repo.updateMarketTagFunc = func(_ context.Context, slug string, req markets.MarketTagRequest) (*markets.MarketTag, error) {
+			if slug != "public-health" || req.DisplayName != "Health" || req.IsActive == nil || *req.IsActive {
+				t.Fatalf("unexpected update args slug=%q req=%+v", slug, req)
+			}
+			return &markets.MarketTag{ID: 7, Slug: slug, DisplayName: req.DisplayName, IsActive: *req.IsActive}, nil
+		}
+	})
+	service := markets.NewService(repo, newNoopUserService(), newFixedClock(now), markets.Config{})
+
+	created, err := service.CreateMarketTag(context.Background(), markets.MarketTagRequest{DisplayName: "Public Health"}, "admin")
+	if err != nil {
+		t.Fatalf("CreateMarketTag returned error: %v", err)
+	}
+	if created.ID != 7 || createdBy != "admin" {
+		t.Fatalf("unexpected created tag: %+v by=%q", created, createdBy)
+	}
+
+	active := false
+	updated, err := service.UpdateMarketTag(context.Background(), "Public-Health", markets.MarketTagRequest{DisplayName: "Health", IsActive: &active})
+	if err != nil {
+		t.Fatalf("UpdateMarketTag returned error: %v", err)
+	}
+	if updated.DisplayName != "Health" || updated.IsActive {
+		t.Fatalf("unexpected updated tag: %+v", updated)
+	}
+}
+
+func TestUpdateMarketTagsRewritesProposedOrPublishedAssignments(t *testing.T) {
+	now := marketsTestTime()
+	var assignedMarketID int64
+	var assignedSlugs []string
+	var assignedBy string
+	var assignmentSource string
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.getByIDFunc = func(_ context.Context, marketID int64) (*markets.Market, error) {
+			return &markets.Market{ID: marketID, LifecycleStatus: markets.MarketLifecyclePublished, Status: markets.MarketStatusActive}, nil
+		}
+		repo.listMarketTagsFunc = func(_ context.Context, includeInactive bool) ([]markets.MarketTag, error) {
+			if includeInactive {
+				t.Fatalf("admin market tag assignment validation should request active tags only")
+			}
+			return []markets.MarketTag{
+				{ID: 1, Slug: "policy", DisplayName: "Policy", IsActive: true},
+				{ID: 2, Slug: "sports", DisplayName: "Sports", IsActive: true},
+			}, nil
+		}
+		repo.setMarketTagsFunc = func(_ context.Context, marketID int64, tagSlugs []string, by string, source string, assignedAt time.Time) ([]markets.MarketTag, error) {
+			assignedMarketID = marketID
+			assignedSlugs = append([]string(nil), tagSlugs...)
+			assignedBy = by
+			assignmentSource = source
+			if !assignedAt.Equal(now) {
+				t.Fatalf("assignedAt = %s, want %s", assignedAt, now)
+			}
+			return []markets.MarketTag{{ID: 1, Slug: "policy", DisplayName: "Policy", IsActive: true}}, nil
+		}
+	})
+	service := markets.NewService(repo, newNoopUserService(), newFixedClock(now), markets.Config{})
+
+	market, err := service.UpdateMarketTags(context.Background(), 99, []string{"sports", "policy"}, "admin")
+	if err != nil {
+		t.Fatalf("UpdateMarketTags returned error: %v", err)
+	}
+	if assignedMarketID != 99 || assignedBy != "admin" || assignmentSource != markets.MarketTagAssignmentSourceAdmin {
+		t.Fatalf("unexpected assignment metadata id=%d by=%q source=%q", assignedMarketID, assignedBy, assignmentSource)
+	}
+	if !reflect.DeepEqual(assignedSlugs, []string{"policy", "sports"}) {
+		t.Fatalf("assigned slugs = %+v", assignedSlugs)
+	}
+	if len(market.Tags) != 1 || market.Tags[0].Slug != "policy" {
+		t.Fatalf("expected returned market tags, got %+v", market.Tags)
+	}
+}
+
+func TestUpdateMarketTagsRejectsRejectedMarkets(t *testing.T) {
+	now := marketsTestTime()
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.getByIDFunc = func(_ context.Context, marketID int64) (*markets.Market, error) {
+			return &markets.Market{ID: marketID, LifecycleStatus: markets.MarketLifecycleRejected, Status: markets.MarketLifecycleRejected}, nil
+		}
+		repo.listMarketTagsFunc = func(context.Context, bool) ([]markets.MarketTag, error) {
+			t.Fatalf("rejected market should fail before tag validation")
+			return nil, nil
+		}
+	})
+	service := markets.NewService(repo, newNoopUserService(), newFixedClock(now), markets.Config{})
+
+	_, err := service.UpdateMarketTags(context.Background(), 99, []string{"policy"}, "admin")
+	if !errors.Is(err, markets.ErrInvalidState) {
+		t.Fatalf("UpdateMarketTags error = %v, want ErrInvalidState", err)
+	}
+}
+
+func TestNormalizeMarketTagSlugsRejectsTooManyOrInvalidSlugs(t *testing.T) {
+	if _, err := markets.NormalizeMarketTagSlugs([]string{"valid", "not valid"}); !errors.Is(err, markets.ErrInvalidInput) {
+		t.Fatalf("invalid slug error = %v, want ErrInvalidInput", err)
+	}
+	if _, err := markets.NormalizeMarketTagSlugs([]string{"a", "b", "c", "d", "e", "f"}); !errors.Is(err, markets.ErrInvalidInput) {
+		t.Fatalf("too many tags error = %v, want ErrInvalidInput", err)
+	}
+}

--- a/backend/internal/domain/users/service.go
+++ b/backend/internal/domain/users/service.go
@@ -110,6 +110,7 @@ type ServiceDependencies struct {
 // ListFilters represents filters for listing users
 type ListFilters struct {
 	UserType string
+	Query    string
 	Limit    int
 	Offset   int
 }

--- a/backend/internal/repository/markets/market_tags.go
+++ b/backend/internal/repository/markets/market_tags.go
@@ -1,0 +1,213 @@
+package markets
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	dmarkets "socialpredict/internal/domain/markets"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+func (r *GormRepository) ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error) {
+	query := r.db.WithContext(ctx).Model(&models.MarketTag{})
+	if !includeInactive {
+		query = query.Where("is_active = ?", true)
+	}
+	query = query.Order("sort_order ASC, display_name ASC, slug ASC")
+
+	var tags []models.MarketTag
+	if err := query.Find(&tags).Error; err != nil {
+		return nil, err
+	}
+	return modelTagsToDomain(tags), nil
+}
+
+func (r *GormRepository) CreateMarketTag(ctx context.Context, tag dmarkets.MarketTag) (*dmarkets.MarketTag, error) {
+	dbTag := domainTagToModel(tag)
+	if err := r.db.WithContext(ctx).
+		Select("Slug", "DisplayName", "Description", "ColorKey", "SortOrder", "IsActive", "CreatedBy").
+		Create(&dbTag).Error; err != nil {
+		return nil, err
+	}
+	if !tag.IsActive {
+		if err := r.db.WithContext(ctx).Model(&models.MarketTag{}).
+			Where("id = ?", dbTag.ID).
+			Update("is_active", false).Error; err != nil {
+			return nil, err
+		}
+		if err := r.db.WithContext(ctx).First(&dbTag, dbTag.ID).Error; err != nil {
+			return nil, err
+		}
+	}
+	out := modelTagToDomain(dbTag)
+	return &out, nil
+}
+
+func (r *GormRepository) UpdateMarketTag(ctx context.Context, slug string, update dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+	updates := map[string]any{
+		"updated_at": time.Now(),
+	}
+	if update.DisplayName != "" {
+		updates["display_name"] = update.DisplayName
+	}
+	updates["description"] = update.Description
+	updates["color_key"] = update.ColorKey
+	updates["sort_order"] = update.SortOrder
+	if update.IsActive != nil {
+		updates["is_active"] = *update.IsActive
+	}
+
+	result := r.db.WithContext(ctx).Model(&models.MarketTag{}).
+		Where("slug = ?", slug).
+		Updates(updates)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, dmarkets.ErrInvalidInput
+	}
+
+	var dbTag models.MarketTag
+	if err := r.db.WithContext(ctx).Where("slug = ?", slug).First(&dbTag).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, dmarkets.ErrInvalidInput
+		}
+		return nil, err
+	}
+	out := modelTagToDomain(dbTag)
+	return &out, nil
+}
+
+func (r *GormRepository) SetMarketTags(ctx context.Context, marketID int64, tagSlugs []string, assignedBy string, source string, assignedAt time.Time) ([]dmarkets.MarketTag, error) {
+	if marketID <= 0 {
+		return nil, dmarkets.ErrInvalidInput
+	}
+	normalized, err := dmarkets.NormalizeMarketTagSlugs(tagSlugs)
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []models.MarketTag
+	if len(normalized) > 0 {
+		if err := r.db.WithContext(ctx).
+			Where("slug IN ? AND is_active = ?", normalized, true).
+			Order("sort_order ASC, display_name ASC, slug ASC").
+			Find(&tags).Error; err != nil {
+			return nil, err
+		}
+		if len(tags) != len(normalized) {
+			return nil, dmarkets.ErrInvalidInput
+		}
+	}
+
+	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Unscoped().Where("market_id = ?", marketID).Delete(&models.MarketTagAssignment{}).Error; err != nil {
+			return err
+		}
+		for _, tag := range tags {
+			assignment := models.MarketTagAssignment{
+				MarketID:   marketID,
+				TagID:      tag.ID,
+				AssignedBy: assignedBy,
+				Source:     source,
+			}
+			assignment.CreatedAt = assignedAt
+			assignment.UpdatedAt = assignedAt
+			if err := tx.Create(&assignment).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return modelTagsToDomain(tags), nil
+}
+
+func (r *GormRepository) hydrateTagsForMarkets(ctx context.Context, markets []*dmarkets.Market) error {
+	if len(markets) == 0 {
+		return nil
+	}
+
+	marketIDs := make([]int64, 0, len(markets))
+	marketByID := make(map[int64]*dmarkets.Market, len(markets))
+	for _, market := range markets {
+		if market == nil {
+			continue
+		}
+		marketIDs = append(marketIDs, market.ID)
+		marketByID[market.ID] = market
+	}
+	if len(marketIDs) == 0 {
+		return nil
+	}
+
+	rows := []struct {
+		MarketID int64
+		models.MarketTag
+	}{}
+	if err := r.db.WithContext(ctx).
+		Table("market_tag_assignments").
+		Select("market_tag_assignments.market_id, market_tags.*").
+		Joins("JOIN market_tags ON market_tags.id = market_tag_assignments.tag_id").
+		Where("market_tag_assignments.market_id IN ?", marketIDs).
+		Order("market_tags.sort_order ASC, market_tags.display_name ASC, market_tags.slug ASC").
+		Scan(&rows).Error; err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+		market := marketByID[row.MarketID]
+		if market == nil {
+			continue
+		}
+		tag := modelTagToDomain(row.MarketTag)
+		market.Tags = append(market.Tags, tag)
+	}
+	for _, market := range markets {
+		if market != nil && market.Tags == nil {
+			market.Tags = []dmarkets.MarketTag{}
+		}
+	}
+	return nil
+}
+
+func domainTagToModel(tag dmarkets.MarketTag) models.MarketTag {
+	return models.MarketTag{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+		CreatedBy:   tag.CreatedBy,
+	}
+}
+
+func modelTagToDomain(tag models.MarketTag) dmarkets.MarketTag {
+	return dmarkets.MarketTag{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+		CreatedBy:   tag.CreatedBy,
+		CreatedAt:   tag.CreatedAt,
+		UpdatedAt:   tag.UpdatedAt,
+	}
+}
+
+func modelTagsToDomain(tags []models.MarketTag) []dmarkets.MarketTag {
+	out := make([]dmarkets.MarketTag, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, modelTagToDomain(tag))
+	}
+	return out
+}

--- a/backend/internal/repository/markets/repository.go
+++ b/backend/internal/repository/markets/repository.go
@@ -50,7 +50,11 @@ func (r *GormRepository) GetByID(ctx context.Context, id int64) (*dmarkets.Marke
 		return nil, err
 	}
 
-	return r.modelToDomain(&dbMarket), nil
+	market := r.modelToDomain(&dbMarket)
+	if err := r.hydrateTagsForMarkets(ctx, []*dmarkets.Market{market}); err != nil {
+		return nil, err
+	}
+	return market, nil
 }
 
 // GetPublicMarket retrieves a market with public-facing attributes.
@@ -63,6 +67,10 @@ func (r *GormRepository) GetPublicMarket(ctx context.Context, marketID int64) (*
 		return nil, err
 	}
 
+	domainMarket := r.modelToDomain(&market)
+	if err := r.hydrateTagsForMarkets(ctx, []*dmarkets.Market{domainMarket}); err != nil {
+		return nil, err
+	}
 	return &dmarkets.PublicMarket{
 		ID:                      market.ID,
 		QuestionTitle:           market.QuestionTitle,
@@ -75,11 +83,13 @@ func (r *GormRepository) GetPublicMarket(ctx context.Context, marketID int64) (*
 		ResolutionResult:        market.ResolutionResult,
 		InitialProbability:      market.InitialProbability,
 		CreatorUsername:         market.CreatorUsername,
+		StewardUsername:         domainMarket.CurrentStewardUsername(),
 		CreatedAt:               market.CreatedAt,
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,
-		Status:                  r.modelToDomain(&market).Status,
+		Status:                  domainMarket.Status,
 		LifecycleStatus:         dmarkets.NormalizeLifecycleStatus(market.LifecycleStatus),
+		Tags:                    domainMarket.Tags,
 	}, nil
 }
 
@@ -110,15 +120,20 @@ func (r *GormRepository) List(ctx context.Context, filters dmarkets.ListFilters)
 
 	query = applyListStatusFilter(query, filters.Status)
 	query = applyCreatedByFilter(query, filters.CreatedBy)
+	query = applyTagSlugFilter(query, filters.TagSlug)
 	query = applyPagination(query, filters.Limit, filters.Offset)
-	query = query.Order("created_at DESC")
+	query = query.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := query.Find(&dbMarkets).Error; err != nil {
 		return nil, err
 	}
 
-	return r.mapMarkets(dbMarkets), nil
+	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
+	return markets, nil
 }
 
 // ListByStatus retrieves markets filtered by status with pagination
@@ -127,32 +142,79 @@ func (r *GormRepository) ListByStatus(ctx context.Context, status string, p dmar
 
 	query = applyStatusByResolution(query, status, time.Now())
 	query = applyPagination(query, p.Limit, p.Offset)
-	query = query.Order("created_at DESC")
+	query = query.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := query.Find(&dbMarkets).Error; err != nil {
 		return nil, err
 	}
 
-	return r.mapMarkets(dbMarkets), nil
+	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
+	return markets, nil
 }
 
 // ListByLifecycle retrieves lifecycle queues that are intentionally excluded
 // from the public market listing scope.
 func (r *GormRepository) ListByLifecycle(ctx context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error) {
-	query := r.db.WithContext(ctx).Model(&models.Market{}).
-		Where("lifecycle_status = ?", dmarkets.NormalizeLifecycleStatus(filters.Status))
+	query := r.db.WithContext(ctx).Model(&models.Market{})
 
+	query = applyLifecycleAdminStatusFilter(query, filters.Status)
+	query = applyLifecycleSearchTerm(query, filters.Query)
 	query = applyCreatedByFilter(query, filters.CreatedBy)
 	query = applyPagination(query, filters.Limit, filters.Offset)
-	query = query.Order("created_at DESC")
+	query = query.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := query.Find(&dbMarkets).Error; err != nil {
 		return nil, err
 	}
 
-	return r.mapMarkets(dbMarkets), nil
+	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
+	if err := r.hydrateStewardshipAudits(ctx, markets); err != nil {
+		return nil, err
+	}
+	return markets, nil
+}
+
+func applyLifecycleAdminStatusFilter(query *gorm.DB, status string) *gorm.DB {
+	normalized := dmarkets.NormalizeLifecycleStatus(status)
+	switch normalized {
+	case dmarkets.MarketStatusAll:
+		return query.Where(
+			"lifecycle_status IN ? OR lifecycle_status = '' OR lifecycle_status IS NULL",
+			[]string{
+				dmarkets.MarketLifecycleProposed,
+				dmarkets.MarketLifecyclePublished,
+				dmarkets.MarketLifecycleClosed,
+				dmarkets.MarketLifecycleResolved,
+			},
+		)
+	case dmarkets.MarketLifecycleClosed:
+		return query.Where("lifecycle_status = ? OR (lifecycle_status = ? AND is_resolved = ? AND resolution_date_time <= ?)",
+			dmarkets.MarketLifecycleClosed,
+			dmarkets.MarketLifecyclePublished,
+			false,
+			time.Now(),
+		)
+	case dmarkets.MarketLifecycleResolved:
+		return query.Where("is_resolved = ? OR lifecycle_status = ?", true, dmarkets.MarketLifecycleResolved)
+	default:
+		return query.Where("lifecycle_status = ?", normalized)
+	}
+}
+
+func applyLifecycleSearchTerm(query *gorm.DB, value string) *gorm.DB {
+	term := strings.TrimSpace(value)
+	if term == "" {
+		return query
+	}
+	return applySearchTerm(query, term)
 }
 
 func applyListStatusFilter(query *gorm.DB, status string) *gorm.DB {
@@ -164,6 +226,18 @@ func applyCreatedByFilter(query *gorm.DB, createdBy string) *gorm.DB {
 		return query
 	}
 	return query.Where("creator_username = ?", createdBy)
+}
+
+func applyTagSlugFilter(query *gorm.DB, tagSlug string) *gorm.DB {
+	tagSlug = strings.Trim(strings.ToLower(strings.TrimSpace(tagSlug)), "-")
+	if tagSlug == "" {
+		return query
+	}
+	return query.
+		Joins("JOIN market_tag_assignments ON market_tag_assignments.market_id = markets.id AND market_tag_assignments.deleted_at IS NULL").
+		Joins("JOIN market_tags ON market_tags.id = market_tag_assignments.tag_id AND market_tags.deleted_at IS NULL").
+		Where("market_tags.slug = ?", tagSlug).
+		Distinct("markets.*")
 }
 
 func applyStatusByResolution(query *gorm.DB, status string, now time.Time) *gorm.DB {
@@ -185,21 +259,26 @@ func (r *GormRepository) Search(ctx context.Context, query string, filters dmark
 
 	dbQuery = applySearchTerm(dbQuery, query)
 	dbQuery = applyStatusFilter(dbQuery, filters.Status)
+	dbQuery = applyTagSlugFilter(dbQuery, filters.TagSlug)
 	dbQuery = applyPagination(dbQuery, filters.Limit, filters.Offset)
-	dbQuery = dbQuery.Order("created_at DESC")
+	dbQuery = dbQuery.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := dbQuery.Find(&dbMarkets).Error; err != nil {
 		return nil, err
 	}
 
-	return r.mapMarkets(dbMarkets), nil
+	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
+	return markets, nil
 }
 
 func applySearchTerm(dbQuery *gorm.DB, query string) *gorm.DB {
 	searchTerm := strings.ToLower(query)
 	searchPattern := "%" + searchTerm + "%"
-	return dbQuery.Where("(LOWER(question_title) LIKE ? OR LOWER(description) LIKE ?)", searchPattern, searchPattern)
+	return dbQuery.Where("(LOWER(markets.question_title) LIKE ? OR LOWER(markets.description) LIKE ?)", searchPattern, searchPattern)
 }
 
 func applyStatusFilter(dbQuery *gorm.DB, status string) *gorm.DB {
@@ -244,6 +323,50 @@ func (r *GormRepository) mapMarkets(dbMarkets []models.Market) []*dmarkets.Marke
 		markets[i] = r.modelToDomain(&dbMarket)
 	}
 	return markets
+}
+
+func (r *GormRepository) hydrateStewardshipAudits(ctx context.Context, markets []*dmarkets.Market) error {
+	if len(markets) == 0 {
+		return nil
+	}
+
+	marketIDs := make([]int64, 0, len(markets))
+	marketByID := make(map[int64]*dmarkets.Market, len(markets))
+	for _, market := range markets {
+		if market == nil {
+			continue
+		}
+		marketIDs = append(marketIDs, market.ID)
+		marketByID[market.ID] = market
+	}
+	if len(marketIDs) == 0 {
+		return nil
+	}
+
+	var dbAudits []models.MarketStewardshipAudit
+	if err := r.db.WithContext(ctx).
+		Where("market_id IN ?", marketIDs).
+		Order("created_at ASC, id ASC").
+		Find(&dbAudits).Error; err != nil {
+		return err
+	}
+
+	for _, dbAudit := range dbAudits {
+		market := marketByID[dbAudit.MarketID]
+		if market == nil {
+			continue
+		}
+		market.StewardshipAudits = append(market.StewardshipAudits, dmarkets.MarketStewardshipAuditRecord{
+			ID:                  dbAudit.ID,
+			MarketID:            dbAudit.MarketID,
+			FromStewardUsername: dbAudit.FromStewardUsername,
+			ToStewardUsername:   dbAudit.ToStewardUsername,
+			ActorUsername:       dbAudit.ActorUsername,
+			Reason:              dbAudit.Reason,
+			CreatedAt:           dbAudit.CreatedAt,
+		})
+	}
+	return nil
 }
 
 // GetUserPosition retrieves the aggregated position for a specific user in a market.
@@ -381,6 +504,35 @@ func (r *GormRepository) RejectMarket(ctx context.Context, id int64, actorUserna
 	return nil
 }
 
+// ReassignMarketSteward updates the current steward and records an audit fact atomically.
+func (r *GormRepository) ReassignMarketSteward(ctx context.Context, marketID int64, fromStewardUsername string, toStewardUsername string, actorUsername string, reason string, changedAt time.Time) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&models.Market{}).
+			Where("id = ?", marketID).
+			Updates(map[string]any{
+				"steward_username": toStewardUsername,
+				"updated_at":       changedAt,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return dmarkets.ErrMarketNotFound
+		}
+
+		audit := models.MarketStewardshipAudit{
+			MarketID:            marketID,
+			FromStewardUsername: fromStewardUsername,
+			ToStewardUsername:   toStewardUsername,
+			ActorUsername:       actorUsername,
+			Reason:              reason,
+		}
+		audit.CreatedAt = changedAt
+		audit.UpdatedAt = changedAt
+		return tx.Create(&audit).Error
+	})
+}
+
 // ListBetsForMarket returns all bets for the specified market ordered by placement time.
 func (r *GormRepository) ListBetsForMarket(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error) {
 	var bets []models.Bet
@@ -488,6 +640,7 @@ func (r *GormRepository) domainToModel(market *dmarkets.Market) models.Market {
 		FinalResolutionDateTime: market.FinalResolutionDateTime,
 		ResolutionResult:        market.ResolutionResult,
 		CreatorUsername:         market.CreatorUsername,
+		StewardUsername:         market.CurrentStewardUsername(),
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,
 		UTCOffset:               market.UTCOffset,
@@ -517,6 +670,7 @@ func (r *GormRepository) modelToDomain(dbMarket *models.Market) *dmarkets.Market
 		FinalResolutionDateTime: dbMarket.FinalResolutionDateTime,
 		ResolutionResult:        dbMarket.ResolutionResult,
 		CreatorUsername:         dbMarket.CreatorUsername,
+		StewardUsername:         dbMarket.StewardUsername,
 		YesLabel:                dbMarket.YesLabel,
 		NoLabel:                 dbMarket.NoLabel,
 		Status:                  status,
@@ -531,6 +685,7 @@ func (r *GormRepository) modelToDomain(dbMarket *models.Market) *dmarkets.Market
 		UpdatedAt:               dbMarket.UpdatedAt,
 		InitialProbability:      dbMarket.InitialProbability,
 		UTCOffset:               dbMarket.UTCOffset,
+		Tags:                    []dmarkets.MarketTag{},
 	}
 }
 

--- a/backend/internal/repository/markets/repository_test.go
+++ b/backend/internal/repository/markets/repository_test.go
@@ -25,6 +25,7 @@ func TestGormRepositoryCreateAndGetByID(t *testing.T) {
 		FinalResolutionDateTime: now.Add(48 * time.Hour),
 		ResolutionResult:        "",
 		CreatorUsername:         "creator",
+		StewardUsername:         "creator",
 		YesLabel:                "YES",
 		NoLabel:                 "NO",
 		Status:                  dmarkets.MarketStatusActive,
@@ -46,7 +47,7 @@ func TestGormRepositoryCreateAndGetByID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByID returned error: %v", err)
 	}
-	if got.QuestionTitle != market.QuestionTitle || got.CreatorUsername != market.CreatorUsername || got.YesLabel != "YES" || got.InitialProbability != 0.5 || got.LifecycleStatus != dmarkets.MarketLifecyclePublished {
+	if got.QuestionTitle != market.QuestionTitle || got.CreatorUsername != market.CreatorUsername || got.CurrentStewardUsername() != "creator" || got.YesLabel != "YES" || got.InitialProbability != 0.5 || got.LifecycleStatus != dmarkets.MarketLifecyclePublished {
 		t.Fatalf("unexpected market data: %+v", got)
 	}
 
@@ -417,5 +418,259 @@ func TestGormRepositoryApproveAndRejectMarketPersistReviewMetadata(t *testing.T)
 
 	if err := repo.ApproveMarket(ctx, published.ID, "admin", approvedAt); !errors.Is(err, dmarkets.ErrInvalidState) {
 		t.Fatalf("ApproveMarket wrong state error = %v, want ErrInvalidState", err)
+	}
+}
+
+func TestGormRepositoryReassignMarketStewardPersistsAudit(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("steward_creator", 1000)
+	backup := modelstesting.GenerateUser("steward_backup", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+	if err := db.Create(&backup).Error; err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+
+	market := modelstesting.GenerateMarket(701, creator.Username)
+	market.StewardUsername = creator.Username
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+
+	changedAt := time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC)
+	if err := repo.ReassignMarketSteward(ctx, market.ID, creator.Username, backup.Username, "admin", "creator inactive", changedAt); err != nil {
+		t.Fatalf("ReassignMarketSteward returned error: %v", err)
+	}
+
+	updated, err := repo.GetByID(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("load market: %v", err)
+	}
+	if updated.CurrentStewardUsername() != backup.Username {
+		t.Fatalf("steward = %q, want %q", updated.CurrentStewardUsername(), backup.Username)
+	}
+
+	var audits []models.MarketStewardshipAudit
+	if err := db.Where("market_id = ?", market.ID).Find(&audits).Error; err != nil {
+		t.Fatalf("load audits: %v", err)
+	}
+	if len(audits) != 1 {
+		t.Fatalf("expected one audit, got %d", len(audits))
+	}
+	audit := audits[0]
+	if audit.FromStewardUsername != creator.Username || audit.ToStewardUsername != backup.Username || audit.ActorUsername != "admin" || audit.Reason != "creator inactive" {
+		t.Fatalf("unexpected audit: %+v", audit)
+	}
+
+	if err := repo.ReassignMarketSteward(ctx, market.ID+999, creator.Username, backup.Username, "admin", "missing", changedAt); !errors.Is(err, dmarkets.ErrMarketNotFound) {
+		t.Fatalf("missing market error = %v, want ErrMarketNotFound", err)
+	}
+}
+
+func TestGormRepositoryListByLifecycleHydratesStewardshipAudits(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("lifecycle_steward_creator", 1000)
+	backup := modelstesting.GenerateUser("lifecycle_steward_backup", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+	if err := db.Create(&backup).Error; err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+
+	market := modelstesting.GenerateMarket(702, creator.Username)
+	market.LifecycleStatus = dmarkets.MarketLifecyclePublished
+	market.StewardUsername = backup.Username
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+
+	changedAt := time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC)
+	audit := models.MarketStewardshipAudit{
+		MarketID:            market.ID,
+		FromStewardUsername: creator.Username,
+		ToStewardUsername:   backup.Username,
+		ActorUsername:       "admin",
+		Reason:              "creator suspended",
+	}
+	audit.CreatedAt = changedAt
+	audit.UpdatedAt = changedAt
+	if err := db.Create(&audit).Error; err != nil {
+		t.Fatalf("seed audit: %v", err)
+	}
+
+	markets, err := repo.ListByLifecycle(ctx, dmarkets.ListFilters{Status: dmarkets.MarketLifecyclePublished, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListByLifecycle returned error: %v", err)
+	}
+	if len(markets) != 1 {
+		t.Fatalf("expected one market, got %d", len(markets))
+	}
+	audits := markets[0].StewardshipAudits
+	if len(audits) != 1 || audits[0].Reason != "creator suspended" || audits[0].FromStewardUsername != creator.Username || audits[0].ToStewardUsername != backup.Username || !audits[0].CreatedAt.Equal(changedAt) {
+		t.Fatalf("unexpected hydrated audits: %+v", audits)
+	}
+}
+
+func TestGormRepositoryListByLifecycleAllExcludesRejectedAndSearchesOperationalMarkets(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("lifecycle_search_creator", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+
+	published := modelstesting.GenerateMarket(703, creator.Username)
+	published.QuestionTitle = "Orchard published market"
+	published.LifecycleStatus = dmarkets.MarketLifecyclePublished
+	rejected := modelstesting.GenerateMarket(704, creator.Username)
+	rejected.QuestionTitle = "Orchard rejected market"
+	rejected.LifecycleStatus = dmarkets.MarketLifecycleRejected
+	resolved := modelstesting.GenerateMarket(705, creator.Username)
+	resolved.QuestionTitle = "Orchard resolved market"
+	resolved.LifecycleStatus = dmarkets.MarketLifecycleResolved
+	resolved.IsResolved = true
+
+	for _, market := range []models.Market{published, rejected, resolved} {
+		if err := db.Create(&market).Error; err != nil {
+			t.Fatalf("seed market %q: %v", market.QuestionTitle, err)
+		}
+	}
+
+	markets, err := repo.ListByLifecycle(ctx, dmarkets.ListFilters{
+		Status: dmarkets.MarketStatusAll,
+		Query:  "orchard",
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("ListByLifecycle returned error: %v", err)
+	}
+	if len(markets) != 2 {
+		t.Fatalf("expected published and resolved markets only, got %d: %+v", len(markets), markets)
+	}
+	for _, market := range markets {
+		if market.LifecycleStatus == dmarkets.MarketLifecycleRejected {
+			t.Fatalf("rejected market should not be included in all stewardship list: %+v", market)
+		}
+	}
+}
+
+func TestGormRepositoryMarketTagsCreateListUpdateAssignAndHydrate(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("tag_creator", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+	market := modelstesting.GenerateMarket(801, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+
+	politics, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "politics", DisplayName: "Politics", IsActive: true, SortOrder: 2, CreatedBy: "admin"})
+	if err != nil {
+		t.Fatalf("CreateMarketTag politics: %v", err)
+	}
+	if _, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "sports", DisplayName: "Sports", IsActive: true, SortOrder: 1, CreatedBy: "admin"}); err != nil {
+		t.Fatalf("CreateMarketTag sports: %v", err)
+	}
+	if _, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "economy", DisplayName: "Economy", IsActive: true, SortOrder: 3, CreatedBy: "admin"}); err != nil {
+		t.Fatalf("CreateMarketTag economy: %v", err)
+	}
+
+	activeTags, err := repo.ListMarketTags(ctx, false)
+	if err != nil {
+		t.Fatalf("ListMarketTags returned error: %v", err)
+	}
+	if len(activeTags) != 3 || activeTags[0].Slug != "sports" || activeTags[1].Slug != "politics" || activeTags[2].Slug != "economy" {
+		t.Fatalf("expected sorted active tags, got %+v", activeTags)
+	}
+
+	inactive := false
+	updated, err := repo.UpdateMarketTag(ctx, politics.Slug, dmarkets.MarketTagRequest{DisplayName: "Civic life", IsActive: &inactive})
+	if err != nil {
+		t.Fatalf("UpdateMarketTag returned error: %v", err)
+	}
+	if updated.DisplayName != "Civic life" || updated.IsActive {
+		t.Fatalf("unexpected updated tag: %+v", updated)
+	}
+
+	assigned, err := repo.SetMarketTags(ctx, market.ID, []string{"sports"}, creator.Username, dmarkets.MarketTagAssignmentSourceCreate, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SetMarketTags returned error: %v", err)
+	}
+	if len(assigned) != 1 || assigned[0].Slug != "sports" {
+		t.Fatalf("unexpected assigned tags: %+v", assigned)
+	}
+
+	got, err := repo.GetByID(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0].Slug != "sports" {
+		t.Fatalf("expected hydrated tag on GetByID, got %+v", got.Tags)
+	}
+
+	listed, err := repo.List(ctx, dmarkets.ListFilters{Limit: 10})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(listed) != 1 || len(listed[0].Tags) != 1 || listed[0].Tags[0].Slug != "sports" {
+		t.Fatalf("expected hydrated tag on List, got %+v", listed)
+	}
+
+	assigned, err = repo.SetMarketTags(ctx, market.ID, []string{"sports", "economy"}, creator.Username, dmarkets.MarketTagAssignmentSourceAdmin, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SetMarketTags with two tags returned error: %v", err)
+	}
+	if len(assigned) != 2 {
+		t.Fatalf("expected two assigned tags, got %+v", assigned)
+	}
+	assigned, err = repo.SetMarketTags(ctx, market.ID, []string{"sports"}, creator.Username, dmarkets.MarketTagAssignmentSourceAdmin, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SetMarketTags removing one retained tag returned error: %v", err)
+	}
+	if len(assigned) != 1 || assigned[0].Slug != "sports" {
+		t.Fatalf("expected only retained sports tag, got %+v", assigned)
+	}
+	got, err = repo.GetByID(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("GetByID after replacing tags returned error: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0].Slug != "sports" {
+		t.Fatalf("expected hydrated retained tag after replacement, got %+v", got.Tags)
+	}
+}
+
+func TestGormRepositorySetMarketTagsRejectsInactiveTags(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("inactive_tag_creator", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+	market := modelstesting.GenerateMarket(802, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+	if _, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "inactive", DisplayName: "Inactive", IsActive: false}); err != nil {
+		t.Fatalf("CreateMarketTag returned error: %v", err)
+	}
+
+	if _, err := repo.SetMarketTags(ctx, market.ID, []string{"inactive"}, creator.Username, dmarkets.MarketTagAssignmentSourceCreate, time.Now().UTC()); !errors.Is(err, dmarkets.ErrInvalidInput) {
+		t.Fatalf("SetMarketTags error = %v, want ErrInvalidInput", err)
 	}
 }

--- a/backend/internal/repository/users/repository.go
+++ b/backend/internal/repository/users/repository.go
@@ -21,6 +21,7 @@ type GormRepository struct {
 type authenticatedUserRow struct {
 	Username           string
 	UserType           string
+	ModeratorStatus    string
 	Password           string
 	MustChangePassword bool
 }
@@ -314,7 +315,7 @@ func (r *GormRepository) FindAuthenticatedUser(ctx context.Context, username str
 	var user authenticatedUserRow
 	if err := r.db.WithContext(ctx).
 		Table("users").
-		Select("username", "user_type", "password", "must_change_password").
+		Select("username", "user_type", "moderator_status", "password", "must_change_password").
 		Where("username = ?", username).
 		Take(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -326,6 +327,7 @@ func (r *GormRepository) FindAuthenticatedUser(ctx context.Context, username str
 	return &boundary.AuthenticatedUser{
 		Username:           user.Username,
 		UserType:           user.UserType,
+		ModeratorStatus:    string(dusers.NormalizeModeratorStatus(user.UserType, user.ModeratorStatus)),
 		PasswordHash:       user.Password,
 		MustChangePassword: user.MustChangePassword,
 	}, nil

--- a/backend/internal/repository/users/repository.go
+++ b/backend/internal/repository/users/repository.go
@@ -3,6 +3,7 @@ package users
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"socialpredict/internal/domain/boundary"
@@ -152,6 +153,16 @@ func (r *GormRepository) List(ctx context.Context, filters dusers.ListFilters) (
 
 	if filters.UserType != "" {
 		query = query.Where("user_type = ?", filters.UserType)
+	}
+
+	if term := strings.ToLower(strings.TrimSpace(filters.Query)); term != "" {
+		like := "%" + term + "%"
+		query = query.Where(
+			"LOWER(username) LIKE ? OR LOWER(display_name) LIKE ? OR LOWER(email) LIKE ?",
+			like,
+			like,
+			like,
+		)
 	}
 
 	if filters.Limit > 0 {

--- a/backend/internal/repository/users/repository_test.go
+++ b/backend/internal/repository/users/repository_test.go
@@ -182,7 +182,7 @@ func TestGormRepositoryIdentityAndCredentialPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindAuthenticatedUser returned error: %v", err)
 	}
-	if authUser.Username != user.Username || authUser.UserType != "admin" || authUser.PasswordHash != "hash-old" || !authUser.MustChangePassword {
+	if authUser.Username != user.Username || authUser.UserType != "admin" || authUser.ModeratorStatus != "none" || authUser.PasswordHash != "hash-old" || !authUser.MustChangePassword {
 		t.Fatalf("unexpected authenticated user: %+v", authUser)
 	}
 

--- a/backend/internal/service/auth/loggin.go
+++ b/backend/internal/service/auth/loggin.go
@@ -32,6 +32,7 @@ type loginResponse struct {
 	Token              string `json:"token"`
 	Username           string `json:"username"`
 	UserType           string `json:"usertype"`
+	ModeratorStatus    string `json:"moderatorStatus"`
 	MustChangePassword bool   `json:"mustChangePassword"`
 }
 
@@ -188,6 +189,7 @@ func writeLoginResponse(w http.ResponseWriter, user boundary.AuthenticatedUser, 
 		Token:              tokenString,
 		Username:           user.Username,
 		UserType:           user.UserType,
+		ModeratorStatus:    user.ModeratorStatus,
 		MustChangePassword: user.MustChangePassword,
 	})
 }

--- a/backend/migration/migrations/20251208_090000_add_market_stewardship.go
+++ b/backend/migration/migrations/20251208_090000_add_market_stewardship.go
@@ -1,0 +1,38 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+// MigrateAddMarketStewardship adds current-steward storage while preserving
+// immutable creator attribution. Existing markets backfill steward to creator.
+func MigrateAddMarketStewardship(db *gorm.DB) error {
+	m := db.Migrator()
+
+	if !m.HasColumn(&models.Market{}, "StewardUsername") {
+		if err := m.AddColumn(&models.Market{}, "StewardUsername"); err != nil {
+			return err
+		}
+	}
+
+	if err := db.Model(&models.Market{}).
+		Where("steward_username IS NULL OR steward_username = ''").
+		Update("steward_username", gorm.Expr("creator_username")).Error; err != nil {
+		return err
+	}
+
+	if err := db.AutoMigrate(&models.MarketStewardshipAudit{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	migration.Register("20251208090000", func(db *gorm.DB) error {
+		return MigrateAddMarketStewardship(db)
+	})
+}

--- a/backend/migration/migrations/20251208_090000_add_market_stewardship_test.go
+++ b/backend/migration/migrations/20251208_090000_add_market_stewardship_test.go
@@ -1,0 +1,79 @@
+package migrations_test
+
+import (
+	"testing"
+	"time"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+type MarketBeforeStewardship struct {
+	ID                      int64 `gorm:"primaryKey"`
+	QuestionTitle           string
+	Description             string
+	OutcomeType             string
+	ResolutionDateTime      time.Time
+	FinalResolutionDateTime time.Time
+	UTCOffset               int
+	IsResolved              bool
+	ResolutionResult        string
+	InitialProbability      float64
+	CreatorUsername         string
+	YesLabel                string
+	NoLabel                 string
+	LifecycleStatus         string
+	ProposalCost            int64
+}
+
+func (MarketBeforeStewardship) TableName() string { return "markets" }
+
+func TestMigrateAddMarketStewardshipAddsColumnBackfillsAndCreatesAuditTable(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	_ = db.Migrator().DropTable(&models.MarketStewardshipAudit{})
+	_ = db.Migrator().DropColumn(&models.Market{}, "StewardUsername")
+
+	seed := MarketBeforeStewardship{
+		ID:                 77,
+		QuestionTitle:      "Needs steward",
+		Description:        "Backfill stewardship",
+		OutcomeType:        "BINARY",
+		ResolutionDateTime: time.Now().Add(24 * time.Hour),
+		InitialProbability: 0.5,
+		CreatorUsername:    "creator",
+		LifecycleStatus:    "published",
+	}
+	if err := db.Create(&seed).Error; err != nil {
+		t.Fatalf("seed old market: %v", err)
+	}
+
+	if err := migrations.MigrateAddMarketStewardship(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	if !db.Migrator().HasColumn(&models.Market{}, "StewardUsername") {
+		t.Fatalf("expected steward_username column")
+	}
+	if !db.Migrator().HasTable(&models.MarketStewardshipAudit{}) {
+		t.Fatalf("expected market stewardship audit table")
+	}
+
+	var out models.Market
+	if err := db.First(&out, seed.ID).Error; err != nil {
+		t.Fatalf("load migrated market: %v", err)
+	}
+	if out.StewardUsername != seed.CreatorUsername {
+		t.Fatalf("steward backfill = %q, want %q", out.StewardUsername, seed.CreatorUsername)
+	}
+}
+
+func TestMigrateAddMarketStewardshipIsIdempotent(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	if err := migrations.MigrateAddMarketStewardship(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateAddMarketStewardship(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20251215_090000_add_market_tags.go
+++ b/backend/migration/migrations/20251215_090000_add_market_tags.go
@@ -1,0 +1,20 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+// MigrateAddMarketTags adds admin-managed market taxonomy tags and the
+// market-to-tag assignment table used by moderator proposals and navigation.
+func MigrateAddMarketTags(db *gorm.DB) error {
+	return db.AutoMigrate(&models.MarketTag{}, &models.MarketTagAssignment{})
+}
+
+func init() {
+	migration.Register("20251215090000", func(db *gorm.DB) error {
+		return MigrateAddMarketTags(db)
+	})
+}

--- a/backend/migration/migrations/20251215_090000_add_market_tags_test.go
+++ b/backend/migration/migrations/20251215_090000_add_market_tags_test.go
@@ -1,0 +1,37 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateAddMarketTagsCreatesTagTables(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+
+	if err := migrations.MigrateAddMarketTags(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	if !db.Migrator().HasTable(&models.MarketTag{}) {
+		t.Fatalf("expected market tags table")
+	}
+	if !db.Migrator().HasTable(&models.MarketTagAssignment{}) {
+		t.Fatalf("expected market tag assignments table")
+	}
+	if !db.Migrator().HasIndex(&models.MarketTag{}, "idx_market_tags_slug") {
+		t.Fatalf("expected unique slug index")
+	}
+}
+
+func TestMigrateAddMarketTagsIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketTags(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateAddMarketTags(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20251222_090000_add_market_discovery_cms.go
+++ b/backend/migration/migrations/20251222_090000_add_market_discovery_cms.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+// MigrateAddMarketDiscoveryCMS adds CMS-owned market discovery page and pin
+// tables for FEATURE/09 taxonomy navigation.
+func MigrateAddMarketDiscoveryCMS(db *gorm.DB) error {
+	return db.AutoMigrate(
+		&models.MarketDiscoveryPage{},
+		&models.MarketDiscoveryPin{},
+	)
+}
+
+func init() {
+	migration.Register("20251222090000", func(db *gorm.DB) error {
+		return MigrateAddMarketDiscoveryCMS(db)
+	})
+}

--- a/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
+++ b/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
@@ -1,0 +1,42 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateAddMarketDiscoveryCMSCreatesTables(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	for _, table := range []any{
+		&models.MarketDiscoveryPage{},
+		&models.MarketDiscoveryPin{},
+	} {
+		if !db.Migrator().HasTable(table) {
+			t.Fatalf("expected table for %T", table)
+		}
+	}
+	if !db.Migrator().HasIndex(&models.MarketDiscoveryPage{}, "idx_market_discovery_pages_slug") {
+		t.Fatalf("expected market discovery page slug index")
+	}
+	if !db.Migrator().HasColumn(&models.MarketDiscoveryPin{}, "target_page_slug") {
+		t.Fatalf("expected market discovery pin target_page_slug column")
+	}
+}
+
+func TestMigrateAddMarketDiscoveryCMSIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published.go
+++ b/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+
+	"gorm.io/gorm"
+)
+
+// MigrateRemoveMarketDiscoveryIsPublished removes the unused CMS draft/publish
+// flag from market discovery pages. Market discovery CMS edits publish
+// immediately, so this column only added confusion.
+func MigrateRemoveMarketDiscoveryIsPublished(db *gorm.DB) error {
+	m := db.Migrator()
+	if !m.HasTable("market_discovery_pages") || !m.HasColumn("market_discovery_pages", "is_published") {
+		return nil
+	}
+	if db.Dialector.Name() == "postgres" {
+		return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN IF EXISTS is_published").Error
+	}
+	return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN is_published").Error
+}
+
+func init() {
+	migration.Register("20251229090000", func(db *gorm.DB) error {
+		return MigrateRemoveMarketDiscoveryIsPublished(db)
+	})
+}

--- a/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published_test.go
+++ b/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published_test.go
@@ -1,0 +1,40 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateRemoveMarketDiscoveryIsPublishedDropsColumn(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := db.Exec("ALTER TABLE market_discovery_pages ADD COLUMN is_published boolean DEFAULT true").Error; err != nil {
+		t.Fatalf("add legacy is_published column: %v", err)
+	}
+	if !db.Migrator().HasColumn("market_discovery_pages", "is_published") {
+		t.Fatalf("expected setup schema to include is_published")
+	}
+	if err := migrations.MigrateRemoveMarketDiscoveryIsPublished(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	if db.Migrator().HasColumn("market_discovery_pages", "is_published") {
+		t.Fatalf("expected is_published to be removed")
+	}
+}
+
+func TestMigrateRemoveMarketDiscoveryIsPublishedIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoveryIsPublished(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoveryIsPublished(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20260105_090000_remove_market_discovery_sections.go
+++ b/backend/migration/migrations/20260105_090000_remove_market_discovery_sections.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+
+	"gorm.io/gorm"
+)
+
+// MigrateRemoveMarketDiscoverySections removes the unused FEATURE/09 section
+// scaffold. Market discovery now uses TOP topic pins plus page-level market
+// pins, so retaining sections would keep dead CMS functionality around.
+func MigrateRemoveMarketDiscoverySections(db *gorm.DB) error {
+	m := db.Migrator()
+	if m.HasTable("market_discovery_sections") {
+		if err := m.DropTable("market_discovery_sections"); err != nil {
+			return err
+		}
+	}
+	if !m.HasTable("market_discovery_pages") || !m.HasColumn("market_discovery_pages", "sections_enabled") {
+		return nil
+	}
+	if db.Dialector.Name() == "postgres" {
+		return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN IF EXISTS sections_enabled").Error
+	}
+	return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN sections_enabled").Error
+}
+
+func init() {
+	migration.Register("20260105090000", func(db *gorm.DB) error {
+		return MigrateRemoveMarketDiscoverySections(db)
+	})
+}

--- a/backend/migration/migrations/20260105_090000_remove_market_discovery_sections_test.go
+++ b/backend/migration/migrations/20260105_090000_remove_market_discovery_sections_test.go
@@ -1,0 +1,49 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateRemoveMarketDiscoverySectionsDropsTableAndColumn(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := db.Exec("ALTER TABLE market_discovery_pages ADD COLUMN sections_enabled boolean DEFAULT false").Error; err != nil {
+		t.Fatalf("add legacy sections_enabled column: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE market_discovery_sections (
+		id integer primary key,
+		page_id integer not null,
+		slug text not null,
+		title text not null
+	)`).Error; err != nil {
+		t.Fatalf("add legacy sections table: %v", err)
+	}
+
+	if err := migrations.MigrateRemoveMarketDiscoverySections(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	if db.Migrator().HasTable("market_discovery_sections") {
+		t.Fatalf("expected market_discovery_sections to be removed")
+	}
+	if db.Migrator().HasColumn("market_discovery_pages", "sections_enabled") {
+		t.Fatalf("expected sections_enabled to be removed")
+	}
+}
+
+func TestMigrateRemoveMarketDiscoverySectionsIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoverySections(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoverySections(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/models/market.go
+++ b/backend/models/market.go
@@ -29,4 +29,36 @@ type Market struct {
 	ProposalCost            int64      `json:"proposalCost" gorm:"not null;default:0"`
 	CreatorUsername         string     `json:"creatorUsername" gorm:"not null"`
 	Creator                 User       `gorm:"foreignKey:CreatorUsername;references:Username"`
+	StewardUsername         string     `json:"stewardUsername" gorm:"index"`
+}
+
+type MarketTag struct {
+	gorm.Model
+	ID          int64  `json:"id" gorm:"primary_key"`
+	Slug        string `json:"slug" gorm:"not null;uniqueIndex;size:64"`
+	DisplayName string `json:"displayName" gorm:"not null;size:120"`
+	Description string `json:"description,omitempty" gorm:"type:text"`
+	ColorKey    string `json:"colorKey,omitempty" gorm:"size:40"`
+	SortOrder   int    `json:"sortOrder" gorm:"not null;default:0;index"`
+	IsActive    bool   `json:"isActive" gorm:"not null;default:true;index"`
+	CreatedBy   string `json:"createdBy,omitempty" gorm:"index"`
+}
+
+type MarketTagAssignment struct {
+	gorm.Model
+	ID         int64  `json:"id" gorm:"primary_key"`
+	MarketID   int64  `json:"marketId" gorm:"not null;uniqueIndex:uniq_market_tag_assignment;index"`
+	TagID      int64  `json:"tagId" gorm:"not null;uniqueIndex:uniq_market_tag_assignment;index"`
+	AssignedBy string `json:"assignedBy,omitempty" gorm:"index"`
+	Source     string `json:"source,omitempty" gorm:"not null;default:moderator_create;index"`
+}
+
+type MarketStewardshipAudit struct {
+	gorm.Model
+	ID                  int64  `json:"id" gorm:"primary_key"`
+	MarketID            int64  `json:"marketId" gorm:"not null;index"`
+	FromStewardUsername string `json:"fromStewardUsername" gorm:"index"`
+	ToStewardUsername   string `json:"toStewardUsername" gorm:"not null;index"`
+	ActorUsername       string `json:"actorUsername" gorm:"not null;index"`
+	Reason              string `json:"reason,omitempty" gorm:"type:text"`
 }

--- a/backend/models/market_discovery.go
+++ b/backend/models/market_discovery.go
@@ -1,0 +1,41 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type MarketDiscoveryPage struct {
+	gorm.Model
+	ID                         uint   `gorm:"primaryKey"`
+	Slug                       string `gorm:"not null;uniqueIndex;size:96"`
+	Title                      string `gorm:"not null;size:160"`
+	Description                string `gorm:"size:500"`
+	PageType                   string `gorm:"not null;index;size:32"`
+	PrimaryTagSlug             string `gorm:"index;size:64"`
+	SearchScope                string `gorm:"not null;default:all;size:32"`
+	FeaturedTopicsEnabled      bool   `gorm:"not null;default:false"`
+	FeaturedMarketsEnabled     bool   `gorm:"not null;default:false"`
+	DefaultRecommendationLimit int    `gorm:"not null;default:20"`
+	CuratedRecommendationLimit int    `gorm:"not null;default:5"`
+	SortOrder                  int    `gorm:"not null;default:0;index"`
+	Version                    uint   `gorm:"not null;default:1"`
+	UpdatedBy                  string `gorm:"size:64"`
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
+}
+
+type MarketDiscoveryPin struct {
+	gorm.Model
+	ID             uint   `gorm:"primaryKey"`
+	ScopeType      string `gorm:"not null;index;size:32"`
+	ScopeID        uint   `gorm:"not null;index"`
+	PinType        string `gorm:"not null;index;size:32"`
+	MarketID       *int64 `gorm:"index"`
+	TargetPageID   *uint  `gorm:"index"`
+	TargetPageSlug string `gorm:"index;size:96"`
+	Label          string `gorm:"size:160"`
+	SortOrder      int    `gorm:"not null;default:0;index"`
+	CreatedBy      string `gorm:"size:64"`
+}

--- a/backend/security/ratelimit.go
+++ b/backend/security/ratelimit.go
@@ -111,6 +111,11 @@ func RateLimitMiddlewareWithProxyTrust(limiter *RateLimiter, trustProxy bool) fu
 func RateLimitMiddlewareWithClientIdentity(limiter *RateLimiter, clientIdentity ClientIdentityExtractor) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if shouldBypassRateLimit(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			clientID := clientIdentity.Extract(r)
 
 			if !limiter.GetLimiter(clientID).Allow() {
@@ -137,6 +142,11 @@ func LoginRateLimitMiddlewareWithProxyTrust(limiter *RateLimiter, trustProxy boo
 func LoginRateLimitMiddlewareWithClientIdentity(limiter *RateLimiter, clientIdentity ClientIdentityExtractor) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if shouldBypassRateLimit(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			clientID := clientIdentity.Extract(r)
 
 			if !limiter.GetLimiter(clientID).Allow() {
@@ -147,6 +157,10 @@ func LoginRateLimitMiddlewareWithClientIdentity(limiter *RateLimiter, clientIden
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func shouldBypassRateLimit(r *http.Request) bool {
+	return r != nil && r.Method == http.MethodOptions
 }
 
 // ClientIdentityExtractor defines which request attributes may identify a client at the HTTP boundary.

--- a/backend/security/ratelimit_test.go
+++ b/backend/security/ratelimit_test.go
@@ -83,6 +83,29 @@ func TestRateLimitMiddleware(t *testing.T) {
 	})
 }
 
+func TestRateLimitMiddlewareBypassesOptionsPreflight(t *testing.T) {
+	rl := NewRateLimiter(rate.Every(time.Hour), 1, time.Minute)
+	wrappedHandler := RateLimitMiddleware(rl)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+	req.RemoteAddr = "192.168.1.10:12345"
+	for i := 0; i < 3; i += 1 {
+		rr := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("OPTIONS preflight %d should bypass rate limit, got %d", i+1, rr.Code)
+		}
+	}
+
+	rr := httptest.NewRecorder()
+	wrappedHandler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/test", nil))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("GET after OPTIONS preflights should still have burst budget, got %d", rr.Code)
+	}
+}
+
 func TestLoginRateLimitMiddleware(t *testing.T) {
 	// Create a stricter rate limiter for login
 	rl := NewRateLimiter(rate.Every(10*time.Second), 1, time.Minute)
@@ -129,6 +152,29 @@ func TestLoginRateLimitMiddleware(t *testing.T) {
 
 		assertRuntimeFailureReason(t, rr, RuntimeReasonLoginRateLimited)
 	})
+}
+
+func TestLoginRateLimitMiddlewareBypassesOptionsPreflight(t *testing.T) {
+	rl := NewRateLimiter(rate.Every(time.Hour), 1, time.Minute)
+	wrappedHandler := LoginRateLimitMiddleware(rl)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/login", nil)
+	req.RemoteAddr = "192.168.1.11:12345"
+	for i := 0; i < 3; i += 1 {
+		rr := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("login OPTIONS preflight %d should bypass rate limit, got %d", i+1, rr.Code)
+		}
+	}
+
+	rr := httptest.NewRecorder()
+	wrappedHandler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/login", nil))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("POST after OPTIONS preflights should still have burst budget, got %d", rr.Code)
+	}
 }
 
 func TestRateLimitMiddlewareUsesExplicitClientIdentityExtractor(t *testing.T) {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -18,6 +18,8 @@ import (
 	sellbetshandlers "socialpredict/handlers/bets/selling"
 	"socialpredict/handlers/cms/homepage"
 	cmshomehttp "socialpredict/handlers/cms/homepage/http"
+	"socialpredict/handlers/cms/marketdiscovery"
+	cmsdiscoveryhttp "socialpredict/handlers/cms/marketdiscovery/http"
 	"socialpredict/handlers/cms/socialshare"
 	cmssocialhttp "socialpredict/handlers/cms/socialshare/http"
 	marketshandlers "socialpredict/handlers/markets"
@@ -328,6 +330,10 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	homepageSvc := homepage.NewService(homepageRepo, homepageRenderer)
 	homepageHandler := cmshomehttp.NewHandler(homepageSvc, authService)
 
+	marketDiscoveryRepo := marketdiscovery.NewGormRepository(db)
+	marketDiscoverySvc := marketdiscovery.NewService(marketDiscoveryRepo)
+	marketDiscoveryHandler := cmsdiscoveryhttp.NewHandler(marketDiscoverySvc, authService)
+
 	socialShareRepo := socialshare.NewGormRepository(db)
 	socialShareSvc := socialshare.NewService(socialShareRepo)
 	socialShareHandler := cmssocialhttp.NewHandler(socialShareSvc, authService)
@@ -386,6 +392,7 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	router.Handle("/v0/markets/{id}/resolve", securityMiddleware(http.HandlerFunc(marketsHandler.ResolveMarket))).Methods("POST")
 	router.Handle("/v0/markets/{id}/leaderboard", securityMiddleware(http.HandlerFunc(marketsHandler.MarketLeaderboard))).Methods("GET")
 	router.Handle("/v0/markets/{id}/projection", securityMiddleware(http.HandlerFunc(marketsHandler.ProjectProbability))).Methods("GET")
+	router.Handle("/v0/market-tags", securityMiddleware(marketshandlers.ListMarketTagsHandler(marketsService))).Methods("GET")
 	router.Handle("/v0/marketprojection/{marketId}/{amount}/{outcome}", securityMiddleware(marketshandlers.ProjectNewProbabilityHandler(marketsService))).Methods("GET")
 	router.Handle("/v0/marketprojection/{marketId}/{amount}/{outcome}/", securityMiddleware(marketshandlers.ProjectNewProbabilityHandler(marketsService))).Methods("GET")
 
@@ -424,9 +431,17 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	router.Handle("/v0/admin/markets", securityMiddleware(adminhandlers.ListReviewMarketsHandler(marketsService, authService))).Methods("GET")
 	router.Handle("/v0/admin/markets/{id}/approve", securityMiddleware(adminhandlers.ApproveMarketHandler(marketsService, authService))).Methods("PATCH")
 	router.Handle("/v0/admin/markets/{id}/reject", securityMiddleware(adminhandlers.RejectMarketHandler(marketsService, authService))).Methods("PATCH")
+	router.Handle("/v0/admin/markets/{id}/steward", securityMiddleware(adminhandlers.ReassignMarketStewardHandler(marketsService, authService))).Methods("PATCH")
+	router.Handle("/v0/admin/markets/{id}/tags", securityMiddleware(adminhandlers.UpdateMarketTagsHandler(marketsService, authService))).Methods("PATCH")
+	router.Handle("/v0/admin/market-tags", securityMiddleware(adminhandlers.ListAdminMarketTagsHandler(marketsService, authService))).Methods("GET")
+	router.Handle("/v0/admin/market-tags", securityMiddleware(adminhandlers.CreateAdminMarketTagHandler(marketsService, authService))).Methods("POST")
+	router.Handle("/v0/admin/market-tags/{slug}", securityMiddleware(adminhandlers.UpdateAdminMarketTagHandler(marketsService, authService))).Methods("PATCH")
 
 	router.HandleFunc("/v0/content/home", homepageHandler.PublicGet).Methods("GET")
 	router.Handle("/v0/admin/content/home", securityMiddleware(http.HandlerFunc(homepageHandler.AdminUpdate))).Methods("PUT")
+	router.HandleFunc("/v0/content/market-discovery/{slug}", marketDiscoveryHandler.PublicGet).Methods("GET")
+	router.Handle("/v0/admin/content/market-discovery/{slug}", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminUpdate))).Methods("PUT")
+	router.Handle("/v0/admin/content/market-discovery/{slug}/pins", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminReplacePins))).Methods("PUT")
 	router.HandleFunc("/v0/content/social-share", socialShareHandler.PublicGet).Methods("GET")
 	router.HandleFunc("/v0/content/social-share/image", socialShareHandler.PublicImage).Methods("GET", "HEAD")
 	router.HandleFunc("/api/v0/content/social-share/image", socialShareHandler.PublicImage).Methods("GET", "HEAD")

--- a/frontend/src/api/adminUsersApi.js
+++ b/frontend/src/api/adminUsersApi.js
@@ -26,11 +26,23 @@ const adminRequest = async ({ path, token, method = 'GET', body }) => {
   });
 };
 
-export const listAdminUsers = ({ token, limit = 100, offset = 0 }) => {
+export const listAdminUsers = ({
+  token,
+  limit = 100,
+  offset = 0,
+  usertype = '',
+  query = '',
+}) => {
   const params = new URLSearchParams({
     limit: String(limit),
     offset: String(offset),
   });
+  if (usertype) {
+    params.set('usertype', usertype);
+  }
+  if (query) {
+    params.set('query', query);
+  }
   return adminRequest({
     path: `/v0/admin/users?${params.toString()}`,
     token,

--- a/frontend/src/api/authStorage.js
+++ b/frontend/src/api/authStorage.js
@@ -2,6 +2,7 @@ const AUTH_STORAGE_KEYS = {
   token: 'token',
   username: 'username',
   usertype: 'usertype',
+  moderatorStatus: 'moderatorStatus',
   changePasswordNeeded: 'changePasswordNeeded',
 };
 
@@ -19,11 +20,13 @@ export const authStorage = {
   getToken: () => read(AUTH_STORAGE_KEYS.token),
   getUsername: () => read(AUTH_STORAGE_KEYS.username),
   getUsertype: () => read(AUTH_STORAGE_KEYS.usertype),
+  getModeratorStatus: () => read(AUTH_STORAGE_KEYS.moderatorStatus),
   setUsername: (username) => write(AUTH_STORAGE_KEYS.username, username),
-  saveLogin: ({ token, username, usertype }) => {
+  saveLogin: ({ token, username, usertype, moderatorStatus }) => {
     write(AUTH_STORAGE_KEYS.token, token);
     write(AUTH_STORAGE_KEYS.username, username);
     write(AUTH_STORAGE_KEYS.usertype, usertype);
+    write(AUTH_STORAGE_KEYS.moderatorStatus, moderatorStatus);
   },
   clearLegacyPasswordChangeFlag: () => {
     localStorage.removeItem(AUTH_STORAGE_KEYS.changePasswordNeeded);

--- a/frontend/src/api/httpClient.js
+++ b/frontend/src/api/httpClient.js
@@ -22,6 +22,19 @@ const mergeHeaders = (headers = {}, token) => {
   return merged;
 };
 
+const inflightGetRequests = new Map();
+
+const requestDedupeKey = ({ url, token, headers }) => {
+  const headerEntries = Object.entries(headers || {})
+    .filter(([key]) => key.toLowerCase() !== 'authorization')
+    .sort(([left], [right]) => left.localeCompare(right));
+  return JSON.stringify({
+    url,
+    token: token || '',
+    headers: headerEntries,
+  });
+};
+
 export const apiRequest = async (
   path,
   {
@@ -31,22 +44,44 @@ export const apiRequest = async (
     unwrap = true,
     authenticated = false,
     authToken,
+    dedupe = true,
     ...options
   } = {},
 ) => {
   const token = authenticated ? (authToken || authStorage.getToken()) : null;
-  const response = await fetch(buildUrl(path), {
-    ...options,
-    headers: mergeHeaders(headers, token),
-  });
-  const text = await response.text();
-  const data = parseApiResponseText(text);
+  const method = (options.method || 'GET').toUpperCase();
+  const url = buildUrl(path);
+  const mergedHeaders = mergeHeaders(headers, token);
 
-  if (!response.ok) {
-    throw new Error(getApiErrorMessage(response, data, fallbackMessage, reasonMessages));
+  const runRequest = async () => {
+    const response = await fetch(url, {
+      ...options,
+      headers: mergedHeaders,
+    });
+    const text = await response.text();
+    const data = parseApiResponseText(text);
+
+    if (!response.ok) {
+      throw new Error(getApiErrorMessage(response, data, fallbackMessage, reasonMessages));
+    }
+
+    return unwrap ? unwrapApiResponse(data) : data;
+  };
+
+  if (method !== 'GET' || !dedupe) {
+    return runRequest();
   }
 
-  return unwrap ? unwrapApiResponse(data) : data;
+  const key = requestDedupeKey({ url, token, headers: mergedHeaders });
+  if (inflightGetRequests.has(key)) {
+    return inflightGetRequests.get(key);
+  }
+
+  const promise = runRequest().finally(() => {
+    inflightGetRequests.delete(key);
+  });
+  inflightGetRequests.set(key, promise);
+  return promise;
 };
 
 export const authenticatedApiRequest = (path, options = {}) => apiRequest(path, {

--- a/frontend/src/api/lifecycleMarketsApi.js
+++ b/frontend/src/api/lifecycleMarketsApi.js
@@ -21,21 +21,24 @@ const lifecycleRequest = async ({ path, token }) => {
   });
 };
 
-const buildLifecycleQuery = ({ status, limit = 50, offset = 0 }) => {
+const buildLifecycleQuery = ({ status, query, limit = 50, offset = 0 }) => {
   const params = new URLSearchParams({
     status,
     limit: String(limit),
     offset: String(offset),
   });
+  if (String(query || '').trim()) {
+    params.set('query', String(query).trim());
+  }
   return params.toString();
 };
 
-export const listMyLifecycleMarkets = ({ token, status, limit, offset }) => lifecycleRequest({
-  path: `/v0/profile/markets?${buildLifecycleQuery({ status, limit, offset })}`,
+export const listMyLifecycleMarkets = ({ token, status, query, limit, offset }) => lifecycleRequest({
+  path: `/v0/profile/markets?${buildLifecycleQuery({ status, query, limit, offset })}`,
   token,
 });
 
-export const listAdminLifecycleMarkets = ({ token, status, limit, offset }) => lifecycleRequest({
-  path: `/v0/admin/markets?${buildLifecycleQuery({ status, limit, offset })}`,
+export const listAdminLifecycleMarkets = ({ token, status, query, limit, offset }) => lifecycleRequest({
+  path: `/v0/admin/markets?${buildLifecycleQuery({ status, query, limit, offset })}`,
   token,
 });

--- a/frontend/src/api/marketTagsApi.js
+++ b/frontend/src/api/marketTagsApi.js
@@ -1,0 +1,42 @@
+import { apiRequest, authenticatedApiRequest } from './httpClient';
+
+const tagReasonMessages = {
+  AUTHORIZATION_DENIED: 'Only admins can manage market tags.',
+  INVALID_REQUEST: 'Check the tag fields and try again.',
+  VALIDATION_FAILED: 'Check the tag fields and try again.',
+};
+
+export const listMarketTags = () => apiRequest('/v0/market-tags', {
+  fallbackMessage: 'Unable to load market tags.',
+});
+
+export const listAdminMarketTags = ({ token, includeInactive = true }) => authenticatedApiRequest(
+  `/v0/admin/market-tags?includeInactive=${includeInactive ? 'true' : 'false'}`,
+  {
+    authToken: token,
+    fallbackMessage: 'Unable to load market tags.',
+    reasonMessages: tagReasonMessages,
+  },
+);
+
+export const createAdminMarketTag = ({ token, tag }) => authenticatedApiRequest('/v0/admin/market-tags', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(tag),
+  authToken: token,
+  fallbackMessage: 'Unable to create market tag.',
+  reasonMessages: tagReasonMessages,
+});
+
+export const updateAdminMarketTag = ({ token, slug, tag }) => authenticatedApiRequest(`/v0/admin/market-tags/${slug}`, {
+  method: 'PATCH',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(tag),
+  authToken: token,
+  fallbackMessage: 'Unable to update market tag.',
+  reasonMessages: tagReasonMessages,
+});

--- a/frontend/src/api/marketsApi.js
+++ b/frontend/src/api/marketsApi.js
@@ -7,7 +7,7 @@ import { API_URL } from '../config';
  * @param {number} limit - Maximum number of results (optional, defaults to 20)
  * @returns {Promise<Object>} Search results object
  */
-export const searchMarkets = async (query, status = 'all', limit = 20) => {
+export const searchMarkets = async (query, status = 'all', limit = 20, options = {}) => {
     if (!query?.trim()) {
         throw new Error('Search query is required');
     }
@@ -17,6 +17,9 @@ export const searchMarkets = async (query, status = 'all', limit = 20) => {
         status: status,
         limit: limit.toString()
     });
+    if (options.tagSlug) {
+        params.set('tagSlug', options.tagSlug);
+    }
 
     const response = await fetch(`${API_URL}/v0/markets/search?${params}`);
 

--- a/frontend/src/api/moderationApi.js
+++ b/frontend/src/api/moderationApi.js
@@ -5,6 +5,7 @@ const marketReviewReasonMessages = {
   INVALID_REQUEST: 'Check the market ID and request fields.',
   INVALID_STATE: 'This market is not in a state that can be reviewed.',
   MARKET_NOT_FOUND: 'No market was found for that ID.',
+  USER_NOT_FOUND: 'No active moderator was found for that steward username.',
   VALIDATION_FAILED: 'Check the review fields and try again.',
 };
 
@@ -47,5 +48,39 @@ export const rejectProposedMarket = ({ marketId, token, reason }) => {
     token,
     action: 'reject',
     body: { reason: normalizedReason },
+  });
+};
+
+export const reassignMarketSteward = ({ marketId, token, stewardUsername, reason }) => {
+  const normalizedStewardUsername = String(stewardUsername || '').trim();
+  const normalizedReason = String(reason || '').trim();
+  if (!normalizedStewardUsername) {
+    throw new Error('A steward username is required.');
+  }
+  if (!normalizedReason) {
+    throw new Error('A reassignment reason is required.');
+  }
+
+  return reviewMarket({
+    marketId,
+    token,
+    action: 'steward',
+    body: {
+      stewardUsername: normalizedStewardUsername,
+      reason: normalizedReason,
+    },
+  });
+};
+
+export const updateMarketTags = ({ marketId, token, tagSlugs }) => {
+  if (!Array.isArray(tagSlugs)) {
+    throw new Error('Market tags must be provided as a list.');
+  }
+
+  return reviewMarket({
+    marketId,
+    token,
+    action: 'tags',
+    body: { tagSlugs },
   });
 };

--- a/frontend/src/components/charts/MarketChart.jsx
+++ b/frontend/src/components/charts/MarketChart.jsx
@@ -3,7 +3,18 @@ import CanvasJSReact from '@canvasjs/react-charts';
 
 const CanvasJSChart = CanvasJSReact.CanvasJSChart;
 
-const MarketChart = ({ data, currentProbability, title, className, closeDateTime, yesLabel, noLabel }) => {
+const MarketChart = ({
+  data,
+  currentProbability,
+  title,
+  className,
+  closeDateTime,
+  yesLabel,
+  noLabel,
+  showHeader = true,
+  compact = false,
+  height,
+}) => {
   const [showInverseProbability, setShowInverseProbability] = useState(false);
 
   const generateDataPoints = (data, isInverse = false) => {
@@ -61,28 +72,39 @@ const MarketChart = ({ data, currentProbability, title, className, closeDateTime
   };
 
   const options = {
-    animationEnabled: true,
+    animationEnabled: !compact,
     backgroundColor: 'transparent',
-    zoomEnabled: true,
+    zoomEnabled: !compact,
     axisX: {
       valueFormatString: 'DD MMM YY HH:mm',
-      labelFontColor: '#708090',
+      labelFontColor: compact ? 'transparent' : '#708090',
     },
     axisY: {
       includeZero: true,
       minimum: 0,
       maximum: 1,
-      labelFontColor: '#708090',
+      labelFontColor: compact ? 'transparent' : '#708090',
       suffix: '',
       valueFormatString: '0.00',
     },
     data: generateChartData(),
   };
+  if (height) {
+    options.height = height;
+  }
+  if (compact) {
+    options.axisX.tickLength = 0;
+    options.axisX.lineThickness = 0;
+    options.axisY.tickLength = 0;
+    options.axisY.lineThickness = 0;
+    options.axisY.gridThickness = 0;
+  }
 
   return (
-    <div className={`rounded-lg shadow p-4 ${className} overflow-hidden`}>
-      <div className="flex justify-between items-center mb-2">
-        <h3 className='text-lg font-medium'>{title}</h3>
+    <div className={`rounded-lg shadow ${compact ? 'p-0' : 'p-4'} ${className} overflow-hidden`}>
+      {showHeader && (
+        <div className="flex justify-between items-center mb-2">
+          <h3 className='text-lg font-medium'>{title}</h3>
           <button
             onClick={() => setShowInverseProbability(!showInverseProbability)}
             className={`px-3 py-1 text-sm rounded-lg transition-colors duration-200 ${showInverseProbability
@@ -93,7 +115,8 @@ const MarketChart = ({ data, currentProbability, title, className, closeDateTime
               ? `Show ${yesLabel} Probability`
               : `Show ${noLabel} Probability`}
           </button>
-      </div>
+        </div>
+      )}
       <CanvasJSChart options={options} />
     </div>
   );

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -6,8 +6,17 @@ import LoadingSpinner from '../../loaders/LoadingSpinner';
 import {
   approveProposedMarket,
   rejectProposedMarket,
+  reassignMarketSteward,
+  updateMarketTags,
 } from '../../../api/moderationApi';
 import { listAdminLifecycleMarkets } from '../../../api/lifecycleMarketsApi';
+import { listAdminUsers } from '../../../api/adminUsersApi';
+import {
+  createAdminMarketTag,
+  listAdminMarketTags,
+  updateAdminMarketTag,
+} from '../../../api/marketTagsApi';
+import MarketTagChips, { MARKET_TAG_COLOR_OPTIONS } from '../../markets/MarketTagChips';
 
 const reviewTabs = [
   { label: 'Proposed Markets', status: 'proposed' },
@@ -15,19 +24,45 @@ const reviewTabs = [
   { label: 'Rejected Markets', status: 'rejected' },
 ];
 
+const maxMarketTagsPerMarket = 5;
+
+const isActiveModerator = (user) => (
+  user?.usertype === 'MODERATOR' && (user.moderatorStatus || 'active') === 'active'
+);
+
+const marketTagSlugs = (market) => (market.tags || [])
+  .map((tag) => tag.slug)
+  .filter(Boolean)
+  .sort();
+
+const sameTagSlugs = (left, right) => (
+  JSON.stringify([...left].sort()) === JSON.stringify([...right].sort())
+);
+
 const AdminMarketQueue = ({ status }) => {
   const { token } = useAuth();
   const [markets, setMarkets] = useState([]);
+  const [activeTags, setActiveTags] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
   const [rejectionReasons, setRejectionReasons] = useState({});
+  const [tagForms, setTagForms] = useState({});
   const [busyMarketId, setBusyMarketId] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
 
-  const loadMarkets = async () => {
+  const tagEditingEnabled = status === 'proposed' || status === 'published';
+
+  const loadMarkets = async (query = searchQuery) => {
     setLoading(true);
     setError('');
     try {
-      const data = await listAdminLifecycleMarkets({ token, status });
+      const data = await listAdminLifecycleMarkets({
+        token,
+        status,
+        query,
+        limit: 100,
+      });
       setMarkets(data.markets || []);
     } catch (err) {
       setError(err.message || 'Unable to load market queue.');
@@ -37,13 +72,46 @@ const AdminMarketQueue = ({ status }) => {
   };
 
   useEffect(() => {
-    loadMarkets();
+    const timeoutId = window.setTimeout(() => {
+      loadMarkets(searchQuery);
+    }, 300);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status, token]);
+  }, [status, token, searchQuery]);
+
+  useEffect(() => {
+    if (!token || !tagEditingEnabled) {
+      return;
+    }
+
+    let ignore = false;
+    const loadActiveTags = async () => {
+      try {
+        const result = await listAdminMarketTags({ token, includeInactive: false });
+        if (!ignore) {
+          setActiveTags(result.tags || []);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load active market tags.');
+        }
+      }
+    };
+
+    loadActiveTags();
+
+    return () => {
+      ignore = true;
+    };
+  }, [token, tagEditingEnabled]);
 
   const approveMarket = async (marketId) => {
     setBusyMarketId(marketId);
     setError('');
+    setSuccessMessage('');
     try {
       await approveProposedMarket({ marketId, token });
       await loadMarkets();
@@ -58,6 +126,7 @@ const AdminMarketQueue = ({ status }) => {
     const reason = rejectionReasons[marketId];
     setBusyMarketId(marketId);
     setError('');
+    setSuccessMessage('');
     try {
       await rejectProposedMarket({ marketId, token, reason });
       setRejectionReasons((current) => ({ ...current, [marketId]: '' }));
@@ -69,39 +138,147 @@ const AdminMarketQueue = ({ status }) => {
     }
   };
 
+  const updateMarketInQueue = (updatedMarket) => {
+    setMarkets((current) => current.map((market) => (
+      market.id === updatedMarket.id ? { ...market, ...updatedMarket } : market
+    )));
+  };
+
+  const tagSlugsForForm = (market) => tagForms[market.id] || marketTagSlugs(market);
+
+  const toggleMarketTag = (market, slug) => {
+    setTagForms((current) => {
+      const selected = current[market.id] || marketTagSlugs(market);
+      const next = selected.includes(slug)
+        ? selected.filter((item) => item !== slug)
+        : [...selected, slug].sort();
+      return { ...current, [market.id]: next };
+    });
+  };
+
+  const saveMarketTags = async (market) => {
+    const tagSlugs = tagSlugsForForm(market);
+    setBusyMarketId(market.id);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const updatedMarket = await updateMarketTags({ marketId: market.id, token, tagSlugs });
+      updateMarketInQueue(updatedMarket);
+      setTagForms((current) => {
+        const next = { ...current };
+        delete next[market.id];
+        return next;
+      });
+      setSuccessMessage(`Updated tags for market ${updatedMarket.id}.`);
+    } catch (err) {
+      setError(err.message || 'Unable to update market tags.');
+    } finally {
+      setBusyMarketId(null);
+    }
+  };
+
+  const renderTagEditor = (market) => {
+    if (!tagEditingEnabled) {
+      return null;
+    }
+    const activeBySlug = new Map(activeTags.map((tag) => [tag.slug, tag]));
+    const tagChoices = [
+      ...activeTags,
+      ...(market.tags || []).filter((tag) => tag.slug && !activeBySlug.has(tag.slug)),
+    ];
+    const selectedSlugs = tagSlugsForForm(market);
+    const originalSlugs = marketTagSlugs(market);
+    const changed = !sameTagSlugs(selectedSlugs, originalSlugs);
+    const atLimit = selectedSlugs.length >= maxMarketTagsPerMarket;
+
+    return (
+      <div className="grid gap-2 rounded-lg border border-gray-700 bg-gray-900/80 p-3">
+        <div>
+          <div className="font-mono text-xs uppercase tracking-[0.14em] text-gray-400">
+            Admin tag adjustment
+          </div>
+          <p className="mt-1 text-xs text-gray-500">
+            Add or remove active tags before or after publication.
+          </p>
+        </div>
+        {tagChoices.length ? (
+          <div className="flex max-w-[280px] flex-wrap gap-2">
+            {tagChoices.map((tag) => {
+              const selected = selectedSlugs.includes(tag.slug);
+              const disabled = !selected && (atLimit || !tag.isActive);
+              return (
+                <button
+                  key={tag.slug}
+                  type="button"
+                  disabled={disabled || busyMarketId === market.id}
+                  onClick={() => toggleMarketTag(market, tag.slug)}
+                  className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                    selected
+                      ? 'border-primary-pink bg-primary-pink/20 text-white'
+                      : 'border-gray-600 bg-gray-800 text-gray-300 hover:border-gray-400'
+                  }`}
+                  title={disabled ? `A market can have up to ${maxMarketTagsPerMarket} active tags.` : tag.description || tag.displayName}
+                >
+                  {selected ? '✓ ' : ''}
+                  {tag.displayName || tag.slug}
+                  {!tag.isActive ? ' (inactive)' : ''}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-xs text-amber-200">Create active tags in the Tags tab before assigning them to markets.</p>
+        )}
+        <button
+          type="button"
+          disabled={busyMarketId === market.id || !changed}
+          onClick={() => saveMarketTags(market)}
+          className="justify-self-start rounded-md bg-sky-700 px-3 py-2 text-sm font-semibold text-white transition hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Save Tags
+        </button>
+      </div>
+    );
+  };
+
   const renderActions = (market) => {
-    if (status !== 'proposed') {
+    if (!tagEditingEnabled) {
       return null;
     }
 
     return (
       <div className="grid min-w-[220px] gap-3">
-        <button
-          type="button"
-          disabled={busyMarketId === market.id}
-          onClick={() => approveMarket(market.id)}
-          className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Approve
-        </button>
-        <textarea
-          value={rejectionReasons[market.id] || ''}
-          onChange={(event) => setRejectionReasons((current) => ({
-            ...current,
-            [market.id]: event.target.value,
-          }))}
-          rows={3}
-          placeholder="Reason for rejection"
-          className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
-        />
-        <button
-          type="button"
-          disabled={busyMarketId === market.id || !(rejectionReasons[market.id] || '').trim()}
-          onClick={() => rejectMarket(market.id)}
-          className="rounded-md bg-rose-700 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-600 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Reject and Refund
-        </button>
+        {renderTagEditor(market)}
+        {status === 'proposed' && (
+          <>
+            <button
+              type="button"
+              disabled={busyMarketId === market.id}
+              onClick={() => approveMarket(market.id)}
+              className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Approve
+            </button>
+            <textarea
+              value={rejectionReasons[market.id] || ''}
+              onChange={(event) => setRejectionReasons((current) => ({
+                ...current,
+                [market.id]: event.target.value,
+              }))}
+              rows={3}
+              placeholder="Reason for rejection"
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+            <button
+              type="button"
+              disabled={busyMarketId === market.id || !(rejectionReasons[market.id] || '').trim()}
+              onClick={() => rejectMarket(market.id)}
+              className="rounded-md bg-rose-700 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Reject and Refund
+            </button>
+          </>
+        )}
       </div>
     );
   };
@@ -117,21 +294,567 @@ const AdminMarketQueue = ({ status }) => {
           {error}
         </div>
       )}
+      {successMessage && (
+        <div className="rounded-md bg-emerald-700 p-3 text-sm text-white">
+          {successMessage}
+        </div>
+      )}
+      <div className="grid gap-2 rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <label htmlFor={`market-review-search-${status}`} className="text-xs font-mono uppercase tracking-[0.16em] text-gray-400">
+          Search markets
+        </label>
+        <div className="relative">
+          <input
+            id={`market-review-search-${status}`}
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={`Search ${status} markets by title or description`}
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 pr-10 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+          {loading && (
+            <div className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-b-2 border-primary-pink" />
+          )}
+        </div>
+      </div>
       <MarketLifecycleTable
         markets={markets}
         emptyMessage={`No ${status} markets found.`}
         showCreator
-        actions={status === 'proposed' ? renderActions : null}
+        showSteward
+        actions={tagEditingEnabled ? renderActions : null}
       />
     </div>
   );
 };
 
+const MarketStewardshipQueue = () => {
+  const { token } = useAuth();
+  const [markets, setMarkets] = useState([]);
+  const [moderators, setModerators] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [moderatorsLoading, setModeratorsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [busyMarketId, setBusyMarketId] = useState(null);
+  const [stewardForms, setStewardForms] = useState({});
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    let ignore = false;
+
+    const loadModerators = async () => {
+      setModeratorsLoading(true);
+      try {
+        const usersResult = await listAdminUsers({ token, limit: 250 });
+        if (!ignore) {
+          setModerators((usersResult.users || []).filter(isActiveModerator));
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load active moderators.');
+        }
+      } finally {
+        if (!ignore) {
+          setModeratorsLoading(false);
+        }
+      }
+    };
+
+    loadModerators();
+
+    return () => {
+      ignore = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    let ignore = false;
+    const timeoutId = window.setTimeout(async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const result = await listAdminLifecycleMarkets({
+          token,
+          status: 'all',
+          query: searchQuery,
+          limit: 100,
+        });
+
+        if (!ignore) {
+          setMarkets(result.markets || []);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load stewardship markets.');
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    }, 300);
+
+    return () => {
+      ignore = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [token, searchQuery]);
+
+  const updateStewardForm = (marketId, updates) => {
+    setStewardForms((current) => ({
+      ...current,
+      [marketId]: {
+        ...(current[marketId] || {}),
+        ...updates,
+      },
+    }));
+  };
+
+  const stewardFormFor = (market) => {
+    const currentSteward = market.stewardUsername || market.creatorUsername || '';
+    return {
+      stewardUsername: currentSteward,
+      reason: '',
+      ...(stewardForms[market.id] || {}),
+    };
+  };
+
+  const updateMarketInQueues = (updatedMarket) => {
+    setMarkets((current) => current.map((market) => (
+      market.id === updatedMarket.id ? { ...market, ...updatedMarket } : market
+    )));
+  };
+
+  const reassignSteward = async (market) => {
+    const form = stewardFormFor(market);
+    setBusyMarketId(market.id);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const updatedMarket = await reassignMarketSteward({
+        marketId: market.id,
+        token,
+        stewardUsername: form.stewardUsername,
+        reason: form.reason,
+      });
+      updateMarketInQueues(updatedMarket);
+      setStewardForms((current) => ({
+        ...current,
+        [market.id]: {
+          stewardUsername: updatedMarket.stewardUsername || form.stewardUsername,
+          reason: '',
+        },
+      }));
+      setSuccessMessage(`Market ${updatedMarket.id} steward reassigned to ${updatedMarket.stewardUsername}.`);
+    } catch (err) {
+      setError(err.message || 'Unable to reassign market steward.');
+    } finally {
+      setBusyMarketId(null);
+    }
+  };
+
+  const renderStewardshipActions = (market) => {
+    const form = stewardFormFor(market);
+    const currentSteward = market.stewardUsername || market.creatorUsername || '';
+    const selectedSteward = String(form.stewardUsername || '').trim();
+    const reason = String(form.reason || '').trim();
+    const canSubmit = selectedSteward && reason && selectedSteward !== currentSteward;
+    const stewardListId = `steward-options-${market.id}`;
+
+    return (
+      <div className="grid min-w-[260px] gap-3">
+        <label className="grid gap-1 text-xs text-gray-300">
+          <span className="font-mono uppercase tracking-[0.14em] text-gray-400">New steward</span>
+          <input
+            list={stewardListId}
+            value={form.stewardUsername}
+            onChange={(event) => updateStewardForm(market.id, { stewardUsername: event.target.value })}
+            placeholder="Search active moderators by username"
+            className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+          <datalist id={stewardListId}>
+            {moderators.map((moderator) => (
+              <option
+                key={moderator.username}
+                value={moderator.username}
+                label={moderator.displayName || moderator.username}
+              />
+            ))}
+          </datalist>
+        </label>
+        <textarea
+          value={form.reason}
+          onChange={(event) => updateStewardForm(market.id, { reason: event.target.value })}
+          rows={3}
+          placeholder="Reason for stewardship reassignment"
+          className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+        />
+        <button
+          type="button"
+          disabled={busyMarketId === market.id || !canSubmit}
+          onClick={() => reassignSteward(market)}
+          className="rounded-md bg-sky-700 px-3 py-2 text-sm font-semibold text-white transition hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Reassign Steward
+        </button>
+        {selectedSteward === currentSteward && (
+          <p className="text-xs text-gray-500">Choose a different active moderator to enable reassignment.</p>
+        )}
+      </div>
+    );
+  };
+
+  if (loading && !markets.length) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="grid gap-4">
+      <div className="rounded-lg border border-sky-800/70 bg-sky-950/30 p-4 text-sm text-sky-100">
+        <p className="text-sky-100/80">
+          Creator stays immutable. Reassign a market steward when a moderator is suspended,
+          unavailable, conflicted, or no longer responsible for resolving the market.
+        </p>
+      </div>
+      <div className="grid gap-2 rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <label htmlFor="stewardship-market-search" className="text-xs font-mono uppercase tracking-[0.16em] text-gray-400">
+          Search stewardship markets
+        </label>
+        <div className="relative">
+          <input
+            id="stewardship-market-search"
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search title or description across proposed, published, closed, and resolved markets"
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 pr-10 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+          {loading && (
+            <div className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-b-2 border-primary-pink" />
+          )}
+        </div>
+        <p className="text-xs text-gray-500">
+          Rejected and cancelled markets are excluded from stewardship governance.
+        </p>
+      </div>
+      {error && (
+        <div className="rounded-md bg-red-700 p-3 text-sm text-white">
+          {error}
+        </div>
+      )}
+      {successMessage && (
+        <div className="rounded-md bg-emerald-700 p-3 text-sm text-white">
+          {successMessage}
+        </div>
+      )}
+      {!moderatorsLoading && moderators.length === 0 && (
+        <div className="rounded-md bg-amber-700 p-3 text-sm text-white">
+          No active moderators are available for stewardship reassignment.
+        </div>
+      )}
+      <MarketLifecycleTable
+        markets={markets}
+        emptyMessage="No markets found for stewardship governance."
+        showCreator
+        showSteward
+        actions={renderStewardshipActions}
+      />
+    </div>
+  );
+};
+
+const emptyTagForm = {
+  slug: '',
+  displayName: '',
+  description: '',
+  colorKey: 'slate',
+  sortOrder: 0,
+};
+
+const ColorKeyPicker = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const selectedOption = MARKET_TAG_COLOR_OPTIONS.find((option) => option.key === value)
+    || MARKET_TAG_COLOR_OPTIONS[0];
+  const previewTag = (option) => ({
+    slug: option.key,
+    displayName: option.label,
+    colorKey: option.key,
+    description: option.label,
+  });
+
+  const chooseColor = (colorKey) => {
+    onChange(colorKey);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="flex w-full items-center justify-between gap-3 rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-left text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+      >
+        <MarketTagChips tags={[previewTag(selectedOption)]} />
+        <span className="text-xs text-gray-400">▾</span>
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Market tag color key"
+          className="absolute z-30 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-gray-700 bg-gray-950 p-2 shadow-xl"
+        >
+          {MARKET_TAG_COLOR_OPTIONS.map((option) => {
+            const selected = option.key === selectedOption.key;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => chooseColor(option.key)}
+                className={`grid w-full gap-1 rounded-md px-3 py-2 text-left transition hover:bg-gray-800 ${
+                  selected ? 'bg-gray-800 ring-1 ring-primary-pink/60' : ''
+                }`}
+              >
+                <MarketTagChips tags={[previewTag(option)]} />
+                <span className="font-mono text-xs text-gray-500">{option.key}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const MarketTaxonomyAdmin = () => {
+  const { token } = useAuth();
+  const [tags, setTags] = useState([]);
+  const [form, setForm] = useState(emptyTagForm);
+  const [loading, setLoading] = useState(true);
+  const [busySlug, setBusySlug] = useState('');
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const loadTags = async () => {
+    if (!token) {
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const result = await listAdminMarketTags({ token, includeInactive: true });
+      setTags(result.tags || []);
+    } catch (err) {
+      setError(err.message || 'Unable to load market tags.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadTags();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const updateForm = (updates) => {
+    setForm((current) => ({ ...current, ...updates }));
+  };
+
+  const createTag = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccessMessage('');
+    try {
+      const created = await createAdminMarketTag({ token, tag: form });
+      setTags((current) => [...current, created].sort((left, right) => (
+        (left.sortOrder - right.sortOrder) || String(left.displayName).localeCompare(String(right.displayName))
+      )));
+      setForm(emptyTagForm);
+      setSuccessMessage(`Created tag ${created.displayName}.`);
+    } catch (err) {
+      setError(err.message || 'Unable to create market tag.');
+    }
+  };
+
+  const setTagActive = async (tag, isActive) => {
+    if (!isActive) {
+      const confirmed = window.confirm(
+        `Deactivate "${tag.displayName}"?\n\nIt will stay visible on markets and existing layouts, but moderators/admins cannot newly assign it until reactivated.`,
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    setBusySlug(tag.slug);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const updated = await updateAdminMarketTag({
+        token,
+        slug: tag.slug,
+        tag: {
+          displayName: tag.displayName,
+          description: tag.description || '',
+          colorKey: tag.colorKey || 'slate',
+          sortOrder: tag.sortOrder || 0,
+          isActive,
+          confirmDeactivate: !isActive,
+        },
+      });
+      setTags((current) => current.map((item) => (item.slug === updated.slug ? updated : item)));
+      setSuccessMessage(`${updated.displayName} is now ${updated.isActive ? 'active' : 'inactive'}.`);
+    } catch (err) {
+      setError(err.message || 'Unable to update market tag.');
+    } finally {
+      setBusySlug('');
+    }
+  };
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="grid gap-6">
+      <div className="rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <h2 className="text-lg font-semibold text-white">Market Tags</h2>
+        <p className="mt-2 text-sm text-gray-300">
+          Admins define the tag vocabulary. Moderators can attach active tags during market creation; admins can review those tags before publication.
+        </p>
+        <p className="mt-2 text-xs text-amber-200">
+          Deactivating a tag does not remove it from existing markets or topic pins. It only prevents new assignments until the tag is reactivated.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-red-700 p-3 text-sm text-white">
+          {error}
+        </div>
+      )}
+      {successMessage && (
+        <div className="rounded-md bg-emerald-700 p-3 text-sm text-white">
+          {successMessage}
+        </div>
+      )}
+
+      <form onSubmit={createTag} className="grid gap-4 rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="grid gap-1 text-sm text-gray-300">
+            Display name
+            <input
+              value={form.displayName}
+              onChange={(event) => updateForm({ displayName: event.target.value })}
+              required
+              maxLength={120}
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            Slug (optional)
+            <input
+              value={form.slug}
+              onChange={(event) => updateForm({ slug: event.target.value })}
+              placeholder="auto-generated from display name"
+              maxLength={64}
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+          </label>
+        </div>
+        <label className="grid gap-1 text-sm text-gray-300">
+          Description
+          <textarea
+            value={form.description}
+            onChange={(event) => updateForm({ description: event.target.value })}
+            rows={3}
+            maxLength={500}
+            className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+        </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="grid gap-1 text-sm text-gray-300">
+            Color key
+            <ColorKeyPicker
+              value={form.colorKey}
+              onChange={(colorKey) => updateForm({ colorKey })}
+            />
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            Sort order
+            <input
+              type="number"
+              value={form.sortOrder}
+              onChange={(event) => updateForm({ sortOrder: Number(event.target.value || 0) })}
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+          </label>
+        </div>
+        <button
+          type="submit"
+          className="justify-self-start rounded-md bg-primary-pink px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-pink/80"
+        >
+          Create Tag
+        </button>
+      </form>
+
+      <div className="grid gap-3">
+        {tags.map((tag) => (
+          <div key={tag.slug} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-900/70 p-4 md:grid-cols-[1fr,auto] md:items-center">
+            <div>
+              <MarketTagChips tags={[tag]} />
+              <div className="mt-2 font-mono text-xs text-gray-500">{tag.slug}</div>
+              {tag.description && <p className="mt-2 text-sm text-gray-300">{tag.description}</p>}
+              {!tag.isActive && <p className="mt-2 text-xs text-amber-300">Inactive tags stay visible on historical markets and layouts but cannot be newly assigned.</p>}
+            </div>
+            <button
+              type="button"
+              disabled={busySlug === tag.slug}
+              onClick={() => setTagActive(tag, !tag.isActive)}
+              className={`rounded-md px-3 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                tag.isActive ? 'bg-amber-700 hover:bg-amber-600' : 'bg-emerald-700 hover:bg-emerald-600'
+              }`}
+            >
+              {tag.isActive ? 'Deactivate' : 'Reactivate'}
+            </button>
+          </div>
+        ))}
+        {!tags.length && (
+          <div className="rounded-lg border border-gray-700 bg-gray-900/70 p-6 text-center text-gray-300">
+            No tags have been created yet.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
 function ModeratorMarketReview() {
-  const tabsData = reviewTabs.map((tab) => ({
-    label: tab.label,
-    content: <AdminMarketQueue status={tab.status} />,
-  }));
+  const tabsData = [
+    ...reviewTabs.map((tab) => ({
+      label: tab.label,
+      content: <AdminMarketQueue status={tab.status} />,
+    })),
+    {
+      label: 'Stewardship',
+      content: <MarketStewardshipQueue />,
+    },
+    {
+      label: 'Tags',
+      content: <MarketTaxonomyAdmin />,
+    },
+  ];
 
   return (
     <section className="p-6 bg-primary-background shadow-md rounded-lg text-white">
@@ -140,9 +863,6 @@ function ModeratorMarketReview() {
           Moderator mode
         </p>
         <h1 className="text-2xl font-bold mt-2">Market Review Queue</h1>
-        <p className="text-sm text-gray-300 mt-2 max-w-3xl">
-          Review proposed markets without manually entering IDs. Approved markets become published and tradable; rejected markets record the reason and refund the proposal cost.
-        </p>
       </div>
 
       <SiteTabs tabs={tabsData} defaultTab="Proposed Markets" />

--- a/frontend/src/components/layouts/admin/UserQueue.jsx
+++ b/frontend/src/components/layouts/admin/UserQueue.jsx
@@ -5,6 +5,22 @@ import {
   promoteUserToModerator,
   updateModeratorSuspension,
 } from '../../../api/adminUsersApi';
+import SiteTabs from '../../tabs/SiteTabs';
+
+const userQueueTabs = [
+  {
+    label: 'Non-Moderators',
+    usertype: 'REGULAR',
+    emptyMessage: 'No non-moderator users found.',
+    searchPlaceholder: 'Search non-moderators by username, display name, or email',
+  },
+  {
+    label: 'Moderators',
+    usertype: 'MODERATOR',
+    emptyMessage: 'No moderators found.',
+    searchPlaceholder: 'Search moderators by username, display name, or email',
+  },
+];
 
 const roleBadgeClass = (user) => {
   if (user.usertype === 'ADMIN') return 'bg-sky-700 text-sky-50';
@@ -18,13 +34,16 @@ const moderatorLabel = (user) => {
   return user.moderatorStatus || 'active';
 };
 
-function UserQueue() {
+const userMatchesTab = (user, usertype) => user?.usertype === usertype;
+
+const UserQueueTab = ({ config }) => {
   const { token } = useAuth();
   const [users, setUsers] = useState([]);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [pendingUsername, setPendingUsername] = useState('');
   const [reasonByUsername, setReasonByUsername] = useState({});
+  const [searchQuery, setSearchQuery] = useState('');
 
   const counts = useMemo(() => users.reduce((acc, user) => {
     if (user.usertype === 'MODERATOR') {
@@ -38,11 +57,16 @@ function UserQueue() {
     return acc;
   }, { candidates: 0, moderators: 0, suspended: 0 }), [users]);
 
-  const loadUsers = async () => {
+  const loadUsers = async (query = searchQuery) => {
     setError('');
     setIsLoading(true);
     try {
-      const result = await listAdminUsers({ token });
+      const result = await listAdminUsers({
+        token,
+        usertype: config.usertype,
+        query,
+        limit: 250,
+      });
       setUsers(result.users || []);
     } catch (err) {
       setError(err.message || 'Failed to load user queue.');
@@ -52,9 +76,19 @@ function UserQueue() {
   };
 
   useEffect(() => {
-    loadUsers();
+    if (!token) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      loadUsers(searchQuery);
+    }, 300);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [token, config.usertype, searchQuery]);
 
   const reasonFor = (username) => reasonByUsername[username] || '';
 
@@ -66,9 +100,14 @@ function UserQueue() {
   };
 
   const updateUserInQueue = (updatedUser) => {
-    setUsers((current) => current.map((user) => (
-      user.username === updatedUser.username ? updatedUser : user
-    )));
+    setUsers((current) => {
+      if (!userMatchesTab(updatedUser, config.usertype)) {
+        return current.filter((user) => user.username !== updatedUser.username);
+      }
+      return current.map((user) => (
+        user.username === updatedUser.username ? updatedUser : user
+      ));
+    });
   };
 
   const runUserAction = async (username, action) => {
@@ -94,50 +133,52 @@ function UserQueue() {
   };
 
   return (
-    <section className="p-6 bg-primary-background shadow-md rounded-lg text-white">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <p className="text-xs uppercase tracking-[0.22em] text-primary-pink">
-            Moderator governance
-          </p>
-          <h1 className="mt-2 text-2xl font-bold">User Queue</h1>
-          <p className="mt-2 max-w-3xl text-sm text-gray-300">
-            Review all users, see who is approved as a moderator, and perform
-            baseline moderator promotion or suspension actions.
-          </p>
+    <div className="grid gap-5">
+      <div className="grid gap-2 rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <label htmlFor={`user-queue-search-${config.usertype}`} className="text-xs font-mono uppercase tracking-[0.16em] text-gray-400">
+          Search users
+        </label>
+        <div className="relative">
+          <input
+            id={`user-queue-search-${config.usertype}`}
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={config.searchPlaceholder}
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 pr-10 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+          {isLoading && (
+            <div className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-b-2 border-primary-pink" />
+          )}
         </div>
-        <button
-          type="button"
-          onClick={loadUsers}
-          disabled={isLoading}
-          className="rounded-md bg-primary-pink px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {isLoading ? 'Refreshing...' : 'Refresh Queue'}
-        </button>
       </div>
 
-      <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {config.usertype === 'REGULAR' && (
         <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
-          <p className="text-xs uppercase tracking-wide text-gray-400">Candidates</p>
+          <p className="text-xs uppercase tracking-wide text-gray-400">Non-moderator users</p>
           <p className="mt-1 text-2xl font-bold">{counts.candidates}</p>
         </div>
-        <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
-          <p className="text-xs uppercase tracking-wide text-gray-400">Moderators</p>
-          <p className="mt-1 text-2xl font-bold">{counts.moderators}</p>
+      )}
+      {config.usertype === 'MODERATOR' && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
+            <p className="text-xs uppercase tracking-wide text-gray-400">Moderators</p>
+            <p className="mt-1 text-2xl font-bold">{counts.moderators}</p>
+          </div>
+          <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
+            <p className="text-xs uppercase tracking-wide text-gray-400">Suspended</p>
+            <p className="mt-1 text-2xl font-bold">{counts.suspended}</p>
+          </div>
         </div>
-        <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
-          <p className="text-xs uppercase tracking-wide text-gray-400">Suspended</p>
-          <p className="mt-1 text-2xl font-bold">{counts.suspended}</p>
-        </div>
-      </div>
+      )}
 
       {error && (
-        <div className="mt-5 rounded-md bg-red-700 p-3 text-sm text-white">
+        <div className="rounded-md bg-red-700 p-3 text-sm text-white">
           {error}
         </div>
       )}
 
-      <div className="mt-6 overflow-x-auto rounded-lg border border-gray-700">
+      <div className="overflow-x-auto rounded-lg border border-gray-700">
         <table className="min-w-full divide-y divide-gray-700 text-left text-sm">
           <thead className="bg-gray-900 text-xs uppercase tracking-wide text-gray-300">
             <tr>
@@ -228,12 +269,39 @@ function UserQueue() {
             {!isLoading && users.length === 0 && (
               <tr>
                 <td className="px-4 py-8 text-center text-gray-400" colSpan="5">
-                  No users found.
+                  {config.emptyMessage}
                 </td>
               </tr>
             )}
           </tbody>
         </table>
+      </div>
+    </div>
+  );
+};
+
+function UserQueue() {
+  const tabsData = userQueueTabs.map((tab) => ({
+    label: tab.label,
+    content: <UserQueueTab config={tab} />,
+  }));
+
+  return (
+    <section className="p-6 bg-primary-background shadow-md rounded-lg text-white">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.22em] text-primary-pink">
+            Moderator governance
+          </p>
+          <h1 className="mt-2 text-2xl font-bold">User Queue</h1>
+          <p className="mt-2 max-w-3xl text-sm text-gray-300">
+            Review users by moderator status and perform baseline moderator promotion or suspension actions.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <SiteTabs tabs={tabsData} defaultTab="Non-Moderators" />
       </div>
     </section>
   );

--- a/frontend/src/components/layouts/profile/MarketLifecycleTable.jsx
+++ b/frontend/src/components/layouts/profile/MarketLifecycleTable.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import MarketTagChips from '../../markets/MarketTagChips';
 
 const formatDate = (value) => {
   if (!value) return 'n/a';
@@ -28,7 +29,28 @@ const MarketLabels = ({ market }) => (
   </div>
 );
 
-const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false, actions }) => {
+const StewardshipAuditTrail = ({ audits = [] }) => {
+  if (!audits.length) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 space-y-2">
+      {audits.map((audit, index) => (
+        <div key={audit.id || `${audit.createdAt || 'audit'}-${index}`} className="rounded-md border border-info-blue/30 bg-info-blue/10 px-3 py-2">
+          <div>
+            Steward reassigned from {audit.fromStewardUsername || 'n/a'} to {audit.toStewardUsername || 'n/a'}
+            {audit.actorUsername ? ` by ${audit.actorUsername}` : ''}
+            {audit.createdAt ? ` at ${formatDate(audit.createdAt)}` : ''}
+          </div>
+          {audit.reason && <div className="mt-1 text-info-blue">Reason: {audit.reason}</div>}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false, showSteward = false, actions }) => {
   const [expandedDescriptions, setExpandedDescriptions] = useState({});
 
   const toggleDescription = (marketId) => {
@@ -53,6 +75,7 @@ const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false,
           <tr>
             <th className="px-4 py-3 text-left">Market</th>
             {showCreator && <th className="px-4 py-3 text-left">Creator</th>}
+            {showSteward && <th className="px-4 py-3 text-left">Steward</th>}
             <th className="px-4 py-3 text-left">Status</th>
             <th className="px-4 py-3 text-left">Created</th>
             <th className="px-4 py-3 text-left">Review Trail</th>
@@ -79,6 +102,7 @@ const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false,
                     </button>
                   </div>
                 )}
+                <MarketTagChips tags={market.tags || []} className="mt-3" />
                 <MarketLabels market={market} />
                 {statusLabel(market) === 'published' && (
                   <Link className="mt-2 inline-block text-primary-pink hover:underline" to={`/markets/${market.id}`}>
@@ -88,6 +112,9 @@ const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false,
               </td>
               {showCreator && (
                 <td className="px-4 py-4 font-mono text-gray-300">{market.creatorUsername || 'n/a'}</td>
+              )}
+              {showSteward && (
+                <td className="px-4 py-4 font-mono text-gray-300">{market.stewardUsername || market.creatorUsername || 'n/a'}</td>
               )}
               <td className="px-4 py-4">
                 <span className="rounded-full bg-gray-700 px-3 py-1 font-mono text-xs text-white">
@@ -100,7 +127,8 @@ const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false,
                 {market.approvedBy && <div>Approved by {market.approvedBy} at {formatDate(market.approvedAt)}</div>}
                 {market.rejectedBy && <div>Rejected by {market.rejectedBy} at {formatDate(market.rejectedAt)}</div>}
                 {market.rejectionReason && <div className="mt-1 text-rose-200">Reason: {market.rejectionReason}</div>}
-                {!market.approvedBy && !market.rejectedBy && <span className="text-gray-500">Awaiting admin review</span>}
+                <StewardshipAuditTrail audits={market.stewardshipAudits || []} />
+                {!market.approvedBy && !market.rejectedBy && !(market.stewardshipAudits || []).length && <span className="text-gray-500">Awaiting admin review</span>}
               </td>
               {actions && <td className="px-4 py-4">{actions(market)}</td>}
             </tr>

--- a/frontend/src/components/layouts/profile/public/UserInfoTabContent.jsx
+++ b/frontend/src/components/layouts/profile/public/UserInfoTabContent.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { API_URL } from '../../../../config';
+import { apiRequest } from '../../../../api/httpClient';
 import LoadingSpinner from '../../../loaders/LoadingSpinner';
 import { useAuth } from '../../../../helpers/AuthContent';
 
@@ -12,20 +12,12 @@ const UserInfoTabContent = ({ username, userData }) => {
     useEffect(() => {
         const fetchUserCredit = async () => {
             try {
-                const headers = token
-                    ? {
-                        Authorization: `Bearer ${token}`,
-                        'Content-Type': 'application/json',
-                    }
-                    : {};
-
-                const response = await fetch(`${API_URL}/v0/usercredit/${username}`, { headers });
-                if (response.ok) {
-                    const data = await response.json();
-                    setUserCredit(data);
-                } else {
-                    throw new Error(`Error fetching user credit: ${response.statusText}`);
-                }
+                const data = await apiRequest(`/v0/usercredit/${username}`, {
+                    authenticated: true,
+                    authToken: token,
+                    fallbackMessage: 'Error fetching user credit',
+                });
+                setUserCredit(data);
             } catch (err) {
                 setError(err.message);
             } finally {

--- a/frontend/src/components/marketDetails/MarketDetailsLayout.jsx
+++ b/frontend/src/components/marketDetails/MarketDetailsLayout.jsx
@@ -7,6 +7,8 @@ import TradeCTA from '../TradeCTA';
 import TradeTabs from '../../components/tabs/TradeTabs';
 import { BetButton } from '../buttons/trade/BetButtons';
 import formatResolutionDate from '../../helpers/formatResolutionDate';
+import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const DEFAULT_CREATOR_EMOJI = '👤';
 
@@ -28,6 +30,7 @@ function MarketDetailsTable({
   const safeCreator = creator ?? {};
   const resolvedMarketId = marketIdProp ?? safeMarket.id;
   const creatorUsername = safeMarket.creatorUsername ?? safeCreator.username ?? 'unknown';
+  const stewardUsername = stewardUsernameFor(safeMarket, creatorUsername);
   const creatorEmoji = safeCreator.personalEmoji ?? DEFAULT_CREATOR_EMOJI;
   const marketDescription = safeMarket.description ?? '';
 
@@ -57,6 +60,9 @@ function MarketDetailsTable({
     isLoggedIn &&
     safeMarket.resolutionDateTime &&
     new Date(safeMarket.resolutionDateTime) > new Date();
+  const canResolveMarket =
+    !safeMarket.isResolved &&
+    String(username || '').trim() === String(stewardUsername || '').trim();
 
   return (
     <div className='bg-gray-900 text-gray-300 p-4 rounded-lg shadow-lg w-full'>
@@ -83,9 +89,11 @@ function MarketDetailsTable({
             </span>
             @{creatorUsername}
           </a>
+          <StewardTag username={stewardUsername} creatorUsername={creatorUsername} />
           <span>•</span>
           <span>🪙 {currentProbability.toFixed(2)}</span>
         </div>
+        <MarketTagChips tags={safeMarket.tags || []} className='mt-3' />
       </div>
 
       <div className='mb-4'>
@@ -175,7 +183,7 @@ function MarketDetailsTable({
       )}
 
       <div className='flex items-center justify-center mb-4 space-x-4 py-4'>
-        {username === creatorUsername && !safeMarket.isResolved && (
+        {canResolveMarket && (
           <ResolveModalButton
             marketId={resolvedMarketId}
             token={token}

--- a/frontend/src/components/markets/MarketTagChips.jsx
+++ b/frontend/src/components/markets/MarketTagChips.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+const colorClasses = {
+  sky: 'border-sky-500/40 bg-sky-950/40 text-sky-100',
+  cyan: 'border-cyan-500/40 bg-cyan-950/40 text-cyan-100',
+  teal: 'border-teal-500/40 bg-teal-950/40 text-teal-100',
+  emerald: 'border-emerald-500/40 bg-emerald-950/40 text-emerald-100',
+  lime: 'border-lime-500/40 bg-lime-950/40 text-lime-100',
+  amber: 'border-amber-500/40 bg-amber-950/40 text-amber-100',
+  orange: 'border-orange-500/40 bg-orange-950/40 text-orange-100',
+  rose: 'border-rose-500/40 bg-rose-950/40 text-rose-100',
+  violet: 'border-violet-500/40 bg-violet-950/40 text-violet-100',
+  slate: 'border-gray-500/40 bg-gray-800/70 text-gray-200',
+};
+
+export const MARKET_TAG_COLOR_OPTIONS = [
+  { key: 'slate', label: 'Slate' },
+  { key: 'sky', label: 'Sky' },
+  { key: 'cyan', label: 'Cyan' },
+  { key: 'teal', label: 'Teal' },
+  { key: 'emerald', label: 'Emerald' },
+  { key: 'lime', label: 'Lime' },
+  { key: 'amber', label: 'Amber' },
+  { key: 'orange', label: 'Orange' },
+  { key: 'rose', label: 'Rose' },
+  { key: 'violet', label: 'Violet' },
+];
+
+export const marketTagChipClassFor = (tag) => {
+  const key = String(tag?.colorKey || 'slate').toLowerCase();
+  return colorClasses[key] || colorClasses.slate;
+};
+
+const MarketTagChips = ({ tags = [], className = '' }) => {
+  const visibleTags = (tags || []).filter((tag) => tag?.slug || tag?.displayName);
+  if (!visibleTags.length) {
+    return null;
+  }
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`.trim()} aria-label="Market tags">
+      {visibleTags.map((tag) => (
+        <span
+          key={tag.slug || tag.displayName}
+          className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${marketTagChipClassFor(tag)}`}
+          title={tag.description || tag.displayName || tag.slug}
+        >
+          {tag.displayName || tag.slug}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default MarketTagChips;

--- a/frontend/src/components/markets/StewardTag.jsx
+++ b/frontend/src/components/markets/StewardTag.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export const stewardUsernameFor = (market = {}, fallbackUsername = '') => (
+  market.stewardUsername
+  ?? market.StewardUsername
+  ?? fallbackUsername
+  ?? ''
+);
+
+const StewardTag = ({ username, creatorUsername = '', className = '' }) => {
+  const normalizedUsername = String(username || '').trim();
+  const normalizedCreatorUsername = String(creatorUsername || '').trim();
+  if (!normalizedUsername || normalizedUsername === 'unknown') {
+    return null;
+  }
+  if (normalizedCreatorUsername && normalizedUsername === normalizedCreatorUsername) {
+    return null;
+  }
+
+  return (
+    <Link
+      to={`/user/${normalizedUsername}`}
+      className={`inline-flex items-center gap-1 rounded-full border border-info-blue/30 bg-info-blue/10 px-2 py-0.5 text-xs font-medium text-custom-gray-verylight transition hover:border-info-blue/60 hover:bg-info-blue/15 ${className}`}
+      title={`Market steward: ${normalizedUsername}`}
+    >
+      <span className="font-mono text-[0.62rem] uppercase tracking-[0.14em] text-info-blue">Steward</span>
+      <span className="text-gray-300">@{normalizedUsername}</span>
+    </Link>
+  );
+};
+
+export default StewardTag;

--- a/frontend/src/components/search/GlobalSearchBar.jsx
+++ b/frontend/src/components/search/GlobalSearchBar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { searchMarkets } from '../../api/marketsApi';
 import { RegularInput } from '../inputs/InputBar';
 
-const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSearching }) => {
+const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSearching, tagSlug = '' }) => {
     const [query, setQuery] = useState('');
     const [loading, setLoading] = useState(false);
 
@@ -19,14 +19,14 @@ const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSea
         }, 300); // 300ms debounce
 
         return () => clearTimeout(timeoutId);
-    }, [query, currentStatus]);
+    }, [query, currentStatus, tagSlug]);
 
     const performSearch = async (searchQuery) => {
         setLoading(true);
         setIsSearching(true);
         
         try {
-            const results = await searchMarkets(searchQuery, currentStatus, 20);
+            const results = await searchMarkets(searchQuery, currentStatus, 20, { tagSlug });
             onSearchResults(results);
         } catch (error) {
             console.error('Search error:', error);
@@ -73,7 +73,9 @@ const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSea
             </div>
             {isSearching && query && (
                 <div className="mt-2 text-sm text-gray-400">
-                    Searching in <span className="text-primary-pink font-medium">{currentStatus}</span> markets for: 
+                    Searching in <span className="text-primary-pink font-medium">{currentStatus}</span> markets{tagSlug ? (
+                        <> tagged <span className="text-primary-pink font-medium">{tagSlug}</span></>
+                    ) : null} for:
                     <span className="text-white font-medium"> "{query}"</span>
                 </div>
             )}

--- a/frontend/src/components/sidebar/Sidebar.jsx
+++ b/frontend/src/components/sidebar/Sidebar.jsx
@@ -33,12 +33,13 @@ const SidebarLink = ({ to, icon: Icon, children, onClick }) => (
 );
 
 const Sidebar = () => {
-  const { isLoggedIn, usertype, logout, changePasswordNeeded, username } = useAuth();
+  const { isLoggedIn, usertype, moderatorStatus, logout, changePasswordNeeded, username } = useAuth();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { userCredit, loading, error } = useUserCredit(username); // Correct destructuring
   const { frontendConfig } = useFrontendConfig();
   const isModeratorMode = frontendConfig?.game?.mode === 'moderator';
-  const canCreateMarket = isLoggedIn && usertype !== 'ADMIN' && !changePasswordNeeded && (!isModeratorMode || usertype === 'MODERATOR');
+  const isActiveModerator = usertype === 'MODERATOR' && moderatorStatus === 'active';
+  const canCreateMarket = isLoggedIn && usertype !== 'ADMIN' && !changePasswordNeeded && (!isModeratorMode || isActiveModerator);
 
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 

--- a/frontend/src/components/sidebar/Sidebar.jsx
+++ b/frontend/src/components/sidebar/Sidebar.jsx
@@ -39,7 +39,8 @@ const Sidebar = () => {
   const { frontendConfig } = useFrontendConfig();
   const isModeratorMode = frontendConfig?.game?.mode === 'moderator';
   const isActiveModerator = usertype === 'MODERATOR' && moderatorStatus === 'active';
-  const canCreateMarket = isLoggedIn && usertype !== 'ADMIN' && !changePasswordNeeded && (!isModeratorMode || isActiveModerator);
+  const isSuspendedModerator = usertype === 'MODERATOR' && moderatorStatus === 'suspended';
+  const canCreateMarket = isLoggedIn && usertype !== 'ADMIN' && !changePasswordNeeded && !isSuspendedModerator && (!isModeratorMode || isActiveModerator);
 
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 

--- a/frontend/src/components/tables/MarketTable.jsx
+++ b/frontend/src/components/tables/MarketTable.jsx
@@ -4,6 +4,8 @@ import formatResolutionDate from '../../helpers/formatResolutionDate';
 import MobileMarketCard from './MobileMarketCard';
 import ExpandableText from '../utils/ExpandableText';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
+import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const TableHeader = () => (
   <thead className='bg-gray-900'>
@@ -59,20 +61,27 @@ const MarketRow = ({ marketData }) => (
           expandIcon="📐"
         />
       </Link>
+      <MarketTagChips tags={marketData.market.tags || []} className="mt-2" />
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
       {formatResolutionDate(marketData.market.resolutionDateTime)}
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
-      <Link
-        to={`/user/${marketData.creator.username}`}
-        className='flex items-center hover:text-blue-400 transition-colors duration-200'
-      >
-        <span role='img' aria-label='Creator' className='mr-2'>
-          {marketData.creator.personalEmoji}
-        </span>
-        @{marketData.creator.username}
-      </Link>
+      <div className='flex flex-col items-start gap-2'>
+        <Link
+          to={`/user/${marketData.creator.username}`}
+          className='flex items-center hover:text-blue-400 transition-colors duration-200'
+        >
+          <span role='img' aria-label='Creator' className='mr-2'>
+            {marketData.creator.personalEmoji}
+          </span>
+          @{marketData.creator.username}
+        </Link>
+        <StewardTag
+          username={stewardUsernameFor(marketData.market, marketData.creator.username)}
+          creatorUsername={marketData.creator.username}
+        />
+      </div>
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
       {marketData.numUsers}

--- a/frontend/src/components/tables/MarketTables.jsx
+++ b/frontend/src/components/tables/MarketTables.jsx
@@ -5,6 +5,8 @@ import formatResolutionDate from '../../helpers/formatResolutionDate';
 import MobileMarketCard from '../../components/tables/MobileMarketCard';
 import LoadingSpinner from '../../components/loaders/LoadingSpinner';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
+import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const TableHeader = () => (
   <thead className='bg-gray-900'>
@@ -44,7 +46,7 @@ const MarketRow = ({ marketData }) => (
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-300'>
       {marketData.lastProbability.toFixed(2)}
     </td>
-    <td className='px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-300'>
+    <td className='px-6 py-4 whitespace-normal text-sm font-medium text-gray-300'>
       <Link
         to={`/markets/${marketData.market.id}`}
         className='hover:text-blue-400 transition-colors duration-200 block max-w-xs overflow-hidden overflow-ellipsis'
@@ -52,20 +54,27 @@ const MarketRow = ({ marketData }) => (
       >
         {marketData.market.questionTitle}
       </Link>
+      <MarketTagChips tags={marketData.market.tags || []} className="mt-2" />
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
       {formatResolutionDate(marketData.market.resolutionDateTime)}
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
-      <Link
-        to={`/user/${marketData.creator.username}`}
-        className='flex items-center hover:text-blue-400 transition-colors duration-200'
-      >
-        <span role='img' aria-label='Creator' className='mr-2'>
-          {marketData.creator.personalEmoji}
-        </span>
-        @{marketData.creator.username}
-      </Link>
+      <div className='flex flex-col items-start gap-2'>
+        <Link
+          to={`/user/${marketData.creator.username}`}
+          className='flex items-center hover:text-blue-400 transition-colors duration-200'
+        >
+          <span role='img' aria-label='Creator' className='mr-2'>
+            {marketData.creator.personalEmoji}
+          </span>
+          @{marketData.creator.username}
+        </Link>
+        <StewardTag
+          username={stewardUsernameFor(marketData.market, marketData.creator.username)}
+          creatorUsername={marketData.creator.username}
+        />
+      </div>
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
       {marketData.numUsers}

--- a/frontend/src/components/tables/MarketsByStatusTable.jsx
+++ b/frontend/src/components/tables/MarketsByStatusTable.jsx
@@ -6,6 +6,8 @@ import MobileMarketCard from './MobileMarketCard';
 import LoadingSpinner from '../loaders/LoadingSpinner';
 import ExpandableLink from '../utils/ExpandableLink';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
+import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_CREATOR_EMOJI = '👤';
@@ -84,6 +86,7 @@ const MarketRow = ({ marketData }) => {
   const creator = marketData?.creator ?? {};
   const creatorUsername = creator.username ?? market.creatorUsername ?? 'unknown';
   const creatorEmoji = creator.personalEmoji ?? DEFAULT_CREATOR_EMOJI;
+  const stewardUsername = stewardUsernameFor(market, creatorUsername);
   const probability = toNumber(marketData?.lastProbability);
   const probabilityDisplay = Number.isFinite(probability)
     ? probability.toFixed(2)
@@ -111,29 +114,35 @@ const MarketRow = ({ marketData }) => {
         {probabilityDisplay}
       </td>
       <td className='px-6 py-4 text-sm font-medium text-gray-300'>
-        <ExpandableLink
-          text={questionTitle}
-          to={marketId ? `/markets/${marketId}` : '#'}
-          maxLength={45}
-          className=''
-          linkClassName='hover:text-blue-400 transition-colors duration-200'
-          buttonClassName='text-xs text-blue-400 hover:text-blue-300 transition-colors ml-1'
-          expandIcon='📐'
-        />
+        <div className='flex max-w-md flex-wrap items-center gap-2'>
+          <ExpandableLink
+            text={questionTitle}
+            to={marketId ? `/markets/${marketId}` : '#'}
+            maxLength={45}
+            className=''
+            linkClassName='hover:text-blue-400 transition-colors duration-200'
+            buttonClassName='text-xs text-blue-400 hover:text-blue-300 transition-colors ml-1'
+            expandIcon='📐'
+          />
+          <MarketTagChips tags={market.tags || []} />
+        </div>
       </td>
       <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
         {formatResolutionDate(resolutionDate)}
       </td>
       <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
-        <Link
-          to={`/user/${creatorUsername}`}
-          className='flex items-center hover:text-blue-400 transition-colors duration-200'
-        >
-          <span role='img' aria-label='Creator' className='mr-2'>
-            {creatorEmoji}
-          </span>
-          @{creatorUsername}
-        </Link>
+        <div className='flex flex-col items-start gap-2'>
+          <Link
+            to={`/user/${creatorUsername}`}
+            className='flex items-center hover:text-blue-400 transition-colors duration-200'
+          >
+            <span role='img' aria-label='Creator' className='mr-2'>
+              {creatorEmoji}
+            </span>
+            @{creatorUsername}
+          </Link>
+          <StewardTag username={stewardUsername} creatorUsername={creatorUsername} />
+        </div>
       </td>
       <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
         {numUsers}
@@ -155,7 +164,7 @@ const MarketRow = ({ marketData }) => {
   );
 };
 
-function MarketsByStatusTable({ status }) {
+function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT, tagSlug = '' }) {
   const [marketsData, setMarketsData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -172,10 +181,13 @@ function MarketsByStatusTable({ status }) {
         const params = new URLSearchParams();
 
         if (status && status.toLowerCase() !== 'all') {
-          params.set('status', status.toUpperCase());
+          params.set('status', status.toLowerCase());
         }
 
-        params.set('limit', String(DEFAULT_LIMIT));
+        params.set('limit', String(limit || DEFAULT_LIMIT));
+        if (tagSlug) {
+          params.set('tagSlug', tagSlug);
+        }
         url.search = params.toString();
 
         const response = await fetch(url.toString(), { signal: controller.signal });
@@ -205,7 +217,7 @@ function MarketsByStatusTable({ status }) {
     fetchMarkets();
 
     return () => controller.abort();
-  }, [status]);
+  }, [status, limit, tagSlug]);
 
   if (loading)
     return (

--- a/frontend/src/components/tables/MobileMarketCard.jsx
+++ b/frontend/src/components/tables/MobileMarketCard.jsx
@@ -3,23 +3,33 @@ import { Link } from 'react-router-dom';
 import formatResolutionDate from '../../helpers/formatResolutionDate';
 import ExpandableText from '../utils/ExpandableText';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
+import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const MobileMarketCard = ({ marketData }) => {
   const isMarketOpen =
     !marketData.market.isResolved &&
     formatResolutionDate(marketData.market.resolutionDateTime) !== 'Closed';
+  const stewardUsername = stewardUsernameFor(marketData.market, marketData.creator.username);
 
   return (
     <div className='bg-gray-800 p-4 mb-4 rounded-lg'>
       <div className='grid grid-cols-[1fr,auto] gap-2 items-center mb-2'>
-        <Link
-          to={`/user/${marketData.creator.username}`}
-          className='text-gray-400 hover:text-blue-400 transition-colors duration-200 truncate'
-        >
-          <span>
-            {marketData.creator.username} {marketData.creator.personalEmoji}
-          </span>
-        </Link>
+        <div className='min-w-0'>
+          <Link
+            to={`/user/${marketData.creator.username}`}
+            className='block truncate text-gray-400 hover:text-blue-400 transition-colors duration-200'
+          >
+            <span>
+              {marketData.creator.username} {marketData.creator.personalEmoji}
+            </span>
+          </Link>
+          <StewardTag
+            username={stewardUsername}
+            creatorUsername={marketData.creator.username}
+            className='mt-2 max-w-full'
+          />
+        </div>
         {isMarketOpen ? (
           <Link
             to={`/markets/${marketData.market.id}`}
@@ -47,6 +57,7 @@ const MobileMarketCard = ({ marketData }) => {
           expandIcon="📐"
         />
       </Link>
+      <MarketTagChips tags={marketData.market.tags || []} className='mb-3' />
       <div className='grid grid-cols-3 text-sm text-gray-400'>
         <span className='truncate'>👤 {marketData.numUsers}</span>
         <span className='text-center'>

--- a/frontend/src/components/utils/userFinanceTools/FetchUserCredit.jsx
+++ b/frontend/src/components/utils/userFinanceTools/FetchUserCredit.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { API_URL } from '../../../config';
+import { apiRequest } from '../../../api/httpClient';
 import { useAuth } from '../../../helpers/AuthContent';
 
 export const USER_CREDIT_REFRESH_EVENT = 'user-credit-refresh';
@@ -16,18 +16,11 @@ const useUserCredit = (username) => {
         setError(null);
 
         try {
-          const headers = token
-            ? {
-                Authorization: `Bearer ${token}`,
-                'Content-Type': 'application/json',
-              }
-            : {};
-
-          const response = await fetch(`${API_URL}/v0/usercredit/${username}`, { headers });
-          if (!response.ok) {
-            throw new Error('Failed to fetch user credit');
-          }
-          const data = await response.json();
+          const data = await apiRequest(`/v0/usercredit/${username}`, {
+            authenticated: true,
+            authToken: token,
+            fallbackMessage: 'Failed to fetch user credit',
+          });
           setUserCredit(data.credit);
         } catch (error) {
           console.error('Error fetching user credit:', error);

--- a/frontend/src/helpers/AppRoutes.jsx
+++ b/frontend/src/helpers/AppRoutes.jsx
@@ -22,7 +22,8 @@ const AppRoutes = () => {
   const isRegularUser = isLoggedIn && auth.usertype !== 'ADMIN';
   const { frontendConfig } = useFrontendConfig();
   const isModeratorMode = frontendConfig?.game?.mode === 'moderator';
-  const canCreateMarket = isRegularUser && (!isModeratorMode || auth.usertype === 'MODERATOR');
+  const isActiveModerator = auth.usertype === 'MODERATOR' && auth.moderatorStatus === 'active';
+  const canCreateMarket = isRegularUser && (!isModeratorMode || isActiveModerator);
   const mustChangePassword = isLoggedIn && auth.changePasswordNeeded;
 
   return (

--- a/frontend/src/helpers/AppRoutes.jsx
+++ b/frontend/src/helpers/AppRoutes.jsx
@@ -40,6 +40,13 @@ const AppRoutes = () => {
           <About />
         )}
       </Route>
+      <Route exact path='/markets/topic/:slug'>
+        {isLoggedIn && mustChangePassword ? (
+          <Redirect to='/changepassword' />
+        ) : (
+          <Markets />
+        )}
+      </Route>
       <Route exact path='/markets/:marketId'>
         {isLoggedIn && mustChangePassword ? (
           <Redirect to='/changepassword' />

--- a/frontend/src/helpers/AppRoutes.jsx
+++ b/frontend/src/helpers/AppRoutes.jsx
@@ -23,7 +23,8 @@ const AppRoutes = () => {
   const { frontendConfig } = useFrontendConfig();
   const isModeratorMode = frontendConfig?.game?.mode === 'moderator';
   const isActiveModerator = auth.usertype === 'MODERATOR' && auth.moderatorStatus === 'active';
-  const canCreateMarket = isRegularUser && (!isModeratorMode || isActiveModerator);
+  const isSuspendedModerator = auth.usertype === 'MODERATOR' && auth.moderatorStatus === 'suspended';
+  const canCreateMarket = isRegularUser && !isSuspendedModerator && (!isModeratorMode || isActiveModerator);
   const mustChangePassword = isLoggedIn && auth.changePasswordNeeded;
 
   return (

--- a/frontend/src/helpers/AuthContent.jsx
+++ b/frontend/src/helpers/AuthContent.jsx
@@ -31,6 +31,7 @@ const getStoredAuthState = () => {
         token,
         username: normalizedUsername,
         usertype: authStorage.getUsertype(),
+        moderatorStatus: authStorage.getModeratorStatus(),
         changePasswordNeeded: false,
     };
 };
@@ -40,6 +41,7 @@ const AuthContext = createContext({
     setUsername: () => {},
     isLoggedIn: false,
     usertype: null,
+    moderatorStatus: null,
     changePasswordNeeded: true, // Default to true until login confirms otherwise
     login: () => {},
     logout: () => {},
@@ -65,6 +67,44 @@ const AuthProvider = ({ children }) => {
             // Redirect or perform other actions based on usertype
         }
     }, [authState.isLoggedIn, authState.usertype]);
+
+    useEffect(() => {
+        if (!authState.isLoggedIn || !authState.token || authState.changePasswordNeeded) {
+            return undefined;
+        }
+
+        let ignore = false;
+        const refreshProfile = async () => {
+            try {
+                const profile = await apiRequest('/v0/privateprofile', {
+                    authenticated: true,
+                    authToken: authState.token,
+                    fallbackMessage: 'Failed to refresh user profile.',
+                });
+                if (ignore) return;
+
+                authStorage.saveLogin({
+                    token: authState.token,
+                    username: profile.username || authState.username,
+                    usertype: profile.usertype || authState.usertype,
+                    moderatorStatus: profile.moderatorStatus || authState.moderatorStatus,
+                });
+                setAuthState((current) => ({
+                    ...current,
+                    username: profile.username || current.username,
+                    usertype: profile.usertype || current.usertype,
+                    moderatorStatus: profile.moderatorStatus || current.moderatorStatus,
+                }));
+            } catch (error) {
+                console.error('Failed to refresh auth profile:', error);
+            }
+        };
+
+        refreshProfile();
+        return () => {
+            ignore = true;
+        };
+    }, [authState.isLoggedIn, authState.token, authState.changePasswordNeeded]);
 
     useEffect(() => {
         authStorage.clearLegacyPasswordChangeFlag();
@@ -95,6 +135,7 @@ const AuthProvider = ({ children }) => {
                 token: authData.token,
                 username: authData.username,
                 usertype: authData.usertype,
+                moderatorStatus: authData.moderatorStatus,
                 changePasswordNeeded: authData.mustChangePassword,
             });
             return { success: true, mustChangePassword: authData.mustChangePassword };
@@ -112,6 +153,7 @@ const AuthProvider = ({ children }) => {
             token: null,
             username: null,
             usertype: null,
+            moderatorStatus: null,
             changePasswordNeeded: null,
         });
     };

--- a/frontend/src/hooks/useMarketDetails.jsx
+++ b/frontend/src/hooks/useMarketDetails.jsx
@@ -39,6 +39,32 @@ const normalizeProbabilityChanges = (raw) => {
     .filter((item) => item !== null);
 };
 
+const normalizeMarketTag = (tag) => {
+  if (!tag || typeof tag !== 'object') {
+    return null;
+  }
+
+  return {
+    id: tag.id ?? tag.ID ?? null,
+    slug: tag.slug ?? tag.Slug ?? '',
+    displayName: tag.displayName ?? tag.DisplayName ?? '',
+    description: tag.description ?? tag.Description ?? '',
+    colorKey: tag.colorKey ?? tag.ColorKey ?? 'slate',
+    sortOrder: toNumber(tag.sortOrder ?? tag.SortOrder),
+    isActive: tag.isActive ?? tag.IsActive ?? true,
+  };
+};
+
+const normalizeMarketTags = (raw) => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .map(normalizeMarketTag)
+    .filter((tag) => tag !== null);
+};
+
 const normalizeMarket = (market) => {
   if (!market || typeof market !== 'object') {
     return {
@@ -48,6 +74,7 @@ const normalizeMarket = (market) => {
       outcomeType: '',
       resolutionDateTime: null,
       creatorUsername: 'unknown',
+      stewardUsername: '',
       yesLabel: '',
       noLabel: '',
       status: '',
@@ -56,6 +83,7 @@ const normalizeMarket = (market) => {
       initialProbability: 0,
       isResolved: false,
       resolutionResult: null,
+      tags: [],
     };
   }
 
@@ -66,6 +94,7 @@ const normalizeMarket = (market) => {
     outcomeType: market.outcomeType ?? market.OutcomeType ?? '',
     resolutionDateTime: market.resolutionDateTime ?? market.ResolutionDateTime ?? null,
     creatorUsername: market.creatorUsername ?? market.CreatorUsername ?? 'unknown',
+    stewardUsername: market.stewardUsername ?? market.StewardUsername ?? '',
     yesLabel: market.yesLabel ?? market.YesLabel ?? '',
     noLabel: market.noLabel ?? market.NoLabel ?? '',
     status: market.status ?? market.Status ?? '',
@@ -74,6 +103,7 @@ const normalizeMarket = (market) => {
     initialProbability: toNumber(market.initialProbability ?? market.InitialProbability),
     isResolved: market.isResolved ?? market.IsResolved ?? false,
     resolutionResult: market.resolutionResult ?? market.ResolutionResult ?? null,
+    tags: normalizeMarketTags(market.tags ?? market.Tags),
   };
 };
 

--- a/frontend/src/hooks/useUserData.jsx
+++ b/frontend/src/hooks/useUserData.jsx
@@ -1,20 +1,6 @@
 import { useState, useEffect } from 'react';
-import { API_URL } from '../config';
+import { apiRequest } from '../api/httpClient';
 import { useAuth } from '../helpers/AuthContent';
-
-const unwrapApiResponse = (payload) => {
-  if (payload && typeof payload === 'object' && 'ok' in payload) {
-    if (payload.ok === false) {
-      throw new Error(payload.reason || 'Request failed');
-    }
-
-    if (payload.ok === true && 'result' in payload) {
-      return payload.result;
-    }
-  }
-
-  return payload;
-};
 
 const useUserData = (username, usePrivateProfile = false) => {
   const [userData, setUserData] = useState(null);
@@ -23,50 +9,45 @@ const useUserData = (username, usePrivateProfile = false) => {
   const { token } = useAuth();
 
   useEffect(() => {
+    let ignore = false;
+
     const fetchUserData = async () => {
       try {
-        let url, headers = {};
-        
-        if (usePrivateProfile) {
-          // Use private profile endpoint for authenticated user's own profile
-          url = `${API_URL}/v0/privateprofile`;
-          headers = {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-          };
-        } else {
-          // Use public user endpoint for viewing other users' profiles
-          url = `${API_URL}/v0/userinfo/${username}`;
-          if (token) {
-            headers = {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/json'
-            };
-          }
+        const path = usePrivateProfile ? '/v0/privateprofile' : `/v0/userinfo/${username}`;
+        const data = await apiRequest(path, {
+          authenticated: true,
+          authToken: token,
+          fallbackMessage: 'Failed to fetch user data',
+        });
+        if (!ignore) {
+          setUserData(data);
         }
-
-        const response = await fetch(url, { headers });
-        if (!response.ok) {
-          throw new Error('Failed to fetch user data');
-        }
-        const data = unwrapApiResponse(await response.json());
-        setUserData(data);
       } catch (error) {
         console.error('Error fetching user data:', error);
-        setUserError(error.toString());
+        if (!ignore) {
+          setUserError(error.toString());
+        }
       } finally {
-        setUserLoading(false);
+        if (!ignore) {
+          setUserLoading(false);
+        }
       }
     };
 
     if (!token) {
       setUserLoading(false);
-      return;
+      return () => {
+        ignore = true;
+      };
     }
 
     if (username || usePrivateProfile) {
       fetchUserData();
     }
+
+    return () => {
+      ignore = true;
+    };
   }, [username, usePrivateProfile, token]);
 
   return { userData, userLoading, userError };

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import AdminAddUser from '../../components/layouts/admin/AddUser';
 import ModeratorMarketReview from '../../components/layouts/admin/ModeratorMarketReview';
 import UserQueue from '../../components/layouts/admin/UserQueue';
-import HomeEditor from './HomeEditor';
-import SocialShareEditor from './SocialShareEditor';
+import CmsDashboard from './CmsDashboard';
 import SiteTabs from '../../components/tabs/SiteTabs';
 
 function AdminDashboard() {
@@ -16,13 +15,9 @@ function AdminDashboard() {
             label: 'User Queue',
             content: <UserQueue />
         },
-        { 
-            label: 'Homepage Editor', 
-            content: <HomeEditor /> 
-        },
         {
-            label: 'Social Share',
-            content: <SocialShareEditor />
+            label: 'CMS',
+            content: <CmsDashboard />
         },
         {
             label: 'Market Review',

--- a/frontend/src/pages/admin/CmsDashboard.jsx
+++ b/frontend/src/pages/admin/CmsDashboard.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import SiteTabs from '../../components/tabs/SiteTabs';
+import HomeEditor from './HomeEditor';
+import MarketDiscoveryLayoutEditor from './MarketDiscoveryLayoutEditor';
+import SocialShareEditor from './SocialShareEditor';
+
+function CmsDashboard() {
+  const tabsData = [
+    {
+      label: 'Market Discovery Layout',
+      content: <MarketDiscoveryLayoutEditor />,
+    },
+    {
+      label: 'Home Page',
+      content: <HomeEditor />,
+    },
+    {
+      label: 'Social Share',
+      content: <SocialShareEditor />,
+    },
+  ];
+
+  return (
+    <section className="bg-primary-background text-white">
+      <div className="p-6 pb-5">
+        <p className="text-xs uppercase tracking-[0.22em] text-primary-pink">Admin CMS</p>
+        <h1 className="mt-2 text-2xl font-bold">Content And Discovery Management</h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-300">
+          Manage public homepage content, market discovery layout planning, and social share defaults.
+        </p>
+      </div>
+      <SiteTabs tabs={tabsData} defaultTab="Market Discovery Layout" />
+    </section>
+  );
+}
+
+export default CmsDashboard;

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -1,0 +1,885 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
+import { getMarketDetails, searchMarkets } from '../../api/marketsApi';
+import { listAdminMarketTags } from '../../api/marketTagsApi';
+
+const layoutModes = {
+  top: {
+    slug: 'markets',
+    label: 'Market page layout (TOP)',
+    route: '/markets',
+    purpose: 'Search-first discovery page for all public markets.',
+    pageType: 'top',
+    fixedBlocks: [
+      'Search bar',
+      'Status tabs: Active, Closed, Resolved, All',
+      'Recommendation fallback',
+    ],
+  },
+  secondary: {
+    slug: 'topic-template',
+    label: 'Topic page pins (SECONDARY)',
+    route: '/markets/topic/:slug',
+    purpose: 'Tag-scoped market discovery page with independent per-topic market pins.',
+    pageType: 'secondary',
+    fixedBlocks: [
+      'Topic title and description',
+      'Search bar filtered by topic tag',
+      'Status tabs: Active, Closed, Resolved, All',
+    ],
+  },
+};
+
+const persistedTables = [
+  'market_discovery_pages',
+  'market_discovery_pins',
+];
+
+const defaultPageState = {
+  slug: 'markets',
+  title: 'Markets',
+  description: 'Browse and search prediction markets.',
+  pageType: 'top',
+  primaryTagSlug: '',
+  searchScope: 'all',
+  featuredTopicsEnabled: false,
+  featuredMarketsEnabled: false,
+  defaultRecommendationLimit: 20,
+  curatedRecommendationLimit: 5,
+  recommendationLimit: 20,
+  version: 0,
+  pins: [],
+};
+
+const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortOrder || 0) - Number(b.sortOrder || 0));
+
+const normalizePage = (page = {}, modeKey = 'top') => {
+  const mode = layoutModes[modeKey];
+  const hasCuratedBlocks = !!(page.featuredTopicsEnabled || page.featuredMarketsEnabled);
+  const defaultRecommendationLimit = Number(page.defaultRecommendationLimit || 20);
+  const curatedRecommendationLimit = Number(page.curatedRecommendationLimit || 5);
+
+  return {
+    ...defaultPageState,
+    slug: page.slug || mode.slug,
+    title: page.title || (modeKey === 'secondary' ? 'Topic Markets' : 'Markets'),
+    description: page.description || (modeKey === 'secondary' ? 'Browse and search markets in this topic.' : 'Browse and search prediction markets.'),
+    pageType: page.pageType || mode.pageType,
+    primaryTagSlug: page.primaryTagSlug || '',
+    searchScope: modeKey === 'secondary' ? 'tag' : 'all',
+    featuredTopicsEnabled: !!page.featuredTopicsEnabled,
+    featuredMarketsEnabled: !!page.featuredMarketsEnabled,
+    defaultRecommendationLimit,
+    curatedRecommendationLimit,
+    recommendationLimit: hasCuratedBlocks ? curatedRecommendationLimit : defaultRecommendationLimit,
+    version: Number(page.version || 0),
+    pins: sortBySortOrder(page.pins || []),
+  };
+};
+
+const nextSortOrder = (items = []) => items.reduce((max, item) => Math.max(max, Number(item.sortOrder || 0)), 0) + 1;
+
+const ToggleCard = ({ title, description, checked, onChange }) => (
+  <label className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition ${
+    checked
+      ? 'border-primary-pink bg-primary-pink/10'
+      : 'border-gray-700 bg-gray-900/70 hover:border-gray-500'
+  }`}>
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      className="mt-1 h-4 w-4 accent-primary-pink"
+    />
+    <span>
+      <span className="block font-semibold text-white">{title}</span>
+      <span className="mt-1 block text-sm text-gray-400">{description}</span>
+    </span>
+  </label>
+);
+
+const Pill = ({ children }) => (
+  <span className="rounded-full border border-sky-500/40 bg-sky-950/40 px-3 py-1 text-xs font-semibold text-sky-100">
+    {children}
+  </span>
+);
+
+const Field = ({ label, children, className = '' }) => (
+  <label className={`grid gap-2 text-sm text-gray-300 ${className}`}>
+    {label}
+    {children}
+  </label>
+);
+
+const textInputClass = 'w-full min-w-0 rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40';
+
+const tagOptionLabel = (tag) => `${tag.displayName || tag.slug} (${tag.slug})`;
+
+const tagOptionsWithCurrent = (tags, currentSlug) => {
+  const normalizedCurrent = String(currentSlug || '').trim();
+  if (!normalizedCurrent || tags.some((tag) => tag.slug === normalizedCurrent)) {
+    return tags;
+  }
+
+  return [
+    ...tags,
+    {
+      slug: normalizedCurrent,
+      displayName: `Saved slug: ${normalizedCurrent}`,
+      isActive: false,
+    },
+  ];
+};
+
+const marketOverviewTitle = (overview) => (
+  overview?.market?.questionTitle
+  || overview?.questionTitle
+  || `Market #${overview?.market?.id || overview?.id || 'unknown'}`
+);
+
+const marketOverviewId = (overview) => overview?.market?.id || overview?.id || overview?.marketId || 0;
+
+const MarketPinSearch = ({ pin, onSelect, tagSlug = '' }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState('');
+  const [selectedTitle, setSelectedTitle] = useState('');
+  const [loadingSelectedTitle, setLoadingSelectedTitle] = useState(false);
+
+  useEffect(() => {
+    const marketId = Number(pin.marketId);
+    if (!marketId) {
+      setSelectedTitle('');
+      setLoadingSelectedTitle(false);
+      return undefined;
+    }
+
+    let ignore = false;
+    setLoadingSelectedTitle(true);
+    getMarketDetails(marketId)
+      .then((details) => {
+        if (!ignore) {
+          setSelectedTitle(details?.market?.questionTitle || `Market #${marketId}`);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setSelectedTitle(`Market #${marketId}`);
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setLoadingSelectedTitle(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [pin.marketId]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setSearchError('');
+      return undefined;
+    }
+
+    let ignore = false;
+    const timeoutId = setTimeout(async () => {
+      setSearching(true);
+      setSearchError('');
+      try {
+        const response = await searchMarkets(trimmed, 'active', 8, tagSlug ? { tagSlug } : {});
+        if (!ignore) {
+          setResults(response.primaryResults || []);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setSearchError(err.message || 'Unable to search active markets.');
+          setResults([]);
+        }
+      } finally {
+        if (!ignore) {
+          setSearching(false);
+        }
+      }
+    }, 250);
+
+    return () => {
+      ignore = true;
+      clearTimeout(timeoutId);
+    };
+  }, [query, tagSlug]);
+
+  return (
+    <div className="grid gap-3">
+      <div className="rounded-lg border border-gray-700 bg-gray-900/70 p-3">
+        <div className="font-mono text-xs uppercase tracking-[0.14em] text-gray-400">Selected Market</div>
+        {Number(pin.marketId) > 0 ? (
+          <>
+            <div className="mt-1 text-sm font-semibold text-white">
+              {loadingSelectedTitle ? 'Loading selected market...' : selectedTitle || `Market #${pin.marketId}`}
+            </div>
+            <div className="mt-1 text-xs text-gray-400">Market #{pin.marketId}</div>
+          </>
+        ) : (
+          <div className="mt-1 text-sm text-white">No market selected yet.</div>
+        )}
+      </div>
+      <Field label="Search Active Markets">
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={tagSlug ? `Search active ${tagSlug} markets...` : 'Type at least 2 characters...'}
+          className={textInputClass}
+        />
+      </Field>
+      {searching && <p className="text-xs text-gray-400">Searching active markets...</p>}
+      {searchError && <p className="text-xs text-red-300">{searchError}</p>}
+      {results.length > 0 && (
+        <div className="grid gap-2">
+          {results.map((overview) => {
+            const id = marketOverviewId(overview);
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => {
+                  setSelectedTitle(marketOverviewTitle(overview));
+                  onSelect(id);
+                  setQuery('');
+                  setResults([]);
+                }}
+                className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                  Number(pin.marketId) === Number(id)
+                    ? 'border-primary-pink bg-primary-pink/15 text-white'
+                    : 'border-gray-700 bg-gray-800 text-gray-200 hover:border-sky-400/60'
+                }`}
+              >
+                <span className="block font-semibold">{marketOverviewTitle(overview)}</span>
+                <span className="mt-1 block text-xs text-gray-400">Active market #{id}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const LayoutPreview = ({ mode, state }) => {
+  const hasCuratedBlocks = state.featuredTopicsEnabled || state.featuredMarketsEnabled;
+  const recommendationLimit = hasCuratedBlocks
+    ? state.curatedRecommendationLimit
+    : state.defaultRecommendationLimit;
+
+  return (
+    <div className="rounded-xl border border-gray-700 bg-gray-950 p-5 shadow-lg">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-sky-300">Preview Contract</p>
+          <h3 className="mt-2 text-xl font-bold text-white">{state.title}</h3>
+          {state.description && <p className="mt-1 text-sm text-gray-400">{state.description}</p>}
+        </div>
+        <Pill>{mode.route}</Pill>
+      </div>
+
+      <div className="mt-5 space-y-3">
+        <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+          <div className="text-sm font-semibold text-white">1. Search first</div>
+          <div className="mt-1 text-xs text-gray-400">
+            {state.searchScope === 'tag' ? 'Search defaults to the page tag.' : 'Search defaults to all public markets.'}
+          </div>
+        </div>
+        <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+          <div className="text-sm font-semibold text-white">2. Recommendations</div>
+          <div className="mt-1 text-xs text-gray-400">
+            Show {recommendationLimit} fallback markets when CMS content is {hasCuratedBlocks ? 'present' : 'empty'}.
+          </div>
+        </div>
+        {state.featuredTopicsEnabled && (
+          <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+            <div className="text-sm font-semibold text-white">Topic Pins</div>
+            <div className="mt-1 text-xs text-gray-400">{state.pins.filter((pin) => pin.pinType === 'discovery_page').length} page pins configured.</div>
+          </div>
+        )}
+        {state.featuredMarketsEnabled && (
+          <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+            <div className="text-sm font-semibold text-white">Market Pins</div>
+            <div className="mt-1 text-xs text-gray-400">{state.pins.filter((pin) => pin.pinType === 'market').length} market pins configured.</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+function MarketDiscoveryLayoutEditor() {
+  const [selectedMode, setSelectedMode] = useState('top');
+  const [selectedSecondarySlug, setSelectedSecondarySlug] = useState('');
+  const [activeEditorTab, setActiveEditorTab] = useState('layout');
+  const [layoutState, setLayoutState] = useState({
+    top: normalizePage({}, 'top'),
+    secondary: normalizePage({}, 'secondary'),
+  });
+  const [loading, setLoading] = useState(true);
+  const [loadingSecondary, setLoadingSecondary] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [savingPins, setSavingPins] = useState(false);
+  const [activeTags, setActiveTags] = useState([]);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let ignore = false;
+
+    const loadPages = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const topPage = await apiRequest('/v0/content/market-discovery/markets', { fallbackMessage: 'Failed to load TOP layout.' });
+        if (!ignore) {
+          setLayoutState({
+            top: normalizePage(topPage, 'top'),
+            secondary: normalizePage({}, 'secondary'),
+          });
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load market discovery layouts.');
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadPages();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const loadActiveTags = async () => {
+      try {
+        const result = await listAdminMarketTags({ includeInactive: false });
+        if (!ignore) {
+          const tags = result.tags || [];
+          setActiveTags(tags);
+          setSelectedSecondarySlug((current) => current || tags[0]?.slug || '');
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load active market tags.');
+        }
+      }
+    };
+
+    loadActiveTags();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedSecondarySlug) {
+      return undefined;
+    }
+
+    let ignore = false;
+
+    const loadSecondaryPage = async () => {
+      setLoadingSecondary(true);
+      setError('');
+      try {
+        const page = await apiRequest(`/v0/content/market-discovery/${selectedSecondarySlug}`, {
+          fallbackMessage: 'Failed to load topic page layout.',
+        });
+        if (!ignore) {
+          setLayoutState((current) => ({
+            ...current,
+            secondary: {
+              ...normalizePage(page, 'secondary'),
+              slug: selectedSecondarySlug,
+              primaryTagSlug: selectedSecondarySlug,
+              searchScope: 'tag',
+              featuredTopicsEnabled: false,
+              featuredMarketsEnabled: true,
+            },
+          }));
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load topic page layout.');
+        }
+      } finally {
+        if (!ignore) {
+          setLoadingSecondary(false);
+        }
+      }
+    };
+
+    loadSecondaryPage();
+
+    return () => {
+      ignore = true;
+    };
+  }, [selectedSecondarySlug]);
+
+  const mode = layoutModes[selectedMode];
+  const state = layoutState[selectedMode];
+  const selectedSecondaryTag = activeTags.find((tag) => tag.slug === selectedSecondarySlug);
+  const selectedPageSlug = selectedMode === 'secondary' ? selectedSecondarySlug : mode.slug;
+  const selectedPageLabel = selectedMode === 'secondary' && selectedSecondarySlug
+    ? `${mode.label}: ${tagOptionLabel(selectedSecondaryTag || { slug: selectedSecondarySlug })}`
+    : mode.label;
+  const selectedRoute = selectedMode === 'secondary' && selectedSecondarySlug
+    ? `/markets/topic/${selectedSecondarySlug}`
+    : mode.route;
+  const canEditSelectedPage = selectedMode !== 'secondary' || !!selectedSecondarySlug;
+  const topicPins = state.pins
+    .map((pin, index) => ({ pin, index }))
+    .filter(({ pin }) => pin.pinType === 'discovery_page');
+  const marketPins = state.pins
+    .map((pin, index) => ({ pin, index }))
+    .filter(({ pin }) => pin.pinType === 'market');
+  const activeTagOptions = useMemo(() => (
+    [...activeTags].sort((left, right) => (
+      (left.displayName || left.slug).localeCompare(right.displayName || right.slug)
+    ))
+  ), [activeTags]);
+  const firstActiveTagSlug = activeTagOptions[0]?.slug || '';
+  const editorTabs = useMemo(() => {
+    const layoutTab = {
+      key: 'layout',
+      label: selectedMode === 'secondary' ? 'Topic page pins (SECONDARY)' : 'Market page layout (TOP)',
+    };
+    if (selectedMode === 'secondary') {
+      return [
+        layoutTab,
+        { key: 'marketPins', label: 'Market Pins' },
+        { key: 'preview', label: 'Preview' },
+      ];
+    }
+    return [
+      layoutTab,
+      { key: 'topicPins', label: 'Topic Pins' },
+      { key: 'marketPins', label: 'Market Pins' },
+      { key: 'preview', label: 'Preview' },
+    ];
+  }, [selectedMode]);
+
+  useEffect(() => {
+    if (!editorTabs.some((tab) => tab.key === activeEditorTab)) {
+      setActiveEditorTab(editorTabs[0]?.key || 'layout');
+    }
+  }, [activeEditorTab, editorTabs]);
+
+  const replaceSelectedState = (saved) => {
+    setLayoutState((current) => ({
+      ...current,
+      [selectedMode]: selectedMode === 'secondary'
+        ? {
+          ...normalizePage(saved, selectedMode),
+          slug: selectedSecondarySlug,
+          primaryTagSlug: selectedSecondarySlug,
+          searchScope: 'tag',
+          featuredTopicsEnabled: false,
+          featuredMarketsEnabled: true,
+        }
+        : normalizePage(saved, selectedMode),
+    }));
+  };
+
+  const updateState = (updates) => {
+    setLayoutState((current) => ({
+      ...current,
+      [selectedMode]: {
+        ...current[selectedMode],
+        ...updates,
+      },
+    }));
+  };
+
+  const updatePin = (index, updates) => {
+    updateState({
+      pins: state.pins.map((pin, currentIndex) => (
+        currentIndex === index ? { ...pin, ...updates } : pin
+      )),
+    });
+  };
+
+  const selectedBlocks = useMemo(() => [
+    ...mode.fixedBlocks,
+    ...(state.featuredTopicsEnabled ? ['Topic Pins'] : []),
+    ...(state.featuredMarketsEnabled ? ['Market Pins'] : []),
+  ], [mode, state]);
+
+  const saveLayout = async () => {
+    setSaving(true);
+    setMessage('');
+    setError('');
+    try {
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${selectedPageSlug}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...state,
+          pageType: mode.pageType,
+          primaryTagSlug: selectedMode === 'secondary' ? selectedSecondarySlug : state.primaryTagSlug,
+          searchScope: selectedMode === 'secondary' ? 'tag' : 'all',
+          featuredTopicsEnabled: selectedMode === 'secondary' ? false : state.featuredTopicsEnabled,
+          featuredMarketsEnabled: selectedMode === 'secondary' ? true : state.featuredMarketsEnabled,
+        }),
+        fallbackMessage: 'Failed to save market discovery layout.',
+      });
+      replaceSelectedState(saved);
+      setMessage(`${selectedPageLabel} saved.`);
+    } catch (err) {
+      setError(err.message || 'Unable to save market discovery layout.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const savePins = async () => {
+    setSavingPins(true);
+    setMessage('');
+    setError('');
+    try {
+      const pins = selectedMode === 'secondary'
+        ? state.pins.filter((pin) => pin.pinType === 'market')
+        : state.pins;
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${selectedPageSlug}/pins`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pins }),
+        fallbackMessage: 'Failed to save discovery pins.',
+      });
+      replaceSelectedState(saved);
+      setMessage(`${selectedPageLabel} pins saved.`);
+    } catch (err) {
+      setError(err.message || 'Unable to save discovery pins.');
+    } finally {
+      setSavingPins(false);
+    }
+  };
+
+  const addPin = (pinType) => {
+    updateState({
+      pins: [
+        ...state.pins,
+        {
+          pinType,
+          marketId: pinType === 'market' ? '' : 0,
+          targetPageSlug: pinType === 'discovery_page' ? firstActiveTagSlug : '',
+          label: pinType === 'market' ? '' : 'Featured Topic',
+          sortOrder: nextSortOrder(state.pins),
+        },
+      ],
+    });
+  };
+
+  const removePin = (index) => {
+    updateState({ pins: state.pins.filter((_, currentIndex) => currentIndex !== index) });
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-primary-background p-8 text-white">
+        Loading market discovery layouts...
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-primary-background p-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-sky-300">CMS</p>
+          <h1 className="mt-2 text-3xl font-bold text-white">Market Discovery Layout</h1>
+        </div>
+
+        {message && <div className="rounded-lg bg-emerald-700 p-4 text-sm text-white">{message}</div>}
+        {error && <div className="rounded-lg bg-red-700 p-4 text-sm text-white">{error}</div>}
+
+        <div className="grid gap-6 lg:grid-cols-[320px,minmax(0,1fr)]">
+          <div className="space-y-4">
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-4">
+              <h2 className="font-semibold text-white">Layout Type</h2>
+              <div className="mt-4 grid gap-3">
+                {Object.entries(layoutModes).map(([key, item]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSelectedMode(key)}
+                    className={`rounded-lg border p-4 text-left transition ${
+                      selectedMode === key
+                        ? 'border-primary-pink bg-primary-pink/15 text-white'
+                        : 'border-gray-700 bg-gray-950 text-gray-300 hover:border-gray-500'
+                    }`}
+                  >
+                    <span className="block font-semibold">{item.label}</span>
+                    <span className="mt-1 block text-xs text-gray-400">{item.route}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-4">
+              <h2 className="font-semibold text-white">Persisted Backend Tables</h2>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {persistedTables.map((table) => (
+                  <Pill key={table}>{table}</Pill>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="flex flex-wrap gap-2 rounded-xl border border-gray-700 bg-gray-900/80 p-3">
+              {editorTabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => setActiveEditorTab(tab.key)}
+                  className={`rounded-lg px-3 py-2 text-sm font-semibold transition ${
+                    activeEditorTab === tab.key
+                      ? 'bg-primary-pink text-white'
+                      : 'border border-gray-700 bg-gray-950 text-gray-300 hover:border-gray-500 hover:text-white'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            {activeEditorTab === 'layout' && (
+              <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-2xl font-bold text-white">{selectedPageLabel}</h2>
+                  <p className="mt-2 max-w-2xl text-sm text-gray-300">{mode.purpose}</p>
+                  <p className="mt-1 text-xs font-semibold text-sky-200">{selectedRoute}</p>
+                </div>
+                <button
+                  type="button"
+                  disabled={saving || loadingSecondary || !canEditSelectedPage}
+                  onClick={saveLayout}
+                  className="rounded-md bg-primary-pink px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-pink/80 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {saving ? 'Saving...' : 'Save Layout'}
+                </button>
+              </div>
+
+              {selectedMode === 'secondary' && (
+                <div className="mt-5 rounded-lg border border-sky-500/30 bg-sky-950/20 p-4">
+                  <Field label="Secondary Topic Page">
+                    <select
+                      value={selectedSecondarySlug}
+                      onChange={(event) => setSelectedSecondarySlug(event.target.value)}
+                      className={textInputClass}
+                    >
+                      {activeTagOptions.length === 0 && <option value="">Create an active tag first</option>}
+                      {activeTagOptions.map((tag) => (
+                        <option key={tag.slug} value={tag.slug}>{tagOptionLabel(tag)}</option>
+                      ))}
+                    </select>
+                  </Field>
+                  <p className="mt-3 text-xs text-sky-100/80">
+                    Secondary pages are stored per active tag. The topic nav is inherited from the TOP /markets page; market pins here are independent and searched within this topic.
+                  </p>
+                  {loadingSecondary && <p className="mt-2 text-xs text-gray-300">Loading selected topic page...</p>}
+                </div>
+              )}
+
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                <Field label="Page Title" className="md:col-span-2">
+                  <input
+                    value={state.title}
+                    maxLength={160}
+                    onChange={(event) => updateState({ title: event.target.value })}
+                    className={textInputClass}
+                  />
+                </Field>
+                <Field label="Page Description" className="md:col-span-2">
+                  <textarea
+                    value={state.description}
+                    maxLength={500}
+                    rows={3}
+                    onChange={(event) => updateState({ description: event.target.value })}
+                    className={textInputClass}
+                  />
+                </Field>
+                <Field label="Empty CMS Recommendation Limit">
+                  <input
+                    type="number"
+                    min="1"
+                    max="50"
+                    value={state.defaultRecommendationLimit}
+                    onChange={(event) => updateState({ defaultRecommendationLimit: Number(event.target.value || 1) })}
+                    className={textInputClass}
+                  />
+                </Field>
+                <Field label="Curated CMS Recommendation Limit">
+                  <input
+                    type="number"
+                    min="1"
+                    max="50"
+                    value={state.curatedRecommendationLimit}
+                    onChange={(event) => updateState({ curatedRecommendationLimit: Number(event.target.value || 1) })}
+                    className={textInputClass}
+                  />
+                </Field>
+              </div>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                {selectedMode === 'top' && (
+                  <ToggleCard
+                    title="Topic Pins"
+                    description="Create the persistent topic navigation bar. TOP Topic Pins appear on /markets and every secondary topic page."
+                    checked={state.featuredTopicsEnabled}
+                    onChange={(checked) => updateState({ featuredTopicsEnabled: checked })}
+                  />
+                )}
+                <ToggleCard
+                  title="Market Pins"
+                  description={selectedMode === 'secondary' ? 'Pin active markets for this topic page only.' : 'Pin active markets as large chart cards before long fallback lists.'}
+                  checked={selectedMode === 'secondary' ? true : state.featuredMarketsEnabled}
+                  onChange={(checked) => updateState({ featuredMarketsEnabled: checked })}
+                />
+              </div>
+
+              <div className="mt-6 rounded-lg border border-gray-700 bg-gray-950 p-4">
+                <h3 className="font-semibold text-white">Selected Render Blocks</h3>
+                <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-gray-300">
+                  {selectedBlocks.map((block) => (
+                    <li key={block}>{block}</li>
+                  ))}
+                </ol>
+              </div>
+            </div>
+            )}
+
+            {selectedMode === 'top' && activeEditorTab === 'topicPins' && (
+              <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-xl font-bold text-white">Topic Pins</h3>
+                  <p className="mt-1 text-sm text-gray-400">
+                    Topic pins build the persistent market topic nav bar. Each entry points to an active tag and appears on /markets and every /markets/topic/:slug page.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => addPin('discovery_page')}
+                    disabled={activeTagOptions.length === 0}
+                    className="rounded-md border border-sky-500/50 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-950/50 disabled:cursor-not-allowed disabled:opacity-50"
+                    title={activeTagOptions.length === 0 ? 'Create an active tag before adding topic pins.' : 'Add a pinned topic from active tags.'}
+                  >
+                    Add Topic Pin
+                  </button>
+                  <button type="button" disabled={savingPins} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
+                    {savingPins ? 'Saving...' : 'Save Pins'}
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-400">
+                <Pill>{topicPins.length} topic pins</Pill>
+              </div>
+              <div className="mt-4 space-y-3">
+                {topicPins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No topic pins yet.</p>}
+                {topicPins.map(({ pin, index }) => (
+                  <div key={`topic-${pin.id || pin.targetPageSlug || index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,90px)]">
+                    <Field label="Nav Label">
+                      <input value={pin.label || ''} onChange={(event) => updatePin(index, { label: event.target.value })} className={textInputClass} />
+                    </Field>
+                    <Field label="Target Topic Tag">
+                      <select
+                        value={pin.targetPageSlug || ''}
+                        onChange={(event) => updatePin(index, { targetPageSlug: event.target.value })}
+                        className={textInputClass}
+                      >
+                        {activeTagOptions.length === 0 && !pin.targetPageSlug && (
+                          <option value="">Create an active tag first</option>
+                        )}
+                        {tagOptionsWithCurrent(activeTagOptions, pin.targetPageSlug).map((tag) => (
+                          <option key={tag.slug} value={tag.slug}>
+                            {tagOptionLabel(tag)}{tag.isActive === false ? ' - inactive or missing' : ''}
+                          </option>
+                        ))}
+                      </select>
+                    </Field>
+                    <Field label="Order">
+                      <input type="number" value={pin.sortOrder || index + 1} onChange={(event) => updatePin(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
+                    </Field>
+                    <div className="md:col-span-3">
+                      <button type="button" onClick={() => removePin(index)} className="text-sm font-semibold text-red-300 hover:text-red-200">
+                        Remove topic pin
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            )}
+
+            {activeEditorTab === 'marketPins' && (
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-xl font-bold text-white">Market Pins</h3>
+                  <p className="mt-1 text-sm text-gray-400">
+                    {selectedMode === 'secondary'
+                      ? `Market pins render selected active ${selectedSecondarySlug || 'topic'} markets on this topic page only.`
+                      : 'Market pins render selected active markets as featured chart cards. Search active markets, select one, then save.'}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" onClick={() => addPin('market')} disabled={!canEditSelectedPage || loadingSecondary} className="rounded-md border border-emerald-500/50 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-950/50 disabled:cursor-not-allowed disabled:opacity-50">Add Market Pin</button>
+                  <button type="button" disabled={savingPins || !canEditSelectedPage || loadingSecondary} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
+                    {savingPins ? 'Saving...' : 'Save Pins'}
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-400">
+                <Pill>{marketPins.length} market pins</Pill>
+              </div>
+              <div className="mt-4 space-y-3">
+                {marketPins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No market pins yet.</p>}
+                {marketPins.map(({ pin, index }) => (
+                  <div key={`market-${pin.id || pin.marketId || index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,90px)]">
+                    <MarketPinSearch pin={pin} tagSlug={selectedMode === 'secondary' ? selectedSecondarySlug : ''} onSelect={(marketId) => updatePin(index, { marketId: Number(marketId), label: '' })} />
+                    <Field label="Order">
+                      <input type="number" value={pin.sortOrder || index + 1} onChange={(event) => updatePin(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
+                    </Field>
+                    <div className="md:col-span-2">
+                      <button type="button" onClick={() => removePin(index)} className="text-sm font-semibold text-red-300 hover:text-red-200">
+                        Remove market pin
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            )}
+
+            {activeEditorTab === 'preview' && <LayoutPreview mode={{ ...mode, route: selectedRoute }} state={state} />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MarketDiscoveryLayoutEditor;

--- a/frontend/src/pages/create/Create.jsx
+++ b/frontend/src/pages/create/Create.jsx
@@ -9,6 +9,8 @@ import EmojiPickerInput from '../../components/inputs/EmojiPicker';
 import SiteButton from '../../components/buttons/SiteButtons';
 import { USER_CREDIT_REFRESH_EVENT } from '../../components/utils/userFinanceTools/FetchUserCredit';
 import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
+import { listMarketTags } from '../../api/marketTagsApi';
+import MarketTagChips from '../../components/markets/MarketTagChips';
 
 function Create() {
   const [questionTitle, setQuestionTitle] = useState('');
@@ -21,6 +23,8 @@ function Create() {
   const [error, setError] = useState('');
   const [createdMarket, setCreatedMarket] = useState(null);
   const [marketCreationCost, setMarketCreationCost] = useState(null);
+  const [marketTags, setMarketTags] = useState([]);
+  const [selectedTagSlugs, setSelectedTagSlugs] = useState([]);
   const { username } = useAuth();
   const history = useHistory();
 
@@ -52,6 +56,42 @@ function Create() {
       ignore = true;
     };
   }, []);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const loadTags = async () => {
+      try {
+        const data = await listMarketTags();
+        if (!ignore) {
+          setMarketTags(data.tags || []);
+        }
+      } catch {
+        if (!ignore) {
+          setMarketTags([]);
+        }
+      }
+    };
+
+    loadTags();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const toggleTagSlug = (slug) => {
+    setSelectedTagSlugs((current) => {
+      if (current.includes(slug)) {
+        return current.filter((value) => value !== slug);
+      }
+      if (current.length >= 5) {
+        setError('You can select up to five market tags.');
+        return current;
+      }
+      setError('');
+      return [...current, slug];
+    });
+  };
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -97,6 +137,7 @@ function Create() {
         utcOffset: new Date().getTimezoneOffset(),
         yesLabel: trimmedYesLabel || 'YES',
         noLabel: trimmedNoLabel || 'NO',
+        tagSlugs: selectedTagSlugs,
       };
 
       const responseData = await authenticatedApiRequest('/v0/markets', {
@@ -172,6 +213,45 @@ function Create() {
             className='w-full h-32 resize-y bg-gray-700 border border-gray-600 text-white px-3 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500'
           />
         </div>
+
+        {marketTags.length > 0 && (
+          <div className='rounded-lg border border-gray-700 bg-gray-900/60 p-4'>
+            <div className='mb-3 flex flex-wrap items-center justify-between gap-2'>
+              <div>
+                <p className='text-sm font-medium text-gray-200'>Market Tags</p>
+                <p className='mt-1 text-xs text-gray-400'>
+                  Pick up to five categories so admins can review routing and users can find this market.
+                </p>
+              </div>
+              <span className='rounded-full bg-gray-800 px-3 py-1 text-xs text-gray-300'>
+                {selectedTagSlugs.length}/5 selected
+              </span>
+            </div>
+            <div className='flex flex-wrap gap-2'>
+              {marketTags.map((tag) => {
+                const selected = selectedTagSlugs.includes(tag.slug);
+                return (
+                  <button
+                    key={tag.slug}
+                    type='button'
+                    onClick={() => toggleTagSlug(tag.slug)}
+                    className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                      selected
+                        ? 'border-primary-pink bg-primary-pink/20 text-white'
+                        : 'border-gray-600 bg-gray-800 text-gray-300 hover:border-primary-pink/70 hover:text-white'
+                    }`}
+                  >
+                    {tag.displayName || tag.slug}
+                  </button>
+                );
+              })}
+            </div>
+            <MarketTagChips
+              tags={marketTags.filter((tag) => selectedTagSlugs.includes(tag.slug))}
+              className='mt-3'
+            />
+          </div>
+        )}
 
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
           <div>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -1,14 +1,392 @@
 import React, { useState, useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
 import SiteTabs from '../../components/tabs/SiteTabs';
 import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
 import GlobalSearchBar from '../../components/search/GlobalSearchBar';
 import SearchResultsTable from '../../components/tables/SearchResultsTable';
+import { marketTagChipClassFor } from '../../components/markets/MarketTagChips';
 import { TAB_TO_STATUS } from '../../utils/statusMap';
+import { apiRequest } from '../../api/httpClient';
+import { listMarketTags } from '../../api/marketTagsApi';
+
+const defaultDiscoveryLayout = {
+    title: 'Markets',
+    description: '',
+    featuredTopicsEnabled: false,
+    featuredMarketsEnabled: false,
+    recommendationLimit: 20,
+    primaryTagSlug: '',
+    searchScope: 'all',
+    pins: [],
+};
+
+const hasCuratedBlocks = (layout) => (
+    layout?.featuredTopicsEnabled || layout?.featuredMarketsEnabled
+);
+
+const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortOrder || 0) - Number(b.sortOrder || 0));
+
+const toNumber = (value, fallback = 0) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : fallback;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const slugTitle = (slug = '') => slug
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+const normalizeDiscoveryLayout = (layout, fallback = {}) => ({
+    ...defaultDiscoveryLayout,
+    ...fallback,
+    ...layout,
+    pins: sortBySortOrder(layout?.pins || []),
+});
+
+const DiscoveryBadge = ({ children, tag }) => {
+    const tones = {
+        sky: 'border-sky-500/40 bg-sky-950/40 text-sky-100',
+    };
+    const className = tag ? marketTagChipClassFor(tag) : tones.sky;
+
+    return (
+        <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${className}`}>
+            {children}
+        </span>
+    );
+};
+
+const TopicNav = ({ topicPins = [] }) => {
+    return (
+        <nav className="mb-5 overflow-x-auto border-b border-gray-800 pb-3" aria-label="Market topics">
+            <div className="flex min-w-max items-center gap-2">
+                <Link
+                    to="/markets"
+                    className="rounded-full border border-sky-500/50 bg-sky-950/40 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:border-sky-300/70 hover:bg-sky-900/50 hover:text-white"
+                >
+                    Markets
+                </Link>
+                {topicPins.map((pin) => (
+                    <Link
+                        key={`topic-${pin.id || pin.targetPageSlug || pin.sortOrder}`}
+                        to={pin.targetPageSlug ? `/markets/topic/${pin.targetPageSlug}` : '#'}
+                        className={`rounded-full border px-4 py-2 text-sm font-semibold transition hover:brightness-125 ${marketTagChipClassFor(pin.tag)}`}
+                        title={pin.tag?.description || pin.label || pin.targetPageSlug}
+                    >
+                        {pin.label || slugTitle(pin.targetPageSlug) || 'Topic'}
+                    </Link>
+                ))}
+            </div>
+        </nav>
+    );
+};
+
+const normalizeProbabilityChanges = (raw = []) => (
+    Array.isArray(raw)
+        ? raw
+            .map((change) => ({
+                probability: toNumber(change?.probability ?? change?.Probability),
+                timestamp: change?.timestamp ?? change?.Timestamp ?? change?.createdAt ?? change?.CreatedAt,
+            }))
+            .filter((change) => change.timestamp)
+        : []
+);
+
+const currentProbabilityFromDetails = (details) => {
+    const changes = normalizeProbabilityChanges(details?.probabilityChanges ?? details?.ProbabilityChanges);
+    if (changes.length > 0) {
+        return toNumber(changes[changes.length - 1].probability);
+    }
+    return toNumber(details?.lastProbability ?? details?.LastProbability ?? details?.market?.initialProbability);
+};
+
+const chartSamplesFromDetails = (details) => {
+    const changes = normalizeProbabilityChanges(details?.probabilityChanges ?? details?.ProbabilityChanges);
+    const currentProbability = currentProbabilityFromDetails(details);
+    const market = details?.market || {};
+    const fallbackTimestamp = market.createdAt || market.CreatedAt || new Date().toISOString();
+    const samples = changes.length > 0
+        ? changes.map((change) => ({
+            probability: toNumber(change.probability, currentProbability),
+            timestamp: new Date(change.timestamp).getTime(),
+        }))
+        : [{
+            probability: currentProbability,
+            timestamp: new Date(fallbackTimestamp).getTime(),
+        }];
+
+    const validSamples = samples
+        .filter((sample) => Number.isFinite(sample.timestamp))
+        .sort((left, right) => left.timestamp - right.timestamp);
+
+    if (validSamples.length === 0) {
+        return [{
+            probability: currentProbability,
+            timestamp: Date.now(),
+        }];
+    }
+
+    return validSamples;
+};
+
+const sampleToPoint = (sample, minTime, maxTime, width, height, inset) => {
+    const usableWidth = width - inset * 2;
+    const usableHeight = height - inset * 2;
+    const timeSpan = Math.max(maxTime - minTime, 1);
+    const probability = Math.max(0, Math.min(1, sample.probability));
+
+    return {
+        x: inset + ((sample.timestamp - minTime) / timeSpan) * usableWidth,
+        y: inset + (1 - probability) * usableHeight,
+    };
+};
+
+const buildStepPath = (points) => {
+    if (points.length === 0) {
+        return '';
+    }
+    const [first, ...rest] = points;
+    const commands = [`M ${first.x.toFixed(2)} ${first.y.toFixed(2)}`];
+
+    rest.forEach((point) => {
+        commands.push(`H ${point.x.toFixed(2)}`);
+        commands.push(`V ${point.y.toFixed(2)}`);
+    });
+
+    if (points.length === 1) {
+        commands.push(`H ${first.x.toFixed(2)}`);
+    }
+
+    return commands.join(' ');
+};
+
+const PinnedMarketSparkline = ({ details }) => {
+    const width = 960;
+    const height = 260;
+    const inset = 18;
+    const samples = chartSamplesFromDetails(details);
+    const currentTime = Date.now();
+    const minTime = Math.min(...samples.map((sample) => sample.timestamp));
+    const maxSampleTime = Math.max(...samples.map((sample) => sample.timestamp));
+    const maxTime = Math.max(maxSampleTime, currentTime, minTime + 1);
+    const points = samples.map((sample) => sampleToPoint(sample, minTime, maxTime, width, height, inset));
+    const firstX = inset;
+    const lastX = width - inset;
+    const floorY = height - inset;
+    const lastPoint = points[points.length - 1] || { x: lastX, y: height / 2 };
+    const stepPath = `${buildStepPath(points)} H ${lastX.toFixed(2)}`;
+    const areaPath = `${stepPath} L ${lastX} ${floorY} L ${firstX} ${floorY} Z`;
+    const currentProbability = currentProbabilityFromDetails(details);
+
+    return (
+        <svg
+            viewBox={`0 0 ${width} ${height}`}
+            className="h-full w-full"
+            preserveAspectRatio="none"
+            role="img"
+            aria-label={`Pinned market probability ${(currentProbability * 100).toFixed(0)} percent`}
+        >
+            <defs>
+                <linearGradient id="pinned-market-area" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#22d3ee" stopOpacity="0.58" />
+                    <stop offset="100%" stopColor="#0e7490" stopOpacity="0.16" />
+                </linearGradient>
+            </defs>
+            <rect width={width} height={height} rx="18" fill="#101827" />
+            <line x1="0" x2={width} y1={height / 2} y2={height / 2} stroke="#334155" strokeWidth="2" strokeDasharray="10 12" opacity="0.45" />
+            <path d={areaPath} fill="url(#pinned-market-area)" />
+            <path d={stepPath} fill="none" stroke="#22d3ee" strokeWidth="8" strokeLinecap="round" strokeLinejoin="round" />
+            <circle cx={lastX} cy={lastPoint.y || height / 2} r="10" fill="#22d3ee" />
+            <text x={width - 28} y="58" textAnchor="end" fill="#e2e8f0" fontSize="24" fontWeight="700">
+                {(currentProbability * 100).toFixed(0)}%
+            </text>
+        </svg>
+    );
+};
+
+const FeaturedMarketPins = ({ marketPins = [] }) => {
+    const [pinnedMarkets, setPinnedMarkets] = useState([]);
+    const pinKey = marketPins
+        .map((pin) => `${pin.id || ''}:${pin.marketId || ''}:${pin.sortOrder || ''}`)
+        .join('|');
+
+    useEffect(() => {
+        let ignore = false;
+        const pinsWithIds = marketPins.filter((pin) => Number(pin.marketId) > 0);
+
+        if (pinsWithIds.length === 0) {
+            setPinnedMarkets([]);
+            return () => {
+                ignore = true;
+            };
+        }
+
+        Promise.all(
+            pinsWithIds.map((pin) => (
+                apiRequest(`/v0/markets/${pin.marketId}`, {
+                    fallbackMessage: `Failed to load pinned market ${pin.marketId}`,
+                })
+                    .then((details) => ({ pin, details }))
+                    .catch(() => null)
+            )),
+        ).then((items) => {
+            if (!ignore) {
+                setPinnedMarkets(items.filter((item) => item?.details?.market));
+            }
+        });
+
+        return () => {
+            ignore = true;
+        };
+    }, [pinKey]);
+
+    if (!pinnedMarkets.length) return null;
+
+    return (
+        <section className="grid gap-3 lg:grid-cols-2" aria-label="Pinned markets">
+            {pinnedMarkets.map(({ pin, details }) => {
+                const market = details.market || {};
+                const marketId = market.id || pin.marketId;
+                return (
+                    <Link
+                        key={`market-${pin.id || marketId || pin.sortOrder}`}
+                        to={marketId ? `/markets/${marketId}` : '#'}
+                        className="block w-full rounded-xl border border-gray-700 bg-gray-950/80 p-3 no-underline shadow-lg transition hover:border-sky-400/60 hover:bg-gray-900"
+                    >
+                        <h3 className="mb-2 line-clamp-2 min-h-[2.5rem] text-sm font-semibold leading-5 text-white">
+                            {market.questionTitle || pin.label || `Market #${marketId}`}
+                        </h3>
+                        <div className="h-36 overflow-hidden rounded-lg border border-gray-800 bg-gray-900/60 sm:h-52">
+                            <PinnedMarketSparkline details={details} />
+                        </div>
+                    </Link>
+                );
+            })}
+        </section>
+    );
+};
+
+const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins = true }) => {
+    const pins = sortBySortOrder(layout.pins || []);
+    const topicPins = persistentTopicPins.length > 0
+        ? persistentTopicPins
+        : (useLayoutTopicPins ? pins.filter((pin) => pin.pinType === 'discovery_page') : []);
+    const marketPins = pins.filter((pin) => pin.pinType === 'market');
+    const hasTopicNav = topicPins.length > 0;
+
+    if (!hasCuratedBlocks(layout) && !hasTopicNav) return null;
+
+    return (
+        <div className="mb-6 space-y-5 text-gray-200">
+            {hasTopicNav && <TopicNav topicPins={topicPins} />}
+
+            {layout.featuredMarketsEnabled && <FeaturedMarketPins marketPins={marketPins} />}
+        </div>
+    );
+};
 
 function Markets() {
+    const { slug: topicSlugParam } = useParams();
+    const topicSlug = topicSlugParam || '';
+    const isTopicPage = !!topicSlug;
     const [searchResults, setSearchResults] = useState(null);
     const [isSearching, setIsSearching] = useState(false);
     const [activeTab, setActiveTab] = useState('Active');
+    const [discoveryLayout, setDiscoveryLayout] = useState(defaultDiscoveryLayout);
+    const [persistentTopicPins, setPersistentTopicPins] = useState([]);
+    const [marketTagsBySlug, setMarketTagsBySlug] = useState({});
+
+    useEffect(() => {
+        let ignore = false;
+
+        listMarketTags()
+            .then((result) => {
+                if (ignore) return;
+                const bySlug = {};
+                (result.tags || []).forEach((tag) => {
+                    if (tag.slug) {
+                        bySlug[tag.slug] = tag;
+                    }
+                });
+                setMarketTagsBySlug(bySlug);
+            })
+            .catch(() => {
+                if (!ignore) {
+                    setMarketTagsBySlug({});
+                }
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, []);
+
+    useEffect(() => {
+        let ignore = false;
+        const discoverySlug = isTopicPage ? topicSlug : 'markets';
+        const fallback = isTopicPage
+            ? {
+                title: slugTitle(topicSlug) || 'Topic Markets',
+                description: 'Browse and search markets in this topic.',
+                primaryTagSlug: topicSlug,
+                searchScope: 'tag',
+                featuredMarketsEnabled: true,
+                recommendationLimit: 5,
+            }
+            : {};
+
+        setSearchResults(null);
+        setIsSearching(false);
+
+        const loadDiscovery = async () => {
+            try {
+                const [layout, topLayout] = await Promise.all([
+                    apiRequest(`/v0/content/market-discovery/${discoverySlug}`, {
+                        fallbackMessage: 'Failed to load market discovery layout',
+                    }),
+                    isTopicPage
+                        ? apiRequest('/v0/content/market-discovery/markets', {
+                            fallbackMessage: 'Failed to load market topic navigation',
+                        })
+                        : Promise.resolve(null),
+                ]);
+                if (!ignore) {
+                    const normalizedLayout = normalizeDiscoveryLayout(layout, fallback);
+                    const topNavLayout = isTopicPage
+                        ? normalizeDiscoveryLayout(topLayout || {}, {})
+                        : normalizedLayout;
+                    const topTopicPins = topNavLayout.featuredTopicsEnabled
+                        ? sortBySortOrder(topNavLayout.pins || [])
+                            .filter((pin) => pin.pinType === 'discovery_page')
+                            .map((pin) => ({ ...pin, tag: marketTagsBySlug[pin.targetPageSlug] }))
+                        : [];
+
+                    setDiscoveryLayout(normalizedLayout);
+                    setPersistentTopicPins(topTopicPins);
+                }
+            } catch {
+                if (!ignore) {
+                    setDiscoveryLayout(normalizeDiscoveryLayout({}, fallback));
+                    setPersistentTopicPins([]);
+                }
+            }
+        };
+
+        loadDiscovery();
+
+        return () => {
+            ignore = true;
+        };
+    }, [isTopicPage, topicSlug, marketTagsBySlug]);
+
+    const tagScope = isTopicPage
+        ? topicSlug
+        : (discoveryLayout.searchScope === 'tag' ? discoveryLayout.primaryTagSlug : '');
+    const tagScopeLabel = marketTagsBySlug[tagScope]?.displayName || slugTitle(tagScope) || tagScope;
 
     const handleSearchResults = (results) => {
         setSearchResults(results);
@@ -16,8 +394,7 @@ function Markets() {
 
     const handleTabChange = (tabLabel) => {
         setActiveTab(tabLabel);
-        // Don't clear search when switching tabs - let GlobalSearchBar re-execute with new status
-        // The search will automatically re-execute due to currentStatus change in GlobalSearchBar
+        // Don't clear search when switching tabs; GlobalSearchBar re-executes with currentStatus.
     };
 
     const tabsData = [
@@ -25,28 +402,28 @@ function Markets() {
             label: 'Active', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="active" />,
+                <MarketsByStatusTable status="active" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('Active')
         },
         { 
             label: 'Closed', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="closed" />,
+                <MarketsByStatusTable status="closed" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('Closed')
         },
         { 
             label: 'Resolved', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="resolved" />,
+                <MarketsByStatusTable status="resolved" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('Resolved')
         },
         { 
             label: 'All', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="all" />,
+                <MarketsByStatusTable status="all" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('All')
         },
     ];
@@ -55,18 +432,52 @@ function Markets() {
         <div className='App'>
             <div className='Center-content'>
                 <div className='Center-content-header'>
-                    <h1 className='text-2xl font-semibold text-gray-300 mb-6'>Markets</h1>
+                    {isTopicPage ? (
+                        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(260px,420px)] md:items-start">
+                            <div>
+                                <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
+                                {discoveryLayout.description && (
+                                    <p className="mb-3 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
+                                )}
+                            </div>
+                            <div className="space-y-2 md:text-right">
+                                {tagScope && (
+                                    <div className="md:flex md:justify-end">
+                                        <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{tagScopeLabel}</DiscoveryBadge>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    ) : (
+                        <>
+                            <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
+                            {discoveryLayout.description && (
+                                <p className="mb-3 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
+                            )}
+                            {tagScope && (
+                                <div className="mb-6">
+                                    <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{tagScopeLabel}</DiscoveryBadge>
+                                </div>
+                            )}
+                        </>
+                    )}
                 </div>
                 <div className='Center-content-table'>
-                    {/* Global Search Bar - Always visible at top */}
                     <GlobalSearchBar 
                         onSearchResults={handleSearchResults}
                         currentStatus={TAB_TO_STATUS[activeTab]}
                         isSearching={isSearching}
                         setIsSearching={setIsSearching}
+                        tagSlug={tagScope}
                     />
+                    {!isSearching && (
+                        <DiscoveryPanel
+                            layout={discoveryLayout}
+                            persistentTopicPins={persistentTopicPins}
+                            useLayoutTopicPins={!isTopicPage}
+                        />
+                    )}
                     
-                    {/* Tabs with Content */}
                     <SiteTabs 
                         tabs={tabsData} 
                         onTabChange={handleTabChange}

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -96,15 +96,17 @@ const Profile = () => {
 
   const proposedMarket = location.state?.proposedMarket;
   const marketCreationCost = location.state?.marketCreationCost;
-  const isModerator = String(userData?.usertype || '').toUpperCase() === 'MODERATOR';
-  const resolvedDefaultTab = isModerator ? defaultTab : 'User Info';
+  const isActiveModerator =
+    String(userData?.usertype || '').toUpperCase() === 'MODERATOR' &&
+    String(userData?.moderatorStatus || '').toLowerCase() === 'active';
+  const resolvedDefaultTab = isActiveModerator ? defaultTab : 'User Info';
 
   const profileTabs = [
     {
       label: 'User Info',
       content: <PrivateUserInfoLayout userData={userData} />,
     },
-    ...(isModerator ? [
+    ...(isActiveModerator ? [
       {
         label: lifecycleTabByStatus.proposed,
         content: <ProfileMarketLifecycleTab status='proposed' />,
@@ -137,7 +139,7 @@ const Profile = () => {
           <p className='mt-2 text-gray-400'>Manage your account, proposals, published markets, rejected markets, portfolio, and financial history.</p>
         </div>
 
-        {isModerator && proposedMarket && (
+        {isActiveModerator && proposedMarket && (
           <div className='mb-6 rounded-lg border border-amber-500 bg-amber-950/40 p-4 text-amber-50'>
             <p className='text-sm uppercase tracking-[0.18em] text-amber-300'>Proposed market created</p>
             <h2 className='mt-2 text-xl font-semibold'>{proposedMarket.questionTitle}</h2>

--- a/frontend/src/pages/style/Style.jsx
+++ b/frontend/src/pages/style/Style.jsx
@@ -31,6 +31,7 @@ import { SharesBadge } from '../../components/buttons/trade/SellButtons';
 import ExpandableText from '../../components/utils/ExpandableText';
 import ExpandableLink from '../../components/utils/ExpandableLink';
 import TradeCTA from '../../components/TradeCTA';
+import MarketTagChips, { MARKET_TAG_COLOR_OPTIONS } from '../../components/markets/MarketTagChips';
 
 const Style = () => {
   const [isSelected, setIsSelected] = useState(false);
@@ -353,6 +354,29 @@ const Style = () => {
             <div className='text-white text-sm font-medium'>NO Probability</div>
             <div className='text-gray-400 text-xs'>red-btn: #D00000</div>
             <div className='text-gray-500 text-xs mt-1'>Used when showing dual probabilities</div>
+          </div>
+        </div>
+
+        {/* Market Tag Colors Section */}
+        <h3 className='text-xl font-bold text-white mb-4 mt-8'>Market Tag Colors</h3>
+        <div className='bg-gray-900 p-4 rounded-lg border border-gray-700 mb-8'>
+          <p className='text-gray-300 text-sm mb-4'>
+            Tag chips use color as a secondary cue. Keep the palette intentionally limited:
+            roughly 8-10 colors is the practical upper bound before users rely more on text than hue.
+          </p>
+          <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4'>
+            {MARKET_TAG_COLOR_OPTIONS.map((option) => (
+              <div key={option.key} className='rounded-lg border border-gray-700 bg-primary-background p-4'>
+                <MarketTagChips tags={[{
+                  slug: option.key,
+                  displayName: option.label,
+                  colorKey: option.key,
+                  description: option.label,
+                }]} />
+                <div className='mt-3 font-mono text-xs text-gray-400'>{option.key}</div>
+                <div className='mt-1 text-xs text-gray-500'>Color key only</div>
+              </div>
+            ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Block suspended moderators from creating markets before any balance validation or proposal-cost deduction runs.
- Preserve reinstatement behavior so active moderators can create proposed markets again after unsuspension.
- Expose moderatorStatus through login and private-profile responses, then update React route/sidebar/profile gates to require an active moderator for market-authoring UI.
- Update OpenAPI response schemas for login and private profile metadata.

## Verification
- go test ./...
- npm run build