### PR TITLE
[ 09 ] Add market taxonomy tag baseline

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/09/09-market-taxonomy-navigation.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/09-market-taxonomy-navigation.md
@@ -5,7 +5,7 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-06-04T00:00:00Z
 updated_at_display: "Thursday, June 4, 2026"
-update_reason: "Start the feature spec for tags, category pages, featured market pinning, section layouts, and CMS-driven market discovery."
+update_reason: "Start the feature spec for tags, category pages, featured market pinning, and CMS-driven market discovery."
 status: draft
 ---
 
@@ -15,7 +15,7 @@ status: draft
 
 SocialPredict needs a richer market discovery model than a single `/markets` page with search and status tabs.
 
-Search should remain the primary entry point because it is direct, familiar, and works even when taxonomy content is sparse. Under that search-first entry point, the platform should support a CMS-managed market taxonomy: tags, top-level and secondary category pages, pinned featured markets, optional sections, and curated page layouts.
+Search should remain the primary entry point because it is direct, familiar, and works even when taxonomy content is sparse. Under that search-first entry point, the platform should support a CMS-managed market taxonomy: tags, top-level and secondary category pages, pinned featured markets, optional and curated page layouts.
 
 This feature creates the design foundation for that hierarchy before implementation.
 
@@ -37,12 +37,11 @@ The market discovery hierarchy should support:
 4. CMS-pinned secondary category pages on the top-level page.
 5. Secondary category pages organized by tag/category.
 6. Search on each secondary page, filtered by that category/tag by default.
-7. Optional sections within each secondary page.
-8. Featured/pinned markets within a page or section.
-9. Market tags displayed as chips in search results, market cards, admin review, and market detail pages.
-10. Moderator-selected tags during market creation, constrained to admin-managed tags.
-11. Admin tag review during market approval.
-12. Admin-only tag creation, deletion, ordering, and page layout management.
+7. Featured/pinned markets within a page.
+8. Market tags displayed as chips in search results, market cards, admin review, and market detail pages.
+9. Moderator-selected tags during market creation, constrained to admin-managed tags.
+10. Admin tag review during market approval.
+11. Admin-only tag creation, deletion, ordering, and page layout management.
 
 ## Current Behavior
 
@@ -62,18 +61,16 @@ Current market discovery is mostly flat:
 - Tag: admin-managed label that can be attached to markets and used for search/filtering.
 - Category page: CMS-managed market discovery page, usually backed by one primary tag or tag query.
 - Secondary page: category page below the top-level `/markets` page.
-- Section: CMS-managed grouping inside a category page; defaults to `All` when no sections are configured.
-- Featured market: market manually pinned to a page or section by an admin.
+- Featured market: market manually pinned to a page by an admin.
 - Featured category: secondary category page manually pinned to the top-level markets page.
 - Recommendation panel: automatic non-CMS fallback list, initially random active markets.
 - Tag chip: compact UI label that shows market tags in lists/details/review flows.
-- Taxonomy: the admin-managed set of tags, category pages, sections, and layout rules.
+- Taxonomy: the admin-managed set of tags, category pages, and layout rules.
 
 Avoid confusing:
 
 - Tag is not a free-form user hashtag.
 - Category page is not necessarily a backend route hardcoded in React.
-- Section is not a market lifecycle status.
 - Featured is manual CMS curation, not the same as algorithmic recommendation.
 - Recommendation is automatic fallback content, not an endorsement unless later copy says so.
 
@@ -93,7 +90,6 @@ Layout when CMS pinning exists:
 2. Compact recommendation panel, about 5 markets.
 3. Featured category/page cards.
 4. Featured market cards.
-5. Optional CMS sections if admins configure them later.
 
 The top-level page should not become blank just because CMS content is empty. Search and recommendation fallback keep the page useful from day one.
 
@@ -108,7 +104,6 @@ Each secondary page should support:
 - status tabs: Active, Closed, Resolved, All
 - recommendation/fallback markets for that tag if nothing is pinned
 - pinned featured markets
-- optional sections
 - tag chips on market cards/results
 
 Default layout when nothing is pinned:
@@ -123,20 +118,6 @@ Layout when page is curated:
 2. Search bar filtered to the category.
 3. Compact recommendation panel, about 5 markets.
 4. Pinned featured markets.
-5. Pinned sections.
-6. Section-specific featured markets.
-
-## Sections
-
-Sections allow a category page to be further organized without creating too many pages.
-
-Examples:
-
-- Politics category with sections: Elections, Policy, Geopolitics.
-- Sports category with sections: NFL, NBA, Soccer.
-- AI category with sections: Models, Regulation, Companies.
-
-Initial behavior can support a default `All` section only. The schema should still leave room for named sections and section-specific featured markets.
 
 ## Tag Assignment Flow
 
@@ -186,8 +167,6 @@ Admin capabilities:
 - create category page from a tag or tag query
 - pin/unpin featured markets
 - pin/unpin featured category pages
-- create/reorder sections
-- assign pinned markets to sections
 
 Deletion requires safety guardrails:
 
@@ -203,7 +182,6 @@ Candidate tables:
 - `market_tags`: admin-owned tag definitions.
 - `market_tag_assignments`: many-to-many relation between markets and tags.
 - `market_discovery_pages`: top/secondary page definitions.
-- `market_discovery_sections`: sections within pages.
 - `market_discovery_pins`: pinned markets and pinned category pages, ordered by admin.
 
 Important design choice: use additive timestamped Go migrations under `backend/migration/migrations`, following the existing migration convention.
@@ -233,7 +211,7 @@ This should be backend-owned enough that frontend does not invent recommendation
 Evans/domain posture:
 
 - Treat taxonomy terms as ubiquitous language before schema work.
-- Separate tags, category pages, sections, featured markets, and recommendations because each has a different business meaning.
+- Separate tags, category pages, featured markets, and recommendations because each has a different business meaning.
 - Do not let React route structure define the domain taxonomy.
 
 Fowler/evolutionary posture:
@@ -252,7 +230,7 @@ Martin/clean-architecture posture:
 
 Planning-level acceptance criteria:
 
-- Feature docs define tags, category pages, sections, featured markets, and recommendations distinctly.
+- Feature docs define tags, category pages, featured markets, and recommendations distinctly.
 - Database migration plan is additive and timestamped.
 - Admin ownership of tag creation/deletion is explicit.
 - Moderator tag selection is constrained to existing admin-managed tags.

--- a/README/PRODUCTION-NOTES/FEATURES/09/09-market-taxonomy-navigation.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/09-market-taxonomy-navigation.md
@@ -1,0 +1,273 @@
+---
+title: Market Taxonomy And Hierarchical Navigation
+document_type: production-notes
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-04T00:00:00Z
+updated_at_display: "Thursday, June 4, 2026"
+update_reason: "Start the feature spec for tags, category pages, featured market pinning, section layouts, and CMS-driven market discovery."
+status: draft
+---
+
+# Market Taxonomy And Hierarchical Navigation
+
+## Purpose
+
+SocialPredict needs a richer market discovery model than a single `/markets` page with search and status tabs.
+
+Search should remain the primary entry point because it is direct, familiar, and works even when taxonomy content is sparse. Under that search-first entry point, the platform should support a CMS-managed market taxonomy: tags, top-level and secondary category pages, pinned featured markets, optional sections, and curated page layouts.
+
+This feature creates the design foundation for that hierarchy before implementation.
+
+## Feature Artifact Map
+
+This directory keeps the market taxonomy/navigation feature work together:
+
+- [09-market-taxonomy-navigation.md](./09-market-taxonomy-navigation.md): feature overview, product behavior, and acceptance criteria.
+- [DESIGN.md](./DESIGN.md): domain, CMS, persistence, search, and frontend architecture design.
+- [PLAN.md](./PLAN.md): backend-first implementation checklist and PR sequencing.
+
+## Product Shape
+
+The market discovery hierarchy should support:
+
+1. A top-level `/markets` page with search as the first control.
+2. A small default recommendation panel under search, initially random active markets.
+3. CMS-pinned featured markets on the top-level page.
+4. CMS-pinned secondary category pages on the top-level page.
+5. Secondary category pages organized by tag/category.
+6. Search on each secondary page, filtered by that category/tag by default.
+7. Optional sections within each secondary page.
+8. Featured/pinned markets within a page or section.
+9. Market tags displayed as chips in search results, market cards, admin review, and market detail pages.
+10. Moderator-selected tags during market creation, constrained to admin-managed tags.
+11. Admin tag review during market approval.
+12. Admin-only tag creation, deletion, ordering, and page layout management.
+
+## Current Behavior
+
+Current market discovery is mostly flat:
+
+- `/markets` has a search bar and status tabs.
+- Search can query across active, closed, resolved, or all public markets.
+- Default tab content shows markets by status.
+- There is no durable category/tag vocabulary.
+- There is no CMS-managed page hierarchy.
+- There is no way to pin markets or category pages.
+- Moderator market creation does not attach category metadata.
+- Admin approval does not review tags.
+
+## Ubiquitous Language
+
+- Tag: admin-managed label that can be attached to markets and used for search/filtering.
+- Category page: CMS-managed market discovery page, usually backed by one primary tag or tag query.
+- Secondary page: category page below the top-level `/markets` page.
+- Section: CMS-managed grouping inside a category page; defaults to `All` when no sections are configured.
+- Featured market: market manually pinned to a page or section by an admin.
+- Featured category: secondary category page manually pinned to the top-level markets page.
+- Recommendation panel: automatic non-CMS fallback list, initially random active markets.
+- Tag chip: compact UI label that shows market tags in lists/details/review flows.
+- Taxonomy: the admin-managed set of tags, category pages, sections, and layout rules.
+
+Avoid confusing:
+
+- Tag is not a free-form user hashtag.
+- Category page is not necessarily a backend route hardcoded in React.
+- Section is not a market lifecycle status.
+- Featured is manual CMS curation, not the same as algorithmic recommendation.
+- Recommendation is automatic fallback content, not an endorsement unless later copy says so.
+
+## Top-Level `/markets` Page
+
+Search remains first.
+
+Default layout when nothing is pinned:
+
+1. Search bar.
+2. Up to 20 recommended active markets, using the current loose/random behavior or a backend-owned equivalent.
+3. Existing status navigation remains available: Active, Closed, Resolved, All.
+
+Layout when CMS pinning exists:
+
+1. Search bar.
+2. Compact recommendation panel, about 5 markets.
+3. Featured category/page cards.
+4. Featured market cards.
+5. Optional CMS sections if admins configure them later.
+
+The top-level page should not become blank just because CMS content is empty. Search and recommendation fallback keep the page useful from day one.
+
+## Secondary Category Pages
+
+A secondary category page should feel familiar relative to the top-level page.
+
+Each secondary page should support:
+
+- search bar at the top
+- search filtered by the page's category/tag by default
+- status tabs: Active, Closed, Resolved, All
+- recommendation/fallback markets for that tag if nothing is pinned
+- pinned featured markets
+- optional sections
+- tag chips on market cards/results
+
+Default layout when nothing is pinned:
+
+1. Category title/description.
+2. Search bar filtered to the category.
+3. Up to 20 random/recommended markets for that category.
+
+Layout when page is curated:
+
+1. Category title/description.
+2. Search bar filtered to the category.
+3. Compact recommendation panel, about 5 markets.
+4. Pinned featured markets.
+5. Pinned sections.
+6. Section-specific featured markets.
+
+## Sections
+
+Sections allow a category page to be further organized without creating too many pages.
+
+Examples:
+
+- Politics category with sections: Elections, Policy, Geopolitics.
+- Sports category with sections: NFL, NBA, Soccer.
+- AI category with sections: Models, Regulation, Companies.
+
+Initial behavior can support a default `All` section only. The schema should still leave room for named sections and section-specific featured markets.
+
+## Tag Assignment Flow
+
+### Moderator Create Flow
+
+Moderators should select tags from admin-managed options while creating a market.
+
+Rules:
+
+- moderators cannot create new tags
+- moderators can select one or more available tags
+- UI should support search/typeahead because tag lists can grow
+- default can be no tag only if policy allows it
+- future policy may require at least one tag before submission
+
+### Admin Review Flow
+
+Admin market review should show proposed tags.
+
+Admins should be able to:
+
+- approve tags as proposed
+- add/remove tags before approval if policy allows
+- see tag chips next to title/description/custom labels
+- treat inappropriate tags as a reason for rejection or adjustment
+
+### Published Market Display
+
+Published markets should show tag chips:
+
+- market detail page
+- `/markets` list/search results
+- category page results
+- admin review/governance tables
+- moderator profile market lists where useful
+
+## CMS And Admin Management
+
+Admins should own taxonomy management.
+
+Admin capabilities:
+
+- create tag
+- edit tag display name/slug/description/color/order
+- disable/archive tag
+- delete tag only when safe or after confirmation
+- create category page from a tag or tag query
+- pin/unpin featured markets
+- pin/unpin featured category pages
+- create/reorder sections
+- assign pinned markets to sections
+
+Deletion requires safety guardrails:
+
+- require confirmation
+- show count of markets using the tag
+- prefer archive/disable over destructive delete
+- prevent deletion if market references exist unless a migration/removal path is explicit
+
+## Persistence Shape Candidate
+
+Candidate tables:
+
+- `market_tags`: admin-owned tag definitions.
+- `market_tag_assignments`: many-to-many relation between markets and tags.
+- `market_discovery_pages`: top/secondary page definitions.
+- `market_discovery_sections`: sections within pages.
+- `market_discovery_pins`: pinned markets and pinned category pages, ordered by admin.
+
+Important design choice: use additive timestamped Go migrations under `backend/migration/migrations`, following the existing migration convention.
+
+## Search And Recommendation
+
+Search should remain familiar.
+
+Baseline behavior:
+
+- existing market search continues to support text query and lifecycle/public status
+- add optional tag/category filter
+- tag-filtered search should use the same text matching semantics as unfiltered search
+- category pages pass their tag filter automatically
+
+Recommendation fallback can start simple:
+
+- random active markets on top-level page
+- random active markets matching the category tag on secondary pages
+- limit 20 when no pinned content exists
+- limit 5 when pinned content exists
+
+This should be backend-owned enough that frontend does not invent recommendation rules independently.
+
+## Design-Agent Cross-Reference
+
+Evans/domain posture:
+
+- Treat taxonomy terms as ubiquitous language before schema work.
+- Separate tags, category pages, sections, featured markets, and recommendations because each has a different business meaning.
+- Do not let React route structure define the domain taxonomy.
+
+Fowler/evolutionary posture:
+
+- Start with tags and page read models before building a large CMS platform.
+- Prefer reversible admin curation tables and simple random recommendations before a real recommender system.
+- Keep a path from flat `/markets` to hierarchical pages without breaking the existing search/status tabs.
+
+Martin/clean-architecture posture:
+
+- Domain/use-case services own tag policy, page composition, and market filtering.
+- Handlers adapt HTTP to use cases; frontend consumes read models.
+- Database tables and React components are details around the taxonomy/navigation policy.
+
+## Acceptance Criteria
+
+Planning-level acceptance criteria:
+
+- Feature docs define tags, category pages, sections, featured markets, and recommendations distinctly.
+- Database migration plan is additive and timestamped.
+- Admin ownership of tag creation/deletion is explicit.
+- Moderator tag selection is constrained to existing admin-managed tags.
+- Admin review includes tag visibility and correction path.
+- Top-level and secondary pages preserve search-first behavior.
+- Empty CMS pages remain useful through recommendation fallback.
+- Pinned content changes page layout but does not remove search.
+- Tag chips appear in relevant market display surfaces.
+
+## Out Of Scope For First Pass
+
+- Machine-learning recommendation system.
+- User-personalized recommendations.
+- Public user-created tags.
+- Tag moderation by non-admins.
+- Full drag-and-drop CMS builder.
+- SEO/URL slug migration strategy beyond basic category page slugs.
+- Analytics-driven auto pinning.

--- a/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
@@ -1,0 +1,316 @@
+---
+title: Market Taxonomy And Hierarchical Navigation Design
+document_type: feature-design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-04T00:00:00Z
+updated_at_display: "Thursday, June 4, 2026"
+update_reason: "Define backend-first taxonomy, CMS, search, recommendation, and page-composition design before implementation."
+status: draft
+---
+
+# Market Taxonomy And Hierarchical Navigation Design
+
+## Design Position
+
+Market taxonomy is a discovery and curation capability. It is not just UI decoration.
+
+Tags affect market creation, admin review, search filtering, page composition, public navigation, and future CMS layout. The backend should own tag definitions, tag assignments, page definitions, section definitions, pinning, and recommendation/fallback policy. The frontend should render backend-owned read models and provide admin/moderator workflows.
+
+## Design Inputs
+
+Primary inputs:
+
+- [09-market-taxonomy-navigation.md](./09-market-taxonomy-navigation.md)
+- Canonical design plan: `/Users/patrick/Projects/spec-socialpredict-tasks/lib/design/design-plan.json`
+- Designer-agent postures from `/Users/patrick/Projects/spec-socialpredict-tasks/.codex/agents/`
+- Existing `/markets` search/status-tab behavior
+- Existing moderator create and admin review flows
+
+## Problem Framing
+
+The flat `/markets` page works as an early discovery surface because search is easy and status tabs are simple. It does not scale well once the platform has many markets across themes, leagues, geographies, communities, or product areas.
+
+The next design step is a taxonomy and page-composition model that preserves search-first discovery while allowing admins to curate market discovery pages.
+
+## Business Outcomes
+
+- Users can quickly search all markets from the top-level page.
+- Users can browse meaningful categories without knowing exact search terms.
+- Admins can curate featured markets and category pages.
+- Moderators can tag proposed markets using a controlled vocabulary.
+- Admins can review and correct tags before publication.
+- The platform can grow toward CMS-driven market pages without a large rewrite.
+
+## Boundary Alignment
+
+| Boundary | Responsibility |
+| --- | --- |
+| Prediction Market Context | Owns market-tag assignment policy and public market filtering by tags. |
+| CMS / Content Context | Owns discovery pages, sections, page copy, pinning, and layout order. |
+| Participant Account Context | Owns admin/moderator authority facts used by taxonomy management and tag assignment workflows. |
+| API And Auth Boundary | Owns admin taxonomy endpoints, moderator create/review payloads, public page/search endpoints, and OpenAPI schemas. |
+| Frontend Experience Context | Owns top-level and secondary page presentation, tag chips, admin taxonomy UI, and moderator tag selection UI. |
+| Repository And Migration Boundary | Owns additive tag/page/section/pin tables and timestamped Go migrations. |
+
+## Core Domain Model
+
+### Tag
+
+Admin-managed label attached to markets.
+
+Candidate fields:
+
+- `id`
+- `slug`
+- `display_name`
+- `description`
+- `color_key` or `style_key`
+- `sort_order`
+- `is_active`
+- `created_by`
+- `created_at`
+- `updated_at`
+
+Rules:
+
+- slugs are unique and stable enough for URLs
+- display names can change
+- inactive tags remain attached historically but cannot be newly selected unless admin reactivates them
+- hard delete should be restricted when assignments exist
+
+### Market Tag Assignment
+
+Many-to-many relation between market and tag.
+
+Candidate fields:
+
+- `market_id`
+- `tag_id`
+- `assigned_by`
+- `assigned_at`
+- `source`: moderator_proposed, admin_adjusted, migration, system
+
+Rules:
+
+- assignments should be unique per market/tag
+- admin can adjust during review
+- moderator can propose only active tags
+
+### Discovery Page
+
+CMS-managed navigation page.
+
+Candidate fields:
+
+- `id`
+- `slug`
+- `title`
+- `description`
+- `page_type`: top, category
+- `primary_tag_id` nullable
+- `query_mode`: tag, tag_set, custom, all
+- `is_published`
+- `sort_order`
+
+Rules:
+
+- top page can be represented as one special page or as a conventional read model for `/markets`
+- secondary pages usually have a primary tag
+- inactive/unpublished pages should not appear publicly
+
+### Section
+
+CMS-managed grouping within a discovery page.
+
+Candidate fields:
+
+- `id`
+- `page_id`
+- `slug`
+- `title`
+- `description`
+- `tag_filter_id` nullable
+- `sort_order`
+- `is_active`
+
+Rules:
+
+- every page has an implicit `All` section even if no explicit sections exist
+- sections can filter by tags or simply group pinned markets
+
+### Pin
+
+Manual CMS curation of a market or category page.
+
+Candidate fields:
+
+- `id`
+- `scope_type`: page, section
+- `scope_id`
+- `pin_type`: market, discovery_page
+- `market_id` nullable
+- `target_page_id` nullable
+- `sort_order`
+- `label` nullable
+- `created_by`
+- `created_at`
+
+Rules:
+
+- pinned markets must be visible/tradable or explicitly allowed by policy
+- pinned category pages must be published
+- pins are ordered manually
+- pins should degrade gracefully if a target market is cancelled/resolved/hidden
+
+## Page Composition Read Model
+
+The backend should expose a composed read model for discovery pages instead of making React assemble the taxonomy from many unrelated calls.
+
+Candidate response shape:
+
+```json
+{
+  "page": {
+    "slug": "markets",
+    "title": "Markets",
+    "description": "Browse and search markets"
+  },
+  "search": {
+    "defaultTagSlug": null,
+    "statusFilters": ["active", "closed", "resolved", "all"]
+  },
+  "recommendations": {
+    "mode": "random_active",
+    "limit": 5,
+    "markets": []
+  },
+  "featuredPages": [],
+  "featuredMarkets": [],
+  "sections": []
+}
+```
+
+Frontend pages should render this read model and call search endpoints with `tag` or `page` filters.
+
+## Search Design
+
+Search remains the primary entry point.
+
+Rules:
+
+- top-level search defaults to all public markets unless status tab narrows it
+- secondary page search defaults to that page's primary tag/category
+- users can still switch Active/Closed/Resolved/All within the scoped search
+- search results include tags as chips
+- empty query falls back to recommendation/page composition, not a failed search state
+
+## Recommendation Design
+
+Initial recommendation is intentionally simple.
+
+Recommended baseline:
+
+- random active markets
+- filtered by page tag on secondary pages
+- limit 20 when no pinned content exists
+- limit 5 when pinned content exists
+
+This is a fallback/recommendation seam, not a personalized recommendation platform. Keep it small and replaceable.
+
+## Moderator And Admin Workflows
+
+### Moderator Create
+
+The create-market use case should accept tag IDs/slugs as proposed market metadata.
+
+Backend rules:
+
+- validate tags exist and are active
+- persist assignments with source `moderator_proposed`
+- reject invalid tag IDs/slugs with a public validation reason
+
+### Admin Review
+
+Admin review should display proposed tags and allow correction.
+
+Backend rules:
+
+- admin can add/remove tags while proposal is pending
+- approved market carries final tag assignments into publication
+- tag changes should be auditable or reconstructable
+
+### Admin CMS
+
+Admin taxonomy management should be separate from ordinary market review.
+
+Admin can manage:
+
+- tags
+- discovery pages
+- sections
+- pins
+
+## Migration Design
+
+Use additive timestamped Go migrations under `backend/migration/migrations`.
+
+Candidate migration slices:
+
+1. Tag definitions and assignments.
+2. Market create/review/read payload support for tags.
+3. Discovery pages and sections.
+4. Pins and page composition read model.
+
+Avoid combining all tables and all UI behavior in one PR unless the migration is purely schema-only and low-risk.
+
+## Designer Lens Review
+
+Evans/domain lens:
+
+- The domain language must distinguish tag, category page, section, pin, featured market, and recommendation.
+- Taxonomy is shared language between moderators, admins, and market browsers.
+- CMS curation and market lifecycle are related but not the same bounded context.
+
+Fowler/evolutionary lens:
+
+- Keep the first implementation narrow: tags plus chips, then page composition, then CMS pinning.
+- Avoid committing to a recommendation platform; random active markets are a reversible seam.
+- Composed read models reduce frontend churn while preserving an evolutionary backend path.
+
+Martin/clean-architecture lens:
+
+- Tag validation and page composition are use cases, not React conditionals.
+- Database tables are details; use cases should expose simple request/response models.
+- Admin/moderator authority is an input to use cases, not a UI-only permission flag.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| CMS scope creep | Start with tags and simple page composition; defer full page builder. |
+| Tag deletion breaks history | Prefer archive/disable; restrict delete with references. |
+| Frontend invents taxonomy rules | Backend composed read model and API contracts. |
+| Search performance degrades | Add indexes on tag assignments, slug, lifecycle/status, and consider query plans before large datasets. |
+| Confusing page/category/tag terms | Maintain glossary and display language in docs/API. |
+| Migration ordering conflicts | Stack from #734 and use timestamped additive migrations later. |
+
+## Open Questions
+
+- Should tags be single-level only, or should parent/child tag hierarchy exist?
+- Should secondary category pages always map to one tag, or support tag queries?
+- Should moderators be required to select at least one tag?
+- Can admins add tags during approval that moderators did not propose?
+- Should tags have colors from a fixed style guide or arbitrary admin-selected colors?
+- Should public users ever see inactive tags on historical markets?
+- Should cancelled/yanked markets be excluded from pins automatically?
+- Should recommendation randomness be stable per day/session or fully random per request?
+
+## Design Exit Criteria
+
+- Tag, page, section, pin, and recommendation language is stable enough for API names.
+- Database migration slices are chosen.
+- Backend-first API contracts are drafted before frontend UI implementation.
+- Admin tag deletion policy is decided.
+- Empty-page fallback behavior is decided.
+- Category search semantics are decided.

--- a/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
@@ -110,14 +110,13 @@ Candidate fields:
 - `page_type`: top, category
 - `primary_tag_id` nullable
 - `query_mode`: tag, tag_set, custom, all
-- `is_published`
 - `sort_order`
 
 Rules:
 
 - top page can be represented as one special page or as a conventional read model for `/markets`
 - secondary pages usually have a primary tag
-- inactive/unpublished pages should not appear publicly
+- page edits publish immediately in the current CMS model
 
 ### Section
 

--- a/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/DESIGN.md
@@ -15,7 +15,7 @@ status: draft
 
 Market taxonomy is a discovery and curation capability. It is not just UI decoration.
 
-Tags affect market creation, admin review, search filtering, page composition, public navigation, and future CMS layout. The backend should own tag definitions, tag assignments, page definitions, section definitions, pinning, and recommendation/fallback policy. The frontend should render backend-owned read models and provide admin/moderator workflows.
+Tags affect market creation, admin review, search filtering, page composition, public navigation, and future CMS layout. The backend should own tag definitions, tag assignments, page definitions, pinning, and recommendation/fallback policy. The frontend should render backend-owned read models and provide admin/moderator workflows.
 
 ## Design Inputs
 
@@ -47,11 +47,11 @@ The next design step is a taxonomy and page-composition model that preserves sea
 | Boundary | Responsibility |
 | --- | --- |
 | Prediction Market Context | Owns market-tag assignment policy and public market filtering by tags. |
-| CMS / Content Context | Owns discovery pages, sections, page copy, pinning, and layout order. |
+| CMS / Content Context | Owns discovery pages, page copy, pinning, and layout order. |
 | Participant Account Context | Owns admin/moderator authority facts used by taxonomy management and tag assignment workflows. |
 | API And Auth Boundary | Owns admin taxonomy endpoints, moderator create/review payloads, public page/search endpoints, and OpenAPI schemas. |
 | Frontend Experience Context | Owns top-level and secondary page presentation, tag chips, admin taxonomy UI, and moderator tag selection UI. |
-| Repository And Migration Boundary | Owns additive tag/page/section/pin tables and timestamped Go migrations. |
+| Repository And Migration Boundary | Owns additive tag/page/pin tables and timestamped Go migrations. |
 
 ## Core Domain Model
 
@@ -118,26 +118,6 @@ Rules:
 - secondary pages usually have a primary tag
 - page edits publish immediately in the current CMS model
 
-### Section
-
-CMS-managed grouping within a discovery page.
-
-Candidate fields:
-
-- `id`
-- `page_id`
-- `slug`
-- `title`
-- `description`
-- `tag_filter_id` nullable
-- `sort_order`
-- `is_active`
-
-Rules:
-
-- every page has an implicit `All` section even if no explicit sections exist
-- sections can filter by tags or simply group pinned markets
-
 ### Pin
 
 Manual CMS curation of a market or category page.
@@ -145,7 +125,7 @@ Manual CMS curation of a market or category page.
 Candidate fields:
 
 - `id`
-- `scope_type`: page, section
+- `scope_type`: page
 - `scope_id`
 - `pin_type`: market, discovery_page
 - `market_id` nullable
@@ -185,8 +165,7 @@ Candidate response shape:
     "markets": []
   },
   "featuredPages": [],
-  "featuredMarkets": [],
-  "sections": []
+  "featuredMarkets": []
 }
 ```
 
@@ -247,7 +226,6 @@ Admin can manage:
 
 - tags
 - discovery pages
-- sections
 - pins
 
 ## Migration Design
@@ -258,7 +236,7 @@ Candidate migration slices:
 
 1. Tag definitions and assignments.
 2. Market create/review/read payload support for tags.
-3. Discovery pages and sections.
+3. Discovery pages .
 4. Pins and page composition read model.
 
 Avoid combining all tables and all UI behavior in one PR unless the migration is purely schema-only and low-risk.
@@ -267,7 +245,7 @@ Avoid combining all tables and all UI behavior in one PR unless the migration is
 
 Evans/domain lens:
 
-- The domain language must distinguish tag, category page, section, pin, featured market, and recommendation.
+- The domain language must distinguish tag, category page, pin, featured market, and recommendation.
 - Taxonomy is shared language between moderators, admins, and market browsers.
 - CMS curation and market lifecycle are related but not the same bounded context.
 
@@ -307,7 +285,7 @@ Martin/clean-architecture lens:
 
 ## Design Exit Criteria
 
-- Tag, page, section, pin, and recommendation language is stable enough for API names.
+- Tag, page, pin, and recommendation language is stable enough for API names.
 - Database migration slices are chosen.
 - Backend-first API contracts are drafted before frontend UI implementation.
 - Admin tag deletion policy is decided.

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -1,0 +1,178 @@
+---
+title: Market Taxonomy And Hierarchical Navigation Plan
+document_type: feature-plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-04T00:00:00Z
+updated_at_display: "Thursday, June 4, 2026"
+update_reason: "Create the implementation checklist for market tags, category pages, pinned content, and CMS-driven discovery."
+status: draft
+---
+
+# Market Taxonomy And Hierarchical Navigation Plan
+
+## Purpose
+
+This plan turns [09-market-taxonomy-navigation.md](./09-market-taxonomy-navigation.md) and [DESIGN.md](./DESIGN.md) into a backend-first implementation sequence.
+
+Agents implementing this feature should mark checklist items as they complete them and leave deferred work unchecked.
+
+## Planning Principles
+
+- Search stays first on top-level and secondary market pages.
+- Tags and CMS page composition are backend-owned policy/read models.
+- Admins manage tag vocabulary; moderators select from active tags.
+- Additive timestamped migrations come before UI dependencies.
+- Start with simple random active recommendations before a recommendation platform.
+- Keep pinned content manual and auditable.
+- Keep every PR independently reviewable.
+
+## 01. Feature Artifact And Design Alignment
+
+Checklist:
+
+- [x] Create `README/PRODUCTION-NOTES/FEATURES/09/`.
+- [x] Add feature overview.
+- [x] Add design artifact.
+- [x] Add implementation plan.
+- [x] Cross-reference canonical design plan and designer-agent postures.
+- [ ] Review final design with product/user-facing terminology before implementation.
+
+## 02. Tag Persistence And Domain Model
+
+Service ownership: prediction market context and repository/migration boundary.
+
+Checklist:
+
+- [ ] Add timestamped migration for `market_tags`.
+- [ ] Add timestamped migration for `market_tag_assignments`.
+- [ ] Add indexes for tag slug and market/tag assignment lookup.
+- [ ] Add domain models for tag and assignment.
+- [ ] Add repository mapping tests.
+- [ ] Add service policy for active tag validation.
+- [ ] Prefer archive/disable over destructive delete when assignments exist.
+
+## 03. Market Create And Admin Review Tag Flow
+
+Service ownership: market creation/review use cases and API boundary.
+
+Checklist:
+
+- [ ] Add tag IDs/slugs to create-market request.
+- [ ] Validate moderator-selected tags exist and are active.
+- [ ] Persist moderator-proposed tag assignments.
+- [ ] Include tag chips/data in admin market review payloads.
+- [ ] Allow admin adjustment of tags during proposal review if policy approves.
+- [ ] Include tags in published market payloads.
+- [ ] Update `backend/docs/openapi.yaml`.
+- [ ] Add handler/domain tests.
+- [ ] Run schemathesis/go-kin validation once OpenAPI is updated.
+
+## 04. Admin Tag Management
+
+Service ownership: CMS/content context plus API/auth boundary.
+
+Checklist:
+
+- [ ] Add admin list/create/update/archive tag APIs.
+- [ ] Add guarded delete or archive-only policy.
+- [ ] Show market count before destructive tag action.
+- [ ] Require confirmation for delete/archive.
+- [ ] Add admin dashboard tag management UI.
+- [ ] Add tests for admin-only access and validation.
+
+## 05. Search And Tag Filtering
+
+Service ownership: market search/read model.
+
+Checklist:
+
+- [ ] Add optional tag filter to public market search.
+- [ ] Add optional tag filter to status-based market listing.
+- [ ] Include tags in search/list result DTOs.
+- [ ] Keep Active/Closed/Resolved/All behavior compatible.
+- [ ] Add query/index tests for tag-filtered search.
+- [ ] Verify performance posture for many tags/markets.
+
+## 06. Discovery Pages And Sections
+
+Service ownership: CMS/content context and composed read model.
+
+Checklist:
+
+- [ ] Add migration for `market_discovery_pages`.
+- [ ] Add migration for `market_discovery_sections`.
+- [ ] Add domain/read models for top-level and secondary category pages.
+- [ ] Support implicit `All` section when no sections exist.
+- [ ] Add public page composition endpoint.
+- [ ] Add admin page/section management APIs.
+- [ ] Add tests for published/unpublished pages and section ordering.
+
+## 07. Pins And Featured Content
+
+Service ownership: CMS/content context.
+
+Checklist:
+
+- [ ] Add migration for `market_discovery_pins`.
+- [ ] Support pinned markets by page and section.
+- [ ] Support pinned secondary category pages on top-level page.
+- [ ] Add ordering controls.
+- [ ] Define behavior for cancelled/resolved/hidden pinned targets.
+- [ ] Add admin pin/unpin APIs.
+- [ ] Add tests for ordering and target validation.
+
+## 08. Recommendation Fallback
+
+Service ownership: market read model and page composition use case.
+
+Checklist:
+
+- [ ] Implement random active market fallback for top-level page.
+- [ ] Implement tag-scoped random active fallback for secondary pages.
+- [ ] Use limit 20 when no pinned content exists.
+- [ ] Use limit 5 when pinned content exists.
+- [ ] Decide stable daily/session randomization versus per-request randomization.
+- [ ] Add tests for empty CMS fallback behavior.
+
+## 09. Frontend Market Discovery UX
+
+Service ownership: frontend experience context.
+
+Checklist:
+
+- [ ] Update `/markets` to consume composed top-level page model.
+- [ ] Preserve search-first layout.
+- [ ] Render compact recommendations when pinned content exists.
+- [ ] Render featured category cards.
+- [ ] Render featured market cards.
+- [ ] Render tag chips in search/list cards.
+- [ ] Add secondary category page route/layout.
+- [ ] Scope secondary-page search to page tag/category by default.
+- [ ] Keep status tabs familiar across top-level and secondary pages.
+
+## 10. Moderator And Admin Frontend UX
+
+Service ownership: frontend moderator/admin workflows.
+
+Checklist:
+
+- [ ] Add tag selector to moderator create market form.
+- [ ] Use typeahead/search when tags exceed a small number.
+- [ ] Show selected tags before submit.
+- [ ] Show proposed tags in admin review table/details.
+- [ ] Allow admin correction if backend policy supports it.
+- [ ] Add tag chips on market detail page.
+- [ ] Add tag chips on profile/admin lifecycle tables where useful.
+
+## Exit Criteria
+
+- Tags are durable and admin-managed.
+- Moderators can only select active existing tags.
+- Admin review surfaces proposed tags.
+- Search can be filtered by tag/category.
+- Top-level `/markets` remains useful with or without CMS pinning.
+- Secondary category pages reuse familiar search/status behavior.
+- Pinned markets/pages and sections are CMS-managed and ordered.
+- Empty pages fall back to recommendation content.
+- OpenAPI and tests are updated before frontend depends on new endpoints.

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -5,7 +5,7 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-06-04T00:00:00Z
 updated_at_display: "Thursday, June 4, 2026"
-update_reason: "Track first implementation slice for market tag persistence, admin tag management, moderator selection, and tag display."
+update_reason: "Track implementation slices for tag persistence, market discovery layout persistence, and page-level CMS sections/pins."
 status: in-progress
 ---
 
@@ -64,7 +64,7 @@ Checklist:
 - [x] Include tag chips/data in admin market review payloads.
 - [ ] Allow admin adjustment of tags during proposal review if policy approves.
 - [x] Include tags in published market payloads.
-- [ ] Update `backend/docs/openapi.yaml`.
+- [x] Update `backend/docs/openapi.yaml`.
 - [x] Add handler/domain tests.
 - [ ] Run schemathesis/go-kin validation once OpenAPI is updated.
 
@@ -107,8 +107,9 @@ Checklist:
 - [ ] Support implicit `All` section when no sections exist.
 - [x] Add public page composition endpoint.
 - [x] Add admin page layout management API.
-- [ ] Add admin section management APIs.
-- [ ] Add tests for published/unpublished pages and section ordering.
+- [x] Add admin section management APIs.
+- [x] Add tests for page composition and section ordering.
+- [ ] Add tests for published/unpublished page visibility once secondary routes are public.
 
 ## 07. Pins And Featured Content
 
@@ -117,12 +118,13 @@ Service ownership: CMS/content context.
 Checklist:
 
 - [x] Add migration for `market_discovery_pins`.
-- [ ] Support pinned markets by page and section.
-- [ ] Support pinned secondary category pages on top-level page.
-- [ ] Add ordering controls.
+- [x] Support page-level pinned markets.
+- [ ] Support section-level pinned markets.
+- [x] Support pinned secondary category pages on top-level page.
+- [x] Add ordering controls.
 - [ ] Define behavior for cancelled/resolved/hidden pinned targets.
-- [ ] Add admin pin/unpin APIs.
-- [ ] Add tests for ordering and target validation.
+- [x] Add admin pin/unpin APIs.
+- [x] Add tests for ordering and target validation.
 
 ## 08. Recommendation Fallback
 
@@ -145,10 +147,10 @@ Checklist:
 
 - [x] Add admin CMS panel that distinguishes Home Page, Market Discovery Layout, and Social Share settings.
 - [x] Update `/markets` to consume composed top-level page model.
-- [ ] Preserve search-first layout.
-- [ ] Render compact recommendations when pinned content exists.
-- [ ] Render featured category cards.
-- [ ] Render featured market cards.
+- [x] Preserve search-first layout.
+- [x] Render compact recommendations when pinned content exists.
+- [x] Render featured category cards.
+- [x] Render featured market cards.
 - [x] Render tag chips in search/list cards.
 - [ ] Add secondary category page route/layout.
 - [ ] Scope secondary-page search to page tag/category by default.

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -5,7 +5,7 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-06-04T00:00:00Z
 updated_at_display: "Thursday, June 4, 2026"
-update_reason: "Track implementation slices for tag persistence, market discovery layout persistence, and page-level CMS sections/pins."
+update_reason: "Track implementation slices for tag persistence, market discovery layout persistence, page-level CMS sections/pins, secondary routes, and tag-scoped discovery."
 status: in-progress
 ---
 
@@ -87,11 +87,11 @@ Service ownership: market search/read model.
 
 Checklist:
 
-- [ ] Add optional tag filter to public market search.
-- [ ] Add optional tag filter to status-based market listing.
+- [x] Add optional tag filter to public market search.
+- [x] Add optional tag filter to status-based market listing.
 - [x] Include tags in search/list result DTOs.
-- [ ] Keep Active/Closed/Resolved/All behavior compatible.
-- [ ] Add query/index tests for tag-filtered search.
+- [x] Keep Active/Closed/Resolved/All behavior compatible.
+- [x] Add query/index tests for tag-filtered search.
 - [ ] Verify performance posture for many tags/markets.
 
 ## 06. Discovery Pages And Sections
@@ -152,9 +152,9 @@ Checklist:
 - [x] Render featured category cards.
 - [x] Render featured market cards.
 - [x] Render tag chips in search/list cards.
-- [ ] Add secondary category page route/layout.
-- [ ] Scope secondary-page search to page tag/category by default.
-- [ ] Keep status tabs familiar across top-level and secondary pages.
+- [x] Add secondary category page route/layout.
+- [x] Scope secondary-page search to page tag/category by default.
+- [x] Keep status tabs familiar across top-level and secondary pages.
 
 ## 10. Moderator And Admin Frontend UX
 

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -100,6 +100,7 @@ Service ownership: CMS/content context and composed read model.
 
 Checklist:
 
+- [x] Add admin CMS scaffold for TOP and SECONDARY market discovery layout options.
 - [ ] Add migration for `market_discovery_pages`.
 - [ ] Add migration for `market_discovery_sections`.
 - [ ] Add domain/read models for top-level and secondary category pages.
@@ -141,6 +142,7 @@ Service ownership: frontend experience context.
 
 Checklist:
 
+- [x] Add admin CMS panel that distinguishes Home Page, Market Discovery Layout, and Social Share settings.
 - [ ] Update `/markets` to consume composed top-level page model.
 - [ ] Preserve search-first layout.
 - [ ] Render compact recommendations when pinned content exists.

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -5,8 +5,8 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-06-04T00:00:00Z
 updated_at_display: "Thursday, June 4, 2026"
-update_reason: "Create the implementation checklist for market tags, category pages, pinned content, and CMS-driven discovery."
-status: draft
+update_reason: "Track first implementation slice for market tag persistence, admin tag management, moderator selection, and tag display."
+status: in-progress
 ---
 
 # Market Taxonomy And Hierarchical Navigation Plan
@@ -44,13 +44,13 @@ Service ownership: prediction market context and repository/migration boundary.
 
 Checklist:
 
-- [ ] Add timestamped migration for `market_tags`.
-- [ ] Add timestamped migration for `market_tag_assignments`.
-- [ ] Add indexes for tag slug and market/tag assignment lookup.
-- [ ] Add domain models for tag and assignment.
-- [ ] Add repository mapping tests.
-- [ ] Add service policy for active tag validation.
-- [ ] Prefer archive/disable over destructive delete when assignments exist.
+- [x] Add timestamped migration for `market_tags`.
+- [x] Add timestamped migration for `market_tag_assignments`.
+- [x] Add indexes for tag slug and market/tag assignment lookup.
+- [x] Add domain models for tag and assignment.
+- [x] Add repository mapping tests.
+- [x] Add service policy for active tag validation.
+- [x] Prefer archive/disable over destructive delete when assignments exist.
 
 ## 03. Market Create And Admin Review Tag Flow
 
@@ -58,14 +58,14 @@ Service ownership: market creation/review use cases and API boundary.
 
 Checklist:
 
-- [ ] Add tag IDs/slugs to create-market request.
-- [ ] Validate moderator-selected tags exist and are active.
-- [ ] Persist moderator-proposed tag assignments.
-- [ ] Include tag chips/data in admin market review payloads.
+- [x] Add tag IDs/slugs to create-market request.
+- [x] Validate moderator-selected tags exist and are active.
+- [x] Persist moderator-proposed tag assignments.
+- [x] Include tag chips/data in admin market review payloads.
 - [ ] Allow admin adjustment of tags during proposal review if policy approves.
-- [ ] Include tags in published market payloads.
+- [x] Include tags in published market payloads.
 - [ ] Update `backend/docs/openapi.yaml`.
-- [ ] Add handler/domain tests.
+- [x] Add handler/domain tests.
 - [ ] Run schemathesis/go-kin validation once OpenAPI is updated.
 
 ## 04. Admin Tag Management
@@ -74,12 +74,12 @@ Service ownership: CMS/content context plus API/auth boundary.
 
 Checklist:
 
-- [ ] Add admin list/create/update/archive tag APIs.
-- [ ] Add guarded delete or archive-only policy.
+- [x] Add admin list/create/update/archive tag APIs.
+- [x] Add guarded delete or archive-only policy.
 - [ ] Show market count before destructive tag action.
-- [ ] Require confirmation for delete/archive.
-- [ ] Add admin dashboard tag management UI.
-- [ ] Add tests for admin-only access and validation.
+- [x] Require confirmation for delete/archive.
+- [x] Add admin dashboard tag management UI.
+- [x] Add tests for admin-only access and validation.
 
 ## 05. Search And Tag Filtering
 
@@ -89,7 +89,7 @@ Checklist:
 
 - [ ] Add optional tag filter to public market search.
 - [ ] Add optional tag filter to status-based market listing.
-- [ ] Include tags in search/list result DTOs.
+- [x] Include tags in search/list result DTOs.
 - [ ] Keep Active/Closed/Resolved/All behavior compatible.
 - [ ] Add query/index tests for tag-filtered search.
 - [ ] Verify performance posture for many tags/markets.
@@ -146,7 +146,7 @@ Checklist:
 - [ ] Render compact recommendations when pinned content exists.
 - [ ] Render featured category cards.
 - [ ] Render featured market cards.
-- [ ] Render tag chips in search/list cards.
+- [x] Render tag chips in search/list cards.
 - [ ] Add secondary category page route/layout.
 - [ ] Scope secondary-page search to page tag/category by default.
 - [ ] Keep status tabs familiar across top-level and secondary pages.
@@ -157,13 +157,13 @@ Service ownership: frontend moderator/admin workflows.
 
 Checklist:
 
-- [ ] Add tag selector to moderator create market form.
+- [x] Add tag selector to moderator create market form.
 - [ ] Use typeahead/search when tags exceed a small number.
-- [ ] Show selected tags before submit.
-- [ ] Show proposed tags in admin review table/details.
+- [x] Show selected tags before submit.
+- [x] Show proposed tags in admin review table/details.
 - [ ] Allow admin correction if backend policy supports it.
-- [ ] Add tag chips on market detail page.
-- [ ] Add tag chips on profile/admin lifecycle tables where useful.
+- [x] Add tag chips on market detail page.
+- [x] Add tag chips on profile/admin lifecycle tables where useful.
 
 ## Exit Criteria
 

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -5,7 +5,7 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-06-04T00:00:00Z
 updated_at_display: "Thursday, June 4, 2026"
-update_reason: "Track implementation slices for tag persistence, market discovery layout persistence, page-level CMS sections/pins, secondary routes, and tag-scoped discovery."
+update_reason: "Track implementation slices for tag persistence, market discovery layout persistence, page-level CMS pins, secondary routes, and tag-scoped discovery."
 status: in-progress
 ---
 
@@ -94,7 +94,7 @@ Checklist:
 - [x] Add query/index tests for tag-filtered search.
 - [ ] Verify performance posture for many tags/markets.
 
-## 06. Discovery Pages And Sections
+## 06. Discovery Pages
 
 Service ownership: CMS/content context and composed read model.
 
@@ -102,13 +102,13 @@ Checklist:
 
 - [x] Add admin CMS scaffold for TOP and SECONDARY market discovery layout options.
 - [x] Add migration for `market_discovery_pages`.
-- [x] Add migration for `market_discovery_sections`.
+- [x] Remove unused `market_discovery_sections` scaffold.
 - [x] Add domain/read models for top-level and secondary category pages.
-- [ ] Support implicit `All` section when no sections exist.
+- [x] Keep implicit All behavior through normal page search/status tabs.
 - [x] Add public page composition endpoint.
 - [x] Add admin page layout management API.
-- [x] Add admin section management APIs.
-- [x] Add tests for page composition and section ordering.
+- [x] Remove unused admin section management APIs.
+- [x] Add tests for page composition ordering.
 
 ## 07. Pins And Featured Content
 
@@ -118,7 +118,6 @@ Checklist:
 
 - [x] Add migration for `market_discovery_pins`.
 - [x] Support page-level pinned markets.
-- [ ] Support section-level pinned markets.
 - [x] Support pinned secondary category pages on top-level page.
 - [x] Add ordering controls.
 - [ ] Define behavior for cancelled/resolved/hidden pinned targets.
@@ -177,6 +176,6 @@ Checklist:
 - Search can be filtered by tag/category.
 - Top-level `/markets` remains useful with or without CMS pinning.
 - Secondary category pages reuse familiar search/status behavior.
-- Pinned markets/pages and sections are CMS-managed and ordered.
+- Pinned markets/pages  are CMS-managed and ordered.
 - Empty pages fall back to recommendation content.
 - OpenAPI and tests are updated before frontend depends on new endpoints.

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -101,12 +101,13 @@ Service ownership: CMS/content context and composed read model.
 Checklist:
 
 - [x] Add admin CMS scaffold for TOP and SECONDARY market discovery layout options.
-- [ ] Add migration for `market_discovery_pages`.
-- [ ] Add migration for `market_discovery_sections`.
-- [ ] Add domain/read models for top-level and secondary category pages.
+- [x] Add migration for `market_discovery_pages`.
+- [x] Add migration for `market_discovery_sections`.
+- [x] Add domain/read models for top-level and secondary category pages.
 - [ ] Support implicit `All` section when no sections exist.
-- [ ] Add public page composition endpoint.
-- [ ] Add admin page/section management APIs.
+- [x] Add public page composition endpoint.
+- [x] Add admin page layout management API.
+- [ ] Add admin section management APIs.
 - [ ] Add tests for published/unpublished pages and section ordering.
 
 ## 07. Pins And Featured Content
@@ -115,7 +116,7 @@ Service ownership: CMS/content context.
 
 Checklist:
 
-- [ ] Add migration for `market_discovery_pins`.
+- [x] Add migration for `market_discovery_pins`.
 - [ ] Support pinned markets by page and section.
 - [ ] Support pinned secondary category pages on top-level page.
 - [ ] Add ordering controls.
@@ -143,7 +144,7 @@ Service ownership: frontend experience context.
 Checklist:
 
 - [x] Add admin CMS panel that distinguishes Home Page, Market Discovery Layout, and Social Share settings.
-- [ ] Update `/markets` to consume composed top-level page model.
+- [x] Update `/markets` to consume composed top-level page model.
 - [ ] Preserve search-first layout.
 - [ ] Render compact recommendations when pinned content exists.
 - [ ] Render featured category cards.

--- a/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/09/PLAN.md
@@ -109,7 +109,6 @@ Checklist:
 - [x] Add admin page layout management API.
 - [x] Add admin section management APIs.
 - [x] Add tests for page composition and section ordering.
-- [ ] Add tests for published/unpublished page visibility once secondary routes are public.
 
 ## 07. Pins And Featured Content
 

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -81,6 +81,8 @@ Current feature specs:
 4. **Load Testing And Release Dossier Evidence** - [`FEATURES/04/04-load-testing.md`](./FEATURES/04/04-load-testing.md), [`FEATURES/04/DESIGN.md`](./FEATURES/04/DESIGN.md), [`FEATURES/04/PLAN.md`](./FEATURES/04/PLAN.md)
 5. **Runtime Rate Limit Policy** - [`FEATURES/05/05-runtime-rate-limit-policy.md`](./FEATURES/05/05-runtime-rate-limit-policy.md), [`FEATURES/05/DESIGN.md`](./FEATURES/05/DESIGN.md), [`FEATURES/05/PLAN.md`](./FEATURES/05/PLAN.md)
 6. **Temporary Load-Test Droplets** - [`FEATURES/06/06-temporary-loadtest-droplets.md`](./FEATURES/06/06-temporary-loadtest-droplets.md), [`FEATURES/06/DESIGN.md`](./FEATURES/06/DESIGN.md), [`FEATURES/06/PLAN.md`](./FEATURES/06/PLAN.md)
+7. **Market Stewardship** - [`FEATURES/07/07-market-stewardship.md`](./FEATURES/07/07-market-stewardship.md), [`FEATURES/07/DESIGN.md`](./FEATURES/07/DESIGN.md), [`FEATURES/07/PLAN.md`](./FEATURES/07/PLAN.md)
+9. **Market Taxonomy And Hierarchical Navigation** - [`FEATURES/09/09-market-taxonomy-navigation.md`](./FEATURES/09/09-market-taxonomy-navigation.md), [`FEATURES/09/DESIGN.md`](./FEATURES/09/DESIGN.md), [`FEATURES/09/PLAN.md`](./FEATURES/09/PLAN.md)
 
 ## Implementation Priority
 

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -230,7 +230,6 @@ x-route-family-migration-matrix:
         - /v0/admin/content/home
         - /v0/content/market-discovery/{slug}
         - /v0/admin/content/market-discovery/{slug}
-        - /v0/admin/content/market-discovery/{slug}/sections
         - /v0/admin/content/market-discovery/{slug}/pins
         - /v0/content/social-share
         - /v0/content/social-share/image
@@ -3234,59 +3233,6 @@ paths:
                 $ref: '#/components/schemas/ReasonResponse'
 
 
-  /v0/admin/content/market-discovery/{slug}/sections:
-    put:
-      tags: [Content]
-      operationId: replaceMarketDiscoverySections
-      summary: Replace market discovery page sections
-      description: Replaces ordered CMS section cards for a TOP or SECONDARY market discovery page.
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: path
-          name: slug
-          required: true
-          schema:
-            type: string
-            enum: [markets, topic-template]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MarketDiscoverySectionsUpdateRequest'
-      responses:
-        '200':
-          description: Market discovery sections updated successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
-        '400':
-          description: Invalid request body or section validation failure.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReasonResponse'
-        '401':
-          description: Authentication failed or token invalid.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReasonResponse'
-        '403':
-          description: Admin privileges required or password change is still required.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReasonResponse'
-        '429':
-          description: Rate limit exceeded by shared security middleware.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReasonResponse'
-
   /v0/admin/content/market-discovery/{slug}/pins:
     put:
       tags: [Content]
@@ -5114,8 +5060,6 @@ components:
           type: boolean
         featuredMarketsEnabled:
           type: boolean
-        sectionsEnabled:
-          type: boolean
         defaultRecommendationLimit:
           type: integer
           minimum: 1
@@ -5133,36 +5077,10 @@ components:
         updatedAt:
           type: string
           format: date-time
-        sections:
-          type: array
-          items:
-            $ref: '#/components/schemas/MarketDiscoverySection'
         pins:
           type: array
           items:
             $ref: '#/components/schemas/MarketDiscoveryPin'
-
-    MarketDiscoverySection:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        slug:
-          type: string
-          maxLength: 96
-        title:
-          type: string
-          maxLength: 160
-        description:
-          type: string
-          maxLength: 500
-        tagFilterSlug:
-          type: string
-        sortOrder:
-          type: integer
-        isActive:
-          type: boolean
 
     MarketDiscoveryPin:
       type: object
@@ -5206,8 +5124,6 @@ components:
           type: boolean
         featuredMarketsEnabled:
           type: boolean
-        sectionsEnabled:
-          type: boolean
         defaultRecommendationLimit:
           type: integer
           minimum: 1
@@ -5219,16 +5135,6 @@ components:
         version:
           type: integer
           format: int64
-
-    MarketDiscoverySectionsUpdateRequest:
-      type: object
-      properties:
-        sections:
-          type: array
-          maxItems: 24
-          items:
-            $ref: '#/components/schemas/MarketDiscoverySection'
-      required: [sections]
 
     MarketDiscoveryPinsUpdateRequest:
       type: object

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -230,6 +230,8 @@ x-route-family-migration-matrix:
         - /v0/admin/content/home
         - /v0/content/market-discovery/{slug}
         - /v0/admin/content/market-discovery/{slug}
+        - /v0/admin/content/market-discovery/{slug}/sections
+        - /v0/admin/content/market-discovery/{slug}/pins
         - /v0/content/social-share
         - /v0/content/social-share/image
         - /v0/admin/content/social-share
@@ -3219,6 +3221,113 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReasonResponse'
 
+
+  /v0/admin/content/market-discovery/{slug}/sections:
+    put:
+      tags: [Content]
+      operationId: replaceMarketDiscoverySections
+      summary: Replace market discovery page sections
+      description: Replaces ordered CMS section cards for a TOP or SECONDARY market discovery page.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            enum: [markets, topic-template]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketDiscoverySectionsUpdateRequest'
+      responses:
+        '200':
+          description: Market discovery sections updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
+        '400':
+          description: Invalid request body or section validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required or password change is still required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/content/market-discovery/{slug}/pins:
+    put:
+      tags: [Content]
+      operationId: replaceMarketDiscoveryPins
+      summary: Replace market discovery page pins
+      description: Replaces ordered page-level featured market and featured topic pins for a market discovery page.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            enum: [markets, topic-template]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketDiscoveryPinsUpdateRequest'
+      responses:
+        '200':
+          description: Market discovery pins updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
+        '400':
+          description: Invalid request body or pin validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required or password change is still required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
   /v0/content/social-share:
     get:
       tags: [Content]
@@ -5015,6 +5124,57 @@ components:
         updatedAt:
           type: string
           format: date-time
+        sections:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketDiscoverySection'
+        pins:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketDiscoveryPin'
+
+    MarketDiscoverySection:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        slug:
+          type: string
+          maxLength: 96
+        title:
+          type: string
+          maxLength: 160
+        description:
+          type: string
+          maxLength: 500
+        tagFilterSlug:
+          type: string
+        sortOrder:
+          type: integer
+        isActive:
+          type: boolean
+
+    MarketDiscoveryPin:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        pinType:
+          type: string
+          enum: [market, discovery_page]
+        marketId:
+          type: integer
+          format: int64
+        targetPageSlug:
+          type: string
+          maxLength: 96
+        label:
+          type: string
+          maxLength: 160
+        sortOrder:
+          type: integer
 
     MarketDiscoveryPageUpdateRequest:
       type: object
@@ -5052,6 +5212,26 @@ components:
         version:
           type: integer
           format: int64
+
+    MarketDiscoverySectionsUpdateRequest:
+      type: object
+      properties:
+        sections:
+          type: array
+          maxItems: 24
+          items:
+            $ref: '#/components/schemas/MarketDiscoverySection'
+      required: [sections]
+
+    MarketDiscoveryPinsUpdateRequest:
+      type: object
+      properties:
+        pins:
+          type: array
+          maxItems: 48
+          items:
+            $ref: '#/components/schemas/MarketDiscoveryPin'
+      required: [pins]
 
     SocialShareSettings:
       type: object

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -223,6 +223,7 @@ x-route-family-migration-matrix:
         - /v0/admin/markets/{id}/approve
         - /v0/admin/markets/{id}/reject
         - /v0/admin/markets/{id}/steward
+        - /v0/admin/markets/{id}/tags
         - /v0/admin/market-tags
         - /v0/admin/market-tags/{slug}
         - /v0/content/home
@@ -2673,6 +2674,81 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReasonResponse'
 
+  /v0/admin/markets/{id}/tags:
+    patch:
+      tags: [Markets]
+      operationId: updateAdminMarketTags
+      summary: Update market tag assignments
+      description: >
+        Admin-only endpoint that rewrites active tag assignments for proposed
+        or published markets. This adjusts market taxonomy without changing the
+        tag vocabulary itself.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminUpdateMarketTagsRequest'
+      responses:
+        '200':
+          description: Market tag assignments updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketReviewEnvelopeResponse'
+        '400':
+          description: Invalid market ID, malformed request, unknown tag, inactive tag, or too many tags.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '404':
+          description: Market was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '409':
+          description: Market is not proposed or published.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag assignment update failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
   /v0/admin/market-tags:
     get:
       tags: [Markets]
@@ -4391,6 +4467,18 @@ components:
           type: string
           minLength: 1
           description: Admin-visible audit reason for stewardship reassignment.
+
+    AdminUpdateMarketTagsRequest:
+      type: object
+      required: [tagSlugs]
+      properties:
+        tagSlugs:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+            pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+          description: Active market tag slugs to assign; an empty list removes all tag assignments.
 
     MarketReviewResponse:
       type: object

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -228,6 +228,8 @@ x-route-family-migration-matrix:
         - /v0/admin/market-tags/{slug}
         - /v0/content/home
         - /v0/admin/content/home
+        - /v0/content/market-discovery/{slug}
+        - /v0/admin/content/market-discovery/{slug}
         - /v0/content/social-share
         - /v0/content/social-share/image
         - /v0/admin/content/social-share
@@ -3138,6 +3140,85 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReasonResponse'
 
+  /v0/content/market-discovery/{slug}:
+    get:
+      tags: [Content]
+      operationId: getMarketDiscoveryPage
+      summary: Get public market discovery page layout
+      description: Retrieves CMS-configured TOP or SECONDARY market discovery layout settings.
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            enum: [markets, topic-template]
+      responses:
+        '200':
+          description: Market discovery page layout returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
+        '400':
+          description: Invalid page slug.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/content/market-discovery/{slug}:
+    put:
+      tags: [Content]
+      operationId: updateMarketDiscoveryPage
+      summary: Update market discovery page layout
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            enum: [markets, topic-template]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketDiscoveryPageUpdateRequest'
+      responses:
+        '200':
+          description: Market discovery page layout updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketDiscoveryPageEnvelopeResponse'
+        '400':
+          description: Invalid request body or update failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required or password change is still required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
   /v0/content/social-share:
     get:
       tags: [Content]
@@ -3589,6 +3670,16 @@ components:
           enum: [true]
         result:
           $ref: '#/components/schemas/HomeContent'
+      required: [ok, result]
+
+    MarketDiscoveryPageEnvelopeResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        result:
+          $ref: '#/components/schemas/MarketDiscoveryPage'
       required: [ok, result]
 
     SocialShareSettingsEnvelopeResponse:
@@ -4875,6 +4966,89 @@ components:
           type: string
         html:
           type: string
+        version:
+          type: integer
+          format: int64
+
+    MarketDiscoveryPage:
+      type: object
+      properties:
+        slug:
+          type: string
+          enum: [markets, topic-template]
+        title:
+          type: string
+          maxLength: 160
+        description:
+          type: string
+          maxLength: 500
+        pageType:
+          type: string
+          enum: [top, secondary]
+        primaryTagSlug:
+          type: string
+        searchScope:
+          type: string
+          enum: [all, tag]
+        featuredTopicsEnabled:
+          type: boolean
+        featuredMarketsEnabled:
+          type: boolean
+        sectionsEnabled:
+          type: boolean
+        defaultRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        curatedRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        recommendationLimit:
+          type: integer
+          description: Effective fallback market list size for the current layout.
+        isPublished:
+          type: boolean
+        version:
+          type: integer
+          format: int64
+        updatedAt:
+          type: string
+          format: date-time
+
+    MarketDiscoveryPageUpdateRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          maxLength: 160
+        description:
+          type: string
+          maxLength: 500
+        pageType:
+          type: string
+          enum: [top, secondary]
+        primaryTagSlug:
+          type: string
+        searchScope:
+          type: string
+          enum: [all, tag]
+        featuredTopicsEnabled:
+          type: boolean
+        featuredMarketsEnabled:
+          type: boolean
+        sectionsEnabled:
+          type: boolean
+        defaultRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        curatedRecommendationLimit:
+          type: integer
+          minimum: 1
+          maximum: 50
+        isPublished:
+          type: boolean
         version:
           type: integer
           format: int64

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -507,6 +507,12 @@ paths:
           schema:
             type: string
         - in: query
+          name: tagSlug
+          required: false
+          description: Only include markets assigned to the given market tag slug.
+          schema:
+            type: string
+        - in: query
           name: limit
           required: false
           description: Maximum number of markets to return.
@@ -666,6 +672,12 @@ paths:
           schema:
             type: string
             enum: [active, closed, resolved, all]
+        - in: query
+          name: tagSlug
+          required: false
+          description: Only search markets assigned to the given market tag slug.
+          schema:
+            type: string
         - in: query
           name: limit
           required: false
@@ -3152,9 +3164,9 @@ paths:
         - in: path
           name: slug
           required: true
+          description: "`markets` for the TOP page, `topic-template` for the default secondary layout, or any topic/tag slug for a secondary page."
           schema:
             type: string
-            enum: [markets, topic-template]
       responses:
         '200':
           description: Market discovery page layout returned successfully.
@@ -5084,7 +5096,6 @@ components:
       properties:
         slug:
           type: string
-          enum: [markets, topic-template]
         title:
           type: string
           maxLength: 160

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -2232,6 +2232,11 @@ paths:
           schema:
             type: string
             enum: [ADMIN, REGULAR, MODERATOR]
+        - in: query
+          name: query
+          schema:
+            type: string
+          description: Optional case-insensitive search across username, display name, and email.
       responses:
         '200':
           description: Admin user queue returned.

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -5127,8 +5127,6 @@ components:
         recommendationLimit:
           type: integer
           description: Effective fallback market list size for the current layout.
-        isPublished:
-          type: boolean
         version:
           type: integer
           format: int64
@@ -5218,8 +5216,6 @@ components:
           type: integer
           minimum: 1
           maximum: 50
-        isPublished:
-          type: boolean
         version:
           type: integer
           format: int64

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -153,6 +153,7 @@ x-route-family-migration-matrix:
         - /v0/markets/{id}/resolve
         - /v0/markets/{id}/leaderboard
         - /v0/markets/{id}/projection
+        - /v0/market-tags
         - /v0/marketprojection/{marketId}/{amount}/{outcome}
         - /v0/marketprojection/{marketId}/{amount}/{outcome}/
       success_contract: mixed raw JSON DTO, no-content action, and selected envelope results
@@ -222,6 +223,8 @@ x-route-family-migration-matrix:
         - /v0/admin/markets/{id}/approve
         - /v0/admin/markets/{id}/reject
         - /v0/admin/markets/{id}/steward
+        - /v0/admin/market-tags
+        - /v0/admin/market-tags/{slug}
         - /v0/content/home
         - /v0/admin/content/home
         - /v0/content/social-share
@@ -594,6 +597,32 @@ paths:
                 $ref: '#/components/schemas/ReasonResponse'
         '500':
           description: Unexpected server error during market creation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/market-tags:
+    get:
+      tags: [Markets]
+      operationId: listMarketTags
+      summary: List active market tags
+      description: Returns active admin-managed market taxonomy tags available for moderator market creation and public display.
+      responses:
+        '200':
+          description: Active market tags returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagsEnvelopeResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected server error while listing tags.
           content:
             application/json:
               schema:
@@ -2644,6 +2673,164 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReasonResponse'
 
+  /v0/admin/market-tags:
+    get:
+      tags: [Markets]
+      operationId: listAdminMarketTags
+      summary: List admin market tags
+      description: Admin-only endpoint for listing active and inactive market taxonomy tags.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: includeInactive
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Market tags returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagsEnvelopeResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag listing failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+    post:
+      tags: [Markets]
+      operationId: createAdminMarketTag
+      summary: Create market tag
+      description: Admin-only endpoint for creating a market taxonomy tag.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminMarketTagRequest'
+      responses:
+        '201':
+          description: Market tag created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagEnvelopeResponse'
+        '400':
+          description: Invalid tag fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag creation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
+  /v0/admin/market-tags/{slug}:
+    patch:
+      tags: [Markets]
+      operationId: updateAdminMarketTag
+      summary: Update or archive market tag
+      description: >
+        Admin-only endpoint for updating tag metadata or archiving/reactivating
+        a tag. Deactivation requires `confirmDeactivate: true`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminMarketTagRequest'
+      responses:
+        '200':
+          description: Market tag updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketTagEnvelopeResponse'
+        '400':
+          description: Invalid tag fields or missing deactivation confirmation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '401':
+          description: Authentication failed or token invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '403':
+          description: Admin privileges required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '429':
+          description: Rate limit exceeded by shared security middleware.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+        '500':
+          description: Unexpected tag update failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReasonResponse'
+
   /v0/portfolio/{username}:
     get:
       tags: [Users]
@@ -3493,6 +3680,90 @@ components:
         noLabel:
           type: string
           maxLength: 20
+        tagSlugs:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+            pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+
+    AdminMarketTagRequest:
+      type: object
+      properties:
+        slug:
+          type: string
+          maxLength: 64
+          pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+        displayName:
+          type: string
+          maxLength: 120
+        description:
+          type: string
+          maxLength: 500
+        colorKey:
+          type: string
+          maxLength: 40
+          pattern: '^[a-z0-9_-]*$'
+        sortOrder:
+          type: integer
+        isActive:
+          type: boolean
+        confirmDeactivate:
+          type: boolean
+          description: Required as true when setting `isActive` to false.
+
+    MarketTagResponse:
+      type: object
+      required: [id, slug, displayName, sortOrder, isActive]
+      properties:
+        id:
+          type: integer
+          format: int64
+        slug:
+          type: string
+        displayName:
+          type: string
+        description:
+          type: string
+        colorKey:
+          type: string
+        sortOrder:
+          type: integer
+        isActive:
+          type: boolean
+        createdBy:
+          type: string
+
+    MarketTagsResponse:
+      type: object
+      required: [tags, total]
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
+        total:
+          type: integer
+
+    MarketTagsEnvelopeResponse:
+      type: object
+      required: [ok, result]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        result:
+          $ref: '#/components/schemas/MarketTagsResponse'
+
+    MarketTagEnvelopeResponse:
+      type: object
+      required: [ok, result]
+      properties:
+        ok:
+          type: boolean
+          enum: [true]
+        result:
+          $ref: '#/components/schemas/MarketTagResponse'
 
     MarketResponse:
       type: object
@@ -3549,6 +3820,10 @@ components:
         updatedAt:
           type: string
           format: date-time
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
 
     CreatorResponse:
       type: object
@@ -3647,6 +3922,10 @@ components:
           type: string
         noLabel:
           type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
 
     ProbabilityChange:
       type: object
@@ -4164,6 +4443,10 @@ components:
         resolutionDateTime:
           type: string
           format: date-time
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketTagResponse'
 
     MarketLifecycleListResponse:
       type: object

--- a/backend/handlers/admin/market_review.go
+++ b/backend/handlers/admin/market_review.go
@@ -31,6 +31,10 @@ type marketStewardReassigner interface {
 	ReassignMarketSteward(ctx context.Context, marketID int64, newStewardUsername string, actorUsername string, reason string) (*dmarkets.Market, error)
 }
 
+type marketTagAdjuster interface {
+	UpdateMarketTags(ctx context.Context, marketID int64, tagSlugs []string, actorUsername string) (*dmarkets.Market, error)
+}
+
 type approveMarketRequest struct {
 	Confirm bool `json:"confirm"`
 }
@@ -42,6 +46,10 @@ type rejectMarketRequest struct {
 type reassignMarketStewardRequest struct {
 	StewardUsername string `json:"stewardUsername"`
 	Reason          string `json:"reason"`
+}
+
+type updateMarketTagsRequest struct {
+	TagSlugs []string `json:"tagSlugs"`
 }
 
 type marketReviewResponse struct {
@@ -208,6 +216,39 @@ func ReassignMarketStewardHandler(svc marketStewardReassigner, auth authsvc.Auth
 		}
 
 		market, err := svc.ReassignMarketSteward(r.Context(), marketID, req.StewardUsername, admin.Username, req.Reason)
+		if err != nil {
+			writeMarketReviewError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, marketReviewResponseFromMarket(market))
+	}
+}
+
+func UpdateMarketTagsHandler(svc marketTagAdjuster, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		admin, ok := requireAdminForMarketReview(w, r, auth)
+		if !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		marketID, ok := marketIDFromRequest(w, r)
+		if !ok {
+			return
+		}
+		var req updateMarketTagsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+			return
+		}
+
+		market, err := svc.UpdateMarketTags(r.Context(), marketID, req.TagSlugs, admin.Username)
 		if err != nil {
 			writeMarketReviewError(w, err)
 			return

--- a/backend/handlers/admin/market_review.go
+++ b/backend/handlers/admin/market_review.go
@@ -61,6 +61,7 @@ type marketReviewResponse struct {
 	RejectionReason    string                           `json:"rejectionReason,omitempty"`
 	ProposalCost       int64                            `json:"proposalCost,omitempty"`
 	StewardshipAudits  []marketStewardshipAuditResponse `json:"stewardshipAudits,omitempty"`
+	Tags               []marketTagResponse              `json:"tags,omitempty"`
 	CreatedAt          time.Time                        `json:"createdAt,omitempty"`
 	UpdatedAt          time.Time                        `json:"updatedAt,omitempty"`
 	ResolutionDateTime time.Time                        `json:"resolutionDateTime,omitempty"`
@@ -275,6 +276,7 @@ func marketReviewResponseFromMarket(market *dmarkets.Market) marketReviewRespons
 		RejectionReason:    market.RejectionReason,
 		ProposalCost:       market.ProposalCost,
 		StewardshipAudits:  marketStewardshipAuditResponsesFromRecords(market.StewardshipAudits),
+		Tags:               marketTagResponses(market.Tags),
 		CreatedAt:          market.CreatedAt,
 		UpdatedAt:          market.UpdatedAt,
 		ResolutionDateTime: market.ResolutionDateTime,

--- a/backend/handlers/admin/market_review_test.go
+++ b/backend/handlers/admin/market_review_test.go
@@ -22,6 +22,7 @@ type marketReviewServiceMock struct {
 	rejectFn   func(context.Context, int64, string, string) (*dmarkets.Market, error)
 	listFn     func(context.Context, dmarkets.ListFilters) ([]*dmarkets.Market, error)
 	reassignFn func(context.Context, int64, string, string, string) (*dmarkets.Market, error)
+	tagsFn     func(context.Context, int64, []string, string) (*dmarkets.Market, error)
 }
 
 func (m marketReviewServiceMock) ApproveProposedMarket(ctx context.Context, marketID int64, actorUsername string, confirmed bool) (*dmarkets.Market, error) {
@@ -38,6 +39,10 @@ func (m marketReviewServiceMock) ListLifecycleMarkets(ctx context.Context, filte
 
 func (m marketReviewServiceMock) ReassignMarketSteward(ctx context.Context, marketID int64, newStewardUsername string, actorUsername string, reason string) (*dmarkets.Market, error) {
 	return m.reassignFn(ctx, marketID, newStewardUsername, actorUsername, reason)
+}
+
+func (m marketReviewServiceMock) UpdateMarketTags(ctx context.Context, marketID int64, tagSlugs []string, actorUsername string) (*dmarkets.Market, error) {
+	return m.tagsFn(ctx, marketID, tagSlugs, actorUsername)
 }
 
 type marketReviewAuthMock struct {
@@ -242,6 +247,42 @@ func TestReassignMarketStewardHandlerReassignsSteward(t *testing.T) {
 	}
 	if len(envelope.Result.StewardshipAudits) != 1 || envelope.Result.StewardshipAudits[0].Reason != "moderator inactive" {
 		t.Fatalf("expected stewardship audit in response, got %+v", envelope.Result.StewardshipAudits)
+	}
+}
+
+func TestUpdateMarketTagsHandlerRewritesMarketTags(t *testing.T) {
+	svc := marketReviewServiceMock{
+		tagsFn: func(_ context.Context, marketID int64, tagSlugs []string, actorUsername string) (*dmarkets.Market, error) {
+			if marketID != 46 || actorUsername != "admin" || len(tagSlugs) != 2 || tagSlugs[0] != "sports" || tagSlugs[1] != "policy" {
+				t.Fatalf("unexpected tag update args: id=%d actor=%q slugs=%+v", marketID, actorUsername, tagSlugs)
+			}
+			return &dmarkets.Market{
+				ID:              marketID,
+				QuestionTitle:   "Tagged market",
+				Status:          dmarkets.MarketStatusActive,
+				LifecycleStatus: dmarkets.MarketLifecyclePublished,
+				Tags: []dmarkets.MarketTag{
+					{ID: 1, Slug: "policy", DisplayName: "Policy", IsActive: true},
+					{ID: 2, Slug: "sports", DisplayName: "Sports", IsActive: true},
+				},
+			}, nil
+		},
+	}
+	handler := UpdateMarketTagsHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodPatch, "/v0/admin/markets/46/tags", bytes.NewBufferString(`{"tagSlugs":["sports","policy"]}`)), map[string]string{"id": "46"})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope handlers.SuccessEnvelope[marketReviewResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.OK || len(envelope.Result.Tags) != 2 || envelope.Result.Tags[0].Slug != "policy" {
+		t.Fatalf("unexpected response: %+v", envelope)
 	}
 }
 

--- a/backend/handlers/admin/market_tags.go
+++ b/backend/handlers/admin/market_tags.go
@@ -1,0 +1,177 @@
+package adminhandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"socialpredict/handlers"
+	dmarkets "socialpredict/internal/domain/markets"
+	authsvc "socialpredict/internal/service/auth"
+)
+
+type marketTagManager interface {
+	ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error)
+	CreateMarketTag(ctx context.Context, req dmarkets.MarketTagRequest, actorUsername string) (*dmarkets.MarketTag, error)
+	UpdateMarketTag(ctx context.Context, slug string, req dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error)
+}
+
+type adminMarketTagRequest struct {
+	Slug              string `json:"slug"`
+	DisplayName       string `json:"displayName"`
+	Description       string `json:"description"`
+	ColorKey          string `json:"colorKey"`
+	SortOrder         int    `json:"sortOrder"`
+	IsActive          *bool  `json:"isActive"`
+	ConfirmDeactivate bool   `json:"confirmDeactivate"`
+}
+
+type marketTagResponse struct {
+	ID          int64  `json:"id"`
+	Slug        string `json:"slug"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description,omitempty"`
+	ColorKey    string `json:"colorKey,omitempty"`
+	SortOrder   int    `json:"sortOrder"`
+	IsActive    bool   `json:"isActive"`
+	CreatedBy   string `json:"createdBy,omitempty"`
+}
+
+type marketTagsResponse struct {
+	Tags  []marketTagResponse `json:"tags"`
+	Total int                 `json:"total"`
+}
+
+func ListAdminMarketTagsHandler(svc marketTagManager, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		if _, ok := requireAdminForMarketReview(w, r, auth); !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+
+		includeInactive, _ := strconv.ParseBool(r.URL.Query().Get("includeInactive"))
+		tags, err := svc.ListMarketTags(r.Context(), includeInactive)
+		if err != nil {
+			writeMarketTagError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, marketTagsResponse{
+			Tags:  marketTagResponses(tags),
+			Total: len(tags),
+		})
+	}
+}
+
+func CreateAdminMarketTagHandler(svc marketTagManager, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		admin, ok := requireAdminForMarketReview(w, r, auth)
+		if !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+
+		var req adminMarketTagRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+			return
+		}
+		tag, err := svc.CreateMarketTag(r.Context(), marketTagRequestFromAdmin(req), admin.Username)
+		if err != nil {
+			writeMarketTagError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusCreated, marketTagResponseFromDomain(*tag))
+	}
+}
+
+func UpdateAdminMarketTagHandler(svc marketTagManager, auth authsvc.Authenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		if _, ok := requireAdminForMarketReview(w, r, auth); !ok {
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+
+		var req adminMarketTagRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+			return
+		}
+		if req.IsActive != nil && !*req.IsActive && !req.ConfirmDeactivate {
+			_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+			return
+		}
+
+		tag, err := svc.UpdateMarketTag(r.Context(), mux.Vars(r)["slug"], marketTagRequestFromAdmin(req))
+		if err != nil {
+			writeMarketTagError(w, err)
+			return
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, marketTagResponseFromDomain(*tag))
+	}
+}
+
+func writeMarketTagError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, dmarkets.ErrInvalidInput):
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+	default:
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+	}
+}
+
+func marketTagRequestFromAdmin(req adminMarketTagRequest) dmarkets.MarketTagRequest {
+	return dmarkets.MarketTagRequest{
+		Slug:        req.Slug,
+		DisplayName: req.DisplayName,
+		Description: req.Description,
+		ColorKey:    req.ColorKey,
+		SortOrder:   req.SortOrder,
+		IsActive:    req.IsActive,
+	}
+}
+
+func marketTagResponses(tags []dmarkets.MarketTag) []marketTagResponse {
+	responses := make([]marketTagResponse, 0, len(tags))
+	for _, tag := range tags {
+		responses = append(responses, marketTagResponseFromDomain(tag))
+	}
+	return responses
+}
+
+func marketTagResponseFromDomain(tag dmarkets.MarketTag) marketTagResponse {
+	return marketTagResponse{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+		CreatedBy:   tag.CreatedBy,
+	}
+}

--- a/backend/handlers/admin/market_tags_test.go
+++ b/backend/handlers/admin/market_tags_test.go
@@ -1,0 +1,113 @@
+package adminhandlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"socialpredict/handlers"
+	dmarkets "socialpredict/internal/domain/markets"
+	dusers "socialpredict/internal/domain/users"
+)
+
+type marketTagServiceMock struct {
+	listFn   func(context.Context, bool) ([]dmarkets.MarketTag, error)
+	createFn func(context.Context, dmarkets.MarketTagRequest, string) (*dmarkets.MarketTag, error)
+	updateFn func(context.Context, string, dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error)
+}
+
+func (m marketTagServiceMock) ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error) {
+	return m.listFn(ctx, includeInactive)
+}
+
+func (m marketTagServiceMock) CreateMarketTag(ctx context.Context, req dmarkets.MarketTagRequest, actorUsername string) (*dmarkets.MarketTag, error) {
+	return m.createFn(ctx, req, actorUsername)
+}
+
+func (m marketTagServiceMock) UpdateMarketTag(ctx context.Context, slug string, req dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+	return m.updateFn(ctx, slug, req)
+}
+
+func TestListAdminMarketTagsHandlerReturnsTags(t *testing.T) {
+	svc := marketTagServiceMock{
+		listFn: func(_ context.Context, includeInactive bool) ([]dmarkets.MarketTag, error) {
+			if !includeInactive {
+				t.Fatalf("expected includeInactive")
+			}
+			return []dmarkets.MarketTag{{ID: 1, Slug: "sports", DisplayName: "Sports", IsActive: true}}, nil
+		},
+	}
+	handler := ListAdminMarketTagsHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := httptest.NewRequest(http.MethodGet, "/v0/admin/market-tags?includeInactive=true", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var envelope handlers.SuccessEnvelope[marketTagsResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.OK || envelope.Result.Total != 1 || envelope.Result.Tags[0].Slug != "sports" {
+		t.Fatalf("unexpected response: %+v", envelope)
+	}
+}
+
+func TestCreateAdminMarketTagHandlerPassesActor(t *testing.T) {
+	svc := marketTagServiceMock{
+		createFn: func(_ context.Context, req dmarkets.MarketTagRequest, actorUsername string) (*dmarkets.MarketTag, error) {
+			if req.DisplayName != "Sports" || actorUsername != "admin" {
+				t.Fatalf("unexpected create args req=%+v actor=%q", req, actorUsername)
+			}
+			return &dmarkets.MarketTag{ID: 2, Slug: "sports", DisplayName: req.DisplayName, IsActive: true, CreatedBy: actorUsername}, nil
+		},
+	}
+	handler := CreateAdminMarketTagHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := httptest.NewRequest(http.MethodPost, "/v0/admin/market-tags", bytes.NewBufferString(`{"displayName":"Sports"}`))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateAdminMarketTagHandlerRequiresDeactivateConfirmation(t *testing.T) {
+	svc := marketTagServiceMock{
+		updateFn: func(context.Context, string, dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+			t.Fatalf("update should not be called without deactivate confirmation")
+			return nil, nil
+		},
+	}
+	handler := UpdateAdminMarketTagHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodPatch, "/v0/admin/market-tags/sports", bytes.NewBufferString(`{"isActive":false}`)), map[string]string{"slug": "sports"})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assertAdminFailure(t, rec, http.StatusBadRequest, handlers.ReasonValidationFailed)
+
+	svc.updateFn = func(_ context.Context, slug string, req dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+		if slug != "sports" || req.IsActive == nil || *req.IsActive {
+			t.Fatalf("unexpected update args slug=%q req=%+v", slug, req)
+		}
+		return &dmarkets.MarketTag{ID: 2, Slug: slug, DisplayName: "Sports", IsActive: false}, nil
+	}
+	handler = UpdateAdminMarketTagHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
+	req = mux.SetURLVars(httptest.NewRequest(http.MethodPatch, "/v0/admin/market-tags/sports", bytes.NewBufferString(`{"isActive":false,"confirmDeactivate":true}`)), map[string]string{"slug": "sports"})
+	rec = httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/handlers/admin/users.go
+++ b/backend/handlers/admin/users.go
@@ -207,6 +207,7 @@ func adminUserListFiltersFromRequest(w http.ResponseWriter, r *http.Request) (du
 
 	return dusers.ListFilters{
 		UserType: strings.TrimSpace(query.Get("usertype")),
+		Query:    strings.TrimSpace(query.Get("query")),
 		Limit:    limit,
 		Offset:   offset,
 	}, true

--- a/backend/handlers/admin/users_test.go
+++ b/backend/handlers/admin/users_test.go
@@ -41,7 +41,7 @@ func (m adminUserManagerMock) UnsuspendModerator(ctx context.Context, username, 
 func TestListAdminUsersHandlerReturnsUserQueue(t *testing.T) {
 	svc := adminUserManagerMock{
 		listFn: func(_ context.Context, filters dusers.ListFilters) ([]*dusers.User, error) {
-			if filters.Limit != 50 || filters.Offset != 10 {
+			if filters.Limit != 50 || filters.Offset != 10 || filters.UserType != string(dusers.UserTypeModerator) || filters.Query != "mod" {
 				t.Fatalf("unexpected filters: %+v", filters)
 			}
 			return []*dusers.User{
@@ -51,7 +51,7 @@ func TestListAdminUsersHandlerReturnsUserQueue(t *testing.T) {
 		},
 	}
 	handler := ListAdminUsersHandler(svc, marketReviewAuthMock{admin: &dusers.User{Username: "admin", UserType: string(dusers.UserTypeAdmin)}})
-	req := httptest.NewRequest(http.MethodGet, "/v0/admin/users?limit=50&offset=10", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/admin/users?limit=50&offset=10&usertype=MODERATOR&query=mod", nil)
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)

--- a/backend/handlers/cms/marketdiscovery/http/handler.go
+++ b/backend/handlers/cms/marketdiscovery/http/handler.go
@@ -1,0 +1,131 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"socialpredict/handlers"
+	"socialpredict/handlers/authhttp"
+	"socialpredict/handlers/cms/marketdiscovery"
+	authsvc "socialpredict/internal/service/auth"
+	"socialpredict/models"
+)
+
+type Handler struct {
+	svc  *marketdiscovery.Service
+	auth authsvc.Authenticator
+}
+
+func NewHandler(svc *marketdiscovery.Service, auth authsvc.Authenticator) *Handler {
+	return &Handler{svc: svc, auth: auth}
+}
+
+type updateReq struct {
+	Title                      string `json:"title"`
+	Description                string `json:"description"`
+	PageType                   string `json:"pageType"`
+	PrimaryTagSlug             string `json:"primaryTagSlug"`
+	SearchScope                string `json:"searchScope"`
+	FeaturedTopicsEnabled      bool   `json:"featuredTopicsEnabled"`
+	FeaturedMarketsEnabled     bool   `json:"featuredMarketsEnabled"`
+	SectionsEnabled            bool   `json:"sectionsEnabled"`
+	DefaultRecommendationLimit int    `json:"defaultRecommendationLimit"`
+	CuratedRecommendationLimit int    `json:"curatedRecommendationLimit"`
+	IsPublished                bool   `json:"isPublished"`
+	Version                    uint   `json:"version"`
+}
+
+type pageResponse struct {
+	Slug                       string `json:"slug"`
+	Title                      string `json:"title"`
+	Description                string `json:"description"`
+	PageType                   string `json:"pageType"`
+	PrimaryTagSlug             string `json:"primaryTagSlug"`
+	SearchScope                string `json:"searchScope"`
+	FeaturedTopicsEnabled      bool   `json:"featuredTopicsEnabled"`
+	FeaturedMarketsEnabled     bool   `json:"featuredMarketsEnabled"`
+	SectionsEnabled            bool   `json:"sectionsEnabled"`
+	DefaultRecommendationLimit int    `json:"defaultRecommendationLimit"`
+	CuratedRecommendationLimit int    `json:"curatedRecommendationLimit"`
+	RecommendationLimit        int    `json:"recommendationLimit"`
+	IsPublished                bool   `json:"isPublished"`
+	Version                    uint   `json:"version"`
+	UpdatedAt                  string `json:"updatedAt,omitempty"`
+}
+
+func (h *Handler) PublicGet(w http.ResponseWriter, r *http.Request) {
+	page, err := h.svc.GetPage(mux.Vars(r)["slug"])
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromPage(page))
+}
+
+func (h *Handler) AdminUpdate(w http.ResponseWriter, r *http.Request) {
+	if h.auth == nil {
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+		return
+	}
+	admin, authErr := h.auth.RequireAdmin(r)
+	if authErr != nil {
+		_ = authhttp.WriteFailure(w, authErr)
+		return
+	}
+
+	var in updateReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return
+	}
+	page, err := h.svc.UpdatePage(mux.Vars(r)["slug"], marketdiscovery.UpdateInput{
+		Title:                      in.Title,
+		Description:                in.Description,
+		PageType:                   in.PageType,
+		PrimaryTagSlug:             in.PrimaryTagSlug,
+		SearchScope:                in.SearchScope,
+		FeaturedTopicsEnabled:      in.FeaturedTopicsEnabled,
+		FeaturedMarketsEnabled:     in.FeaturedMarketsEnabled,
+		SectionsEnabled:            in.SectionsEnabled,
+		DefaultRecommendationLimit: in.DefaultRecommendationLimit,
+		CuratedRecommendationLimit: in.CuratedRecommendationLimit,
+		IsPublished:                in.IsPublished,
+		Version:                    in.Version,
+		UpdatedBy:                  admin.Username,
+	})
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromPage(page))
+}
+
+func responseFromPage(page *models.MarketDiscoveryPage) pageResponse {
+	response := pageResponse{
+		Slug:                       page.Slug,
+		Title:                      page.Title,
+		Description:                page.Description,
+		PageType:                   page.PageType,
+		PrimaryTagSlug:             page.PrimaryTagSlug,
+		SearchScope:                page.SearchScope,
+		FeaturedTopicsEnabled:      page.FeaturedTopicsEnabled,
+		FeaturedMarketsEnabled:     page.FeaturedMarketsEnabled,
+		SectionsEnabled:            page.SectionsEnabled,
+		DefaultRecommendationLimit: page.DefaultRecommendationLimit,
+		CuratedRecommendationLimit: page.CuratedRecommendationLimit,
+		IsPublished:                page.IsPublished,
+		Version:                    page.Version,
+	}
+	if page.UpdatedAt.IsZero() {
+		response.UpdatedAt = ""
+	} else {
+		response.UpdatedAt = page.UpdatedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	response.RecommendationLimit = response.DefaultRecommendationLimit
+	if page.FeaturedTopicsEnabled || page.FeaturedMarketsEnabled || page.SectionsEnabled {
+		response.RecommendationLimit = response.CuratedRecommendationLimit
+	}
+	return response
+}

--- a/backend/handlers/cms/marketdiscovery/http/handler.go
+++ b/backend/handlers/cms/marketdiscovery/http/handler.go
@@ -31,23 +31,9 @@ type updateReq struct {
 	SearchScope                string `json:"searchScope"`
 	FeaturedTopicsEnabled      bool   `json:"featuredTopicsEnabled"`
 	FeaturedMarketsEnabled     bool   `json:"featuredMarketsEnabled"`
-	SectionsEnabled            bool   `json:"sectionsEnabled"`
 	DefaultRecommendationLimit int    `json:"defaultRecommendationLimit"`
 	CuratedRecommendationLimit int    `json:"curatedRecommendationLimit"`
 	Version                    uint   `json:"version"`
-}
-
-type replaceSectionsReq struct {
-	Sections []sectionReq `json:"sections"`
-}
-
-type sectionReq struct {
-	Slug          string `json:"slug"`
-	Title         string `json:"title"`
-	Description   string `json:"description"`
-	TagFilterSlug string `json:"tagFilterSlug"`
-	SortOrder     int    `json:"sortOrder"`
-	IsActive      bool   `json:"isActive"`
 }
 
 type replacePinsReq struct {
@@ -63,32 +49,20 @@ type pinReq struct {
 }
 
 type pageResponse struct {
-	Slug                       string            `json:"slug"`
-	Title                      string            `json:"title"`
-	Description                string            `json:"description"`
-	PageType                   string            `json:"pageType"`
-	PrimaryTagSlug             string            `json:"primaryTagSlug"`
-	SearchScope                string            `json:"searchScope"`
-	FeaturedTopicsEnabled      bool              `json:"featuredTopicsEnabled"`
-	FeaturedMarketsEnabled     bool              `json:"featuredMarketsEnabled"`
-	SectionsEnabled            bool              `json:"sectionsEnabled"`
-	DefaultRecommendationLimit int               `json:"defaultRecommendationLimit"`
-	CuratedRecommendationLimit int               `json:"curatedRecommendationLimit"`
-	RecommendationLimit        int               `json:"recommendationLimit"`
-	Version                    uint              `json:"version"`
-	UpdatedAt                  string            `json:"updatedAt,omitempty"`
-	Sections                   []sectionResponse `json:"sections"`
-	Pins                       []pinResponse     `json:"pins"`
-}
-
-type sectionResponse struct {
-	ID            uint   `json:"id,omitempty"`
-	Slug          string `json:"slug"`
-	Title         string `json:"title"`
-	Description   string `json:"description,omitempty"`
-	TagFilterSlug string `json:"tagFilterSlug,omitempty"`
-	SortOrder     int    `json:"sortOrder"`
-	IsActive      bool   `json:"isActive"`
+	Slug                       string        `json:"slug"`
+	Title                      string        `json:"title"`
+	Description                string        `json:"description"`
+	PageType                   string        `json:"pageType"`
+	PrimaryTagSlug             string        `json:"primaryTagSlug"`
+	SearchScope                string        `json:"searchScope"`
+	FeaturedTopicsEnabled      bool          `json:"featuredTopicsEnabled"`
+	FeaturedMarketsEnabled     bool          `json:"featuredMarketsEnabled"`
+	DefaultRecommendationLimit int           `json:"defaultRecommendationLimit"`
+	CuratedRecommendationLimit int           `json:"curatedRecommendationLimit"`
+	RecommendationLimit        int           `json:"recommendationLimit"`
+	Version                    uint          `json:"version"`
+	UpdatedAt                  string        `json:"updatedAt,omitempty"`
+	Pins                       []pinResponse `json:"pins"`
 }
 
 type pinResponse struct {
@@ -133,7 +107,6 @@ func (h *Handler) AdminUpdate(w http.ResponseWriter, r *http.Request) {
 		SearchScope:                in.SearchScope,
 		FeaturedTopicsEnabled:      in.FeaturedTopicsEnabled,
 		FeaturedMarketsEnabled:     in.FeaturedMarketsEnabled,
-		SectionsEnabled:            in.SectionsEnabled,
 		DefaultRecommendationLimit: in.DefaultRecommendationLimit,
 		CuratedRecommendationLimit: in.CuratedRecommendationLimit,
 		Version:                    in.Version,
@@ -146,25 +119,6 @@ func (h *Handler) AdminUpdate(w http.ResponseWriter, r *http.Request) {
 	composition, err := h.svc.GetComposition(page.Slug)
 	if err != nil {
 		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
-		return
-	}
-	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
-}
-
-func (h *Handler) AdminReplaceSections(w http.ResponseWriter, r *http.Request) {
-	admin, ok := h.requireAdmin(w, r)
-	if !ok {
-		return
-	}
-	_ = admin
-	var in replaceSectionsReq
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
-		return
-	}
-	composition, err := h.svc.ReplaceSections(mux.Vars(r)["slug"], sectionInputsFromRequest(in.Sections))
-	if err != nil {
-		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
 		return
 	}
 	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
@@ -202,10 +156,10 @@ func (h *Handler) requireAdmin(w http.ResponseWriter, r *http.Request) (*dusers.
 }
 
 func responseFromComposition(composition *marketdiscovery.PageComposition) pageResponse {
-	return responseFromPage(composition.Page, composition.Sections, composition.Pins)
+	return responseFromPage(composition.Page, composition.Pins)
 }
 
-func responseFromPage(page *models.MarketDiscoveryPage, sections []models.MarketDiscoverySection, pins []models.MarketDiscoveryPin) pageResponse {
+func responseFromPage(page *models.MarketDiscoveryPage, pins []models.MarketDiscoveryPin) pageResponse {
 	response := pageResponse{
 		Slug:                       page.Slug,
 		Title:                      page.Title,
@@ -215,11 +169,9 @@ func responseFromPage(page *models.MarketDiscoveryPage, sections []models.Market
 		SearchScope:                page.SearchScope,
 		FeaturedTopicsEnabled:      page.FeaturedTopicsEnabled,
 		FeaturedMarketsEnabled:     page.FeaturedMarketsEnabled,
-		SectionsEnabled:            page.SectionsEnabled,
 		DefaultRecommendationLimit: page.DefaultRecommendationLimit,
 		CuratedRecommendationLimit: page.CuratedRecommendationLimit,
 		Version:                    page.Version,
-		Sections:                   sectionResponses(sections),
 		Pins:                       pinResponses(pins),
 	}
 	if page.UpdatedAt.IsZero() {
@@ -228,25 +180,10 @@ func responseFromPage(page *models.MarketDiscoveryPage, sections []models.Market
 		response.UpdatedAt = page.UpdatedAt.Format("2006-01-02T15:04:05Z07:00")
 	}
 	response.RecommendationLimit = response.DefaultRecommendationLimit
-	if page.FeaturedTopicsEnabled || page.FeaturedMarketsEnabled || page.SectionsEnabled {
+	if page.FeaturedTopicsEnabled || page.FeaturedMarketsEnabled {
 		response.RecommendationLimit = response.CuratedRecommendationLimit
 	}
 	return response
-}
-
-func sectionInputsFromRequest(sections []sectionReq) []marketdiscovery.SectionInput {
-	inputs := make([]marketdiscovery.SectionInput, 0, len(sections))
-	for _, section := range sections {
-		inputs = append(inputs, marketdiscovery.SectionInput{
-			Slug:          section.Slug,
-			Title:         section.Title,
-			Description:   section.Description,
-			TagFilterSlug: section.TagFilterSlug,
-			SortOrder:     section.SortOrder,
-			IsActive:      section.IsActive,
-		})
-	}
-	return inputs
 }
 
 func pinInputsFromRequest(pins []pinReq) []marketdiscovery.PinInput {
@@ -261,22 +198,6 @@ func pinInputsFromRequest(pins []pinReq) []marketdiscovery.PinInput {
 		})
 	}
 	return inputs
-}
-
-func sectionResponses(sections []models.MarketDiscoverySection) []sectionResponse {
-	responses := make([]sectionResponse, 0, len(sections))
-	for _, section := range sections {
-		responses = append(responses, sectionResponse{
-			ID:            section.ID,
-			Slug:          section.Slug,
-			Title:         section.Title,
-			Description:   section.Description,
-			TagFilterSlug: section.TagFilterSlug,
-			SortOrder:     section.SortOrder,
-			IsActive:      section.IsActive,
-		})
-	}
-	return responses
 }
 
 func pinResponses(pins []models.MarketDiscoveryPin) []pinResponse {

--- a/backend/handlers/cms/marketdiscovery/http/handler.go
+++ b/backend/handlers/cms/marketdiscovery/http/handler.go
@@ -34,7 +34,6 @@ type updateReq struct {
 	SectionsEnabled            bool   `json:"sectionsEnabled"`
 	DefaultRecommendationLimit int    `json:"defaultRecommendationLimit"`
 	CuratedRecommendationLimit int    `json:"curatedRecommendationLimit"`
-	IsPublished                bool   `json:"isPublished"`
 	Version                    uint   `json:"version"`
 }
 
@@ -76,7 +75,6 @@ type pageResponse struct {
 	DefaultRecommendationLimit int               `json:"defaultRecommendationLimit"`
 	CuratedRecommendationLimit int               `json:"curatedRecommendationLimit"`
 	RecommendationLimit        int               `json:"recommendationLimit"`
-	IsPublished                bool              `json:"isPublished"`
 	Version                    uint              `json:"version"`
 	UpdatedAt                  string            `json:"updatedAt,omitempty"`
 	Sections                   []sectionResponse `json:"sections"`
@@ -138,7 +136,6 @@ func (h *Handler) AdminUpdate(w http.ResponseWriter, r *http.Request) {
 		SectionsEnabled:            in.SectionsEnabled,
 		DefaultRecommendationLimit: in.DefaultRecommendationLimit,
 		CuratedRecommendationLimit: in.CuratedRecommendationLimit,
-		IsPublished:                in.IsPublished,
 		Version:                    in.Version,
 		UpdatedBy:                  admin.Username,
 	})
@@ -221,7 +218,6 @@ func responseFromPage(page *models.MarketDiscoveryPage, sections []models.Market
 		SectionsEnabled:            page.SectionsEnabled,
 		DefaultRecommendationLimit: page.DefaultRecommendationLimit,
 		CuratedRecommendationLimit: page.CuratedRecommendationLimit,
-		IsPublished:                page.IsPublished,
 		Version:                    page.Version,
 		Sections:                   sectionResponses(sections),
 		Pins:                       pinResponses(pins),

--- a/backend/handlers/cms/marketdiscovery/http/handler.go
+++ b/backend/handlers/cms/marketdiscovery/http/handler.go
@@ -9,6 +9,7 @@ import (
 	"socialpredict/handlers"
 	"socialpredict/handlers/authhttp"
 	"socialpredict/handlers/cms/marketdiscovery"
+	dusers "socialpredict/internal/domain/users"
 	authsvc "socialpredict/internal/service/auth"
 	"socialpredict/models"
 )
@@ -37,31 +38,77 @@ type updateReq struct {
 	Version                    uint   `json:"version"`
 }
 
+type replaceSectionsReq struct {
+	Sections []sectionReq `json:"sections"`
+}
+
+type sectionReq struct {
+	Slug          string `json:"slug"`
+	Title         string `json:"title"`
+	Description   string `json:"description"`
+	TagFilterSlug string `json:"tagFilterSlug"`
+	SortOrder     int    `json:"sortOrder"`
+	IsActive      bool   `json:"isActive"`
+}
+
+type replacePinsReq struct {
+	Pins []pinReq `json:"pins"`
+}
+
+type pinReq struct {
+	PinType        string `json:"pinType"`
+	MarketID       int64  `json:"marketId"`
+	TargetPageSlug string `json:"targetPageSlug"`
+	Label          string `json:"label"`
+	SortOrder      int    `json:"sortOrder"`
+}
+
 type pageResponse struct {
-	Slug                       string `json:"slug"`
-	Title                      string `json:"title"`
-	Description                string `json:"description"`
-	PageType                   string `json:"pageType"`
-	PrimaryTagSlug             string `json:"primaryTagSlug"`
-	SearchScope                string `json:"searchScope"`
-	FeaturedTopicsEnabled      bool   `json:"featuredTopicsEnabled"`
-	FeaturedMarketsEnabled     bool   `json:"featuredMarketsEnabled"`
-	SectionsEnabled            bool   `json:"sectionsEnabled"`
-	DefaultRecommendationLimit int    `json:"defaultRecommendationLimit"`
-	CuratedRecommendationLimit int    `json:"curatedRecommendationLimit"`
-	RecommendationLimit        int    `json:"recommendationLimit"`
-	IsPublished                bool   `json:"isPublished"`
-	Version                    uint   `json:"version"`
-	UpdatedAt                  string `json:"updatedAt,omitempty"`
+	Slug                       string            `json:"slug"`
+	Title                      string            `json:"title"`
+	Description                string            `json:"description"`
+	PageType                   string            `json:"pageType"`
+	PrimaryTagSlug             string            `json:"primaryTagSlug"`
+	SearchScope                string            `json:"searchScope"`
+	FeaturedTopicsEnabled      bool              `json:"featuredTopicsEnabled"`
+	FeaturedMarketsEnabled     bool              `json:"featuredMarketsEnabled"`
+	SectionsEnabled            bool              `json:"sectionsEnabled"`
+	DefaultRecommendationLimit int               `json:"defaultRecommendationLimit"`
+	CuratedRecommendationLimit int               `json:"curatedRecommendationLimit"`
+	RecommendationLimit        int               `json:"recommendationLimit"`
+	IsPublished                bool              `json:"isPublished"`
+	Version                    uint              `json:"version"`
+	UpdatedAt                  string            `json:"updatedAt,omitempty"`
+	Sections                   []sectionResponse `json:"sections"`
+	Pins                       []pinResponse     `json:"pins"`
+}
+
+type sectionResponse struct {
+	ID            uint   `json:"id,omitempty"`
+	Slug          string `json:"slug"`
+	Title         string `json:"title"`
+	Description   string `json:"description,omitempty"`
+	TagFilterSlug string `json:"tagFilterSlug,omitempty"`
+	SortOrder     int    `json:"sortOrder"`
+	IsActive      bool   `json:"isActive"`
+}
+
+type pinResponse struct {
+	ID             uint   `json:"id,omitempty"`
+	PinType        string `json:"pinType"`
+	MarketID       int64  `json:"marketId,omitempty"`
+	TargetPageSlug string `json:"targetPageSlug,omitempty"`
+	Label          string `json:"label,omitempty"`
+	SortOrder      int    `json:"sortOrder"`
 }
 
 func (h *Handler) PublicGet(w http.ResponseWriter, r *http.Request) {
-	page, err := h.svc.GetPage(mux.Vars(r)["slug"])
+	composition, err := h.svc.GetComposition(mux.Vars(r)["slug"])
 	if err != nil {
 		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
 		return
 	}
-	_ = handlers.WriteResult(w, http.StatusOK, responseFromPage(page))
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
 }
 
 func (h *Handler) AdminUpdate(w http.ResponseWriter, r *http.Request) {
@@ -99,10 +146,69 @@ func (h *Handler) AdminUpdate(w http.ResponseWriter, r *http.Request) {
 		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
 		return
 	}
-	_ = handlers.WriteResult(w, http.StatusOK, responseFromPage(page))
+	composition, err := h.svc.GetComposition(page.Slug)
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
 }
 
-func responseFromPage(page *models.MarketDiscoveryPage) pageResponse {
+func (h *Handler) AdminReplaceSections(w http.ResponseWriter, r *http.Request) {
+	admin, ok := h.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	_ = admin
+	var in replaceSectionsReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return
+	}
+	composition, err := h.svc.ReplaceSections(mux.Vars(r)["slug"], sectionInputsFromRequest(in.Sections))
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
+}
+
+func (h *Handler) AdminReplacePins(w http.ResponseWriter, r *http.Request) {
+	admin, ok := h.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	var in replacePinsReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonInvalidRequest)
+		return
+	}
+	composition, err := h.svc.ReplacePins(mux.Vars(r)["slug"], pinInputsFromRequest(in.Pins), admin.Username)
+	if err != nil {
+		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
+		return
+	}
+	_ = handlers.WriteResult(w, http.StatusOK, responseFromComposition(composition))
+}
+
+func (h *Handler) requireAdmin(w http.ResponseWriter, r *http.Request) (*dusers.User, bool) {
+	if h.auth == nil {
+		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+		return nil, false
+	}
+	admin, authErr := h.auth.RequireAdmin(r)
+	if authErr != nil {
+		_ = authhttp.WriteFailure(w, authErr)
+		return nil, false
+	}
+	return admin, true
+}
+
+func responseFromComposition(composition *marketdiscovery.PageComposition) pageResponse {
+	return responseFromPage(composition.Page, composition.Sections, composition.Pins)
+}
+
+func responseFromPage(page *models.MarketDiscoveryPage, sections []models.MarketDiscoverySection, pins []models.MarketDiscoveryPin) pageResponse {
 	response := pageResponse{
 		Slug:                       page.Slug,
 		Title:                      page.Title,
@@ -117,6 +223,8 @@ func responseFromPage(page *models.MarketDiscoveryPage) pageResponse {
 		CuratedRecommendationLimit: page.CuratedRecommendationLimit,
 		IsPublished:                page.IsPublished,
 		Version:                    page.Version,
+		Sections:                   sectionResponses(sections),
+		Pins:                       pinResponses(pins),
 	}
 	if page.UpdatedAt.IsZero() {
 		response.UpdatedAt = ""
@@ -128,4 +236,67 @@ func responseFromPage(page *models.MarketDiscoveryPage) pageResponse {
 		response.RecommendationLimit = response.CuratedRecommendationLimit
 	}
 	return response
+}
+
+func sectionInputsFromRequest(sections []sectionReq) []marketdiscovery.SectionInput {
+	inputs := make([]marketdiscovery.SectionInput, 0, len(sections))
+	for _, section := range sections {
+		inputs = append(inputs, marketdiscovery.SectionInput{
+			Slug:          section.Slug,
+			Title:         section.Title,
+			Description:   section.Description,
+			TagFilterSlug: section.TagFilterSlug,
+			SortOrder:     section.SortOrder,
+			IsActive:      section.IsActive,
+		})
+	}
+	return inputs
+}
+
+func pinInputsFromRequest(pins []pinReq) []marketdiscovery.PinInput {
+	inputs := make([]marketdiscovery.PinInput, 0, len(pins))
+	for _, pin := range pins {
+		inputs = append(inputs, marketdiscovery.PinInput{
+			PinType:        pin.PinType,
+			MarketID:       pin.MarketID,
+			TargetPageSlug: pin.TargetPageSlug,
+			Label:          pin.Label,
+			SortOrder:      pin.SortOrder,
+		})
+	}
+	return inputs
+}
+
+func sectionResponses(sections []models.MarketDiscoverySection) []sectionResponse {
+	responses := make([]sectionResponse, 0, len(sections))
+	for _, section := range sections {
+		responses = append(responses, sectionResponse{
+			ID:            section.ID,
+			Slug:          section.Slug,
+			Title:         section.Title,
+			Description:   section.Description,
+			TagFilterSlug: section.TagFilterSlug,
+			SortOrder:     section.SortOrder,
+			IsActive:      section.IsActive,
+		})
+	}
+	return responses
+}
+
+func pinResponses(pins []models.MarketDiscoveryPin) []pinResponse {
+	responses := make([]pinResponse, 0, len(pins))
+	for _, pin := range pins {
+		response := pinResponse{
+			ID:             pin.ID,
+			PinType:        pin.PinType,
+			TargetPageSlug: pin.TargetPageSlug,
+			Label:          pin.Label,
+			SortOrder:      pin.SortOrder,
+		}
+		if pin.MarketID != nil {
+			response.MarketID = *pin.MarketID
+		}
+		responses = append(responses, response)
+	}
+	return responses
 }

--- a/backend/handlers/cms/marketdiscovery/repo.go
+++ b/backend/handlers/cms/marketdiscovery/repo.go
@@ -1,0 +1,32 @@
+package marketdiscovery
+
+import (
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+type Repository interface {
+	GetPageBySlug(slug string) (*models.MarketDiscoveryPage, error)
+	SavePage(page *models.MarketDiscoveryPage) error
+}
+
+type GormRepository struct {
+	db *gorm.DB
+}
+
+func NewGormRepository(db *gorm.DB) *GormRepository {
+	return &GormRepository{db: db}
+}
+
+func (r *GormRepository) GetPageBySlug(slug string) (*models.MarketDiscoveryPage, error) {
+	var page models.MarketDiscoveryPage
+	if err := r.db.Where("slug = ?", slug).First(&page).Error; err != nil {
+		return nil, err
+	}
+	return &page, nil
+}
+
+func (r *GormRepository) SavePage(page *models.MarketDiscoveryPage) error {
+	return r.db.Save(page).Error
+}

--- a/backend/handlers/cms/marketdiscovery/repo.go
+++ b/backend/handlers/cms/marketdiscovery/repo.go
@@ -9,6 +9,10 @@ import (
 type Repository interface {
 	GetPageBySlug(slug string) (*models.MarketDiscoveryPage, error)
 	SavePage(page *models.MarketDiscoveryPage) error
+	ListSections(pageID uint) ([]models.MarketDiscoverySection, error)
+	ReplaceSections(pageID uint, sections []models.MarketDiscoverySection) error
+	ListPins(pageID uint) ([]models.MarketDiscoveryPin, error)
+	ReplacePins(pageID uint, pins []models.MarketDiscoveryPin) error
 }
 
 type GormRepository struct {
@@ -29,4 +33,51 @@ func (r *GormRepository) GetPageBySlug(slug string) (*models.MarketDiscoveryPage
 
 func (r *GormRepository) SavePage(page *models.MarketDiscoveryPage) error {
 	return r.db.Save(page).Error
+}
+
+func (r *GormRepository) ListSections(pageID uint) ([]models.MarketDiscoverySection, error) {
+	var sections []models.MarketDiscoverySection
+	if err := r.db.Where("page_id = ?", pageID).Order("sort_order ASC, id ASC").Find(&sections).Error; err != nil {
+		return nil, err
+	}
+	return sections, nil
+}
+
+func (r *GormRepository) ReplaceSections(pageID uint, sections []models.MarketDiscoverySection) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("page_id = ?", pageID).Delete(&models.MarketDiscoverySection{}).Error; err != nil {
+			return err
+		}
+		for index := range sections {
+			sections[index].PageID = pageID
+			if err := tx.Create(&sections[index]).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (r *GormRepository) ListPins(pageID uint) ([]models.MarketDiscoveryPin, error) {
+	var pins []models.MarketDiscoveryPin
+	if err := r.db.Where("scope_type = ? AND scope_id = ?", "page", pageID).Order("sort_order ASC, id ASC").Find(&pins).Error; err != nil {
+		return nil, err
+	}
+	return pins, nil
+}
+
+func (r *GormRepository) ReplacePins(pageID uint, pins []models.MarketDiscoveryPin) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("scope_type = ? AND scope_id = ?", "page", pageID).Delete(&models.MarketDiscoveryPin{}).Error; err != nil {
+			return err
+		}
+		for index := range pins {
+			pins[index].ScopeType = "page"
+			pins[index].ScopeID = pageID
+			if err := tx.Create(&pins[index]).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }

--- a/backend/handlers/cms/marketdiscovery/repo.go
+++ b/backend/handlers/cms/marketdiscovery/repo.go
@@ -9,8 +9,6 @@ import (
 type Repository interface {
 	GetPageBySlug(slug string) (*models.MarketDiscoveryPage, error)
 	SavePage(page *models.MarketDiscoveryPage) error
-	ListSections(pageID uint) ([]models.MarketDiscoverySection, error)
-	ReplaceSections(pageID uint, sections []models.MarketDiscoverySection) error
 	ListPins(pageID uint) ([]models.MarketDiscoveryPin, error)
 	ReplacePins(pageID uint, pins []models.MarketDiscoveryPin) error
 }
@@ -33,29 +31,6 @@ func (r *GormRepository) GetPageBySlug(slug string) (*models.MarketDiscoveryPage
 
 func (r *GormRepository) SavePage(page *models.MarketDiscoveryPage) error {
 	return r.db.Save(page).Error
-}
-
-func (r *GormRepository) ListSections(pageID uint) ([]models.MarketDiscoverySection, error) {
-	var sections []models.MarketDiscoverySection
-	if err := r.db.Where("page_id = ?", pageID).Order("sort_order ASC, id ASC").Find(&sections).Error; err != nil {
-		return nil, err
-	}
-	return sections, nil
-}
-
-func (r *GormRepository) ReplaceSections(pageID uint, sections []models.MarketDiscoverySection) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("page_id = ?", pageID).Delete(&models.MarketDiscoverySection{}).Error; err != nil {
-			return err
-		}
-		for index := range sections {
-			sections[index].PageID = pageID
-			if err := tx.Create(&sections[index]).Error; err != nil {
-				return err
-			}
-		}
-		return nil
-	})
 }
 
 func (r *GormRepository) ListPins(pageID uint) ([]models.MarketDiscoveryPin, error) {

--- a/backend/handlers/cms/marketdiscovery/service.go
+++ b/backend/handlers/cms/marketdiscovery/service.go
@@ -22,7 +22,6 @@ const (
 	MaxTitleLength       = 160
 	MaxDescriptionLength = 500
 	MaxSlugLength        = 96
-	MaxSectionsPerPage   = 24
 	MaxPinsPerPage       = 48
 	MinRecommendation    = 1
 	MaxRecommendation    = 50
@@ -48,20 +47,10 @@ type UpdateInput struct {
 	SearchScope                string
 	FeaturedTopicsEnabled      bool
 	FeaturedMarketsEnabled     bool
-	SectionsEnabled            bool
 	DefaultRecommendationLimit int
 	CuratedRecommendationLimit int
 	UpdatedBy                  string
 	Version                    uint
-}
-
-type SectionInput struct {
-	Slug          string
-	Title         string
-	Description   string
-	TagFilterSlug string
-	SortOrder     int
-	IsActive      bool
 }
 
 type PinInput struct {
@@ -73,9 +62,8 @@ type PinInput struct {
 }
 
 type PageComposition struct {
-	Page     *models.MarketDiscoveryPage
-	Sections []models.MarketDiscoverySection
-	Pins     []models.MarketDiscoveryPin
+	Page *models.MarketDiscoveryPage
+	Pins []models.MarketDiscoveryPin
 }
 
 func (s *Service) GetPage(slug string) (*models.MarketDiscoveryPage, error) {
@@ -99,17 +87,13 @@ func (s *Service) GetComposition(slug string) (*PageComposition, error) {
 		return nil, err
 	}
 	if page.ID == 0 {
-		return &PageComposition{Page: page, Sections: []models.MarketDiscoverySection{}, Pins: []models.MarketDiscoveryPin{}}, nil
-	}
-	sections, err := s.repo.ListSections(page.ID)
-	if err != nil {
-		return nil, err
+		return &PageComposition{Page: page, Pins: []models.MarketDiscoveryPin{}}, nil
 	}
 	pins, err := s.repo.ListPins(page.ID)
 	if err != nil {
 		return nil, err
 	}
-	return &PageComposition{Page: page, Sections: sections, Pins: pins}, nil
+	return &PageComposition{Page: page, Pins: pins}, nil
 }
 
 func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscoveryPage, error) {
@@ -138,7 +122,6 @@ func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscove
 	page.SearchScope = searchScope
 	page.FeaturedTopicsEnabled = in.FeaturedTopicsEnabled
 	page.FeaturedMarketsEnabled = in.FeaturedMarketsEnabled
-	page.SectionsEnabled = in.SectionsEnabled
 	page.DefaultRecommendationLimit = defaultLimit
 	page.CuratedRecommendationLimit = curatedLimit
 	page.UpdatedBy = strings.TrimSpace(in.UpdatedBy)
@@ -152,28 +135,6 @@ func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscove
 		return nil, err
 	}
 	return page, nil
-}
-
-func (s *Service) ReplaceSections(slug string, inputs []SectionInput) (*PageComposition, error) {
-	if len(inputs) > MaxSectionsPerPage {
-		return nil, errors.New("too many sections")
-	}
-	page, err := s.ensurePersistedPage(slug)
-	if err != nil {
-		return nil, err
-	}
-	sections := make([]models.MarketDiscoverySection, 0, len(inputs))
-	for index, input := range inputs {
-		section, err := sectionFromInput(input, index)
-		if err != nil {
-			return nil, err
-		}
-		sections = append(sections, section)
-	}
-	if err := s.repo.ReplaceSections(page.ID, sections); err != nil {
-		return nil, err
-	}
-	return s.GetComposition(page.Slug)
 }
 
 func (s *Service) ReplacePins(slug string, inputs []PinInput, actorUsername string) (*PageComposition, error) {
@@ -222,7 +183,6 @@ func DefaultPage(slug string) *models.MarketDiscoveryPage {
 		SearchScope:                SearchScopeAll,
 		FeaturedTopicsEnabled:      false,
 		FeaturedMarketsEnabled:     false,
-		SectionsEnabled:            false,
 		DefaultRecommendationLimit: 20,
 		CuratedRecommendationLimit: 5,
 		Version:                    1,
@@ -233,7 +193,6 @@ func DefaultPage(slug string) *models.MarketDiscoveryPage {
 		page.PageType = PageTypeSecondary
 		page.SearchScope = SearchScopeTag
 		page.FeaturedMarketsEnabled = true
-		page.SectionsEnabled = true
 	} else if slug != PageSlugMarkets {
 		page.Title = titleFromSlug(slug)
 		page.Description = "Browse and search markets in this topic."
@@ -241,42 +200,8 @@ func DefaultPage(slug string) *models.MarketDiscoveryPage {
 		page.PrimaryTagSlug = slug
 		page.SearchScope = SearchScopeTag
 		page.FeaturedMarketsEnabled = true
-		page.SectionsEnabled = true
 	}
 	return page
-}
-
-func sectionFromInput(input SectionInput, index int) (models.MarketDiscoverySection, error) {
-	title := strings.Join(strings.Fields(strings.TrimSpace(input.Title)), " ")
-	if title == "" {
-		return models.MarketDiscoverySection{}, errors.New("section title is required")
-	}
-	if len([]rune(title)) > MaxTitleLength {
-		return models.MarketDiscoverySection{}, errors.New("section title is too long")
-	}
-	description := strings.Join(strings.Fields(strings.TrimSpace(input.Description)), " ")
-	if len([]rune(description)) > MaxDescriptionLength {
-		return models.MarketDiscoverySection{}, errors.New("section description is too long")
-	}
-	slug := normalizeSlug(input.Slug)
-	if slug == "" {
-		slug = slugFromTitle(title)
-	}
-	if len([]rune(slug)) > MaxSlugLength {
-		return models.MarketDiscoverySection{}, errors.New("section slug is too long")
-	}
-	sortOrder := input.SortOrder
-	if sortOrder == 0 {
-		sortOrder = index + 1
-	}
-	return models.MarketDiscoverySection{
-		Slug:          slug,
-		Title:         title,
-		Description:   description,
-		TagFilterSlug: normalizeSlug(input.TagFilterSlug),
-		SortOrder:     sortOrder,
-		IsActive:      input.IsActive,
-	}, nil
 }
 
 func pinFromInput(input PinInput, index int, actorUsername string) (models.MarketDiscoveryPin, error) {

--- a/backend/handlers/cms/marketdiscovery/service.go
+++ b/backend/handlers/cms/marketdiscovery/service.go
@@ -1,0 +1,183 @@
+package marketdiscovery
+
+import (
+	"errors"
+	"strings"
+
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+const (
+	PageSlugMarkets       = "markets"
+	PageSlugTopicTemplate = "topic-template"
+
+	PageTypeTop       = "top"
+	PageTypeSecondary = "secondary"
+
+	SearchScopeAll = "all"
+	SearchScopeTag = "tag"
+
+	MaxTitleLength       = 160
+	MaxDescriptionLength = 500
+	MinRecommendation    = 1
+	MaxRecommendation    = 50
+)
+
+type Service struct {
+	repo Repository
+}
+
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+type UpdateInput struct {
+	Title                      string
+	Description                string
+	PageType                   string
+	PrimaryTagSlug             string
+	SearchScope                string
+	FeaturedTopicsEnabled      bool
+	FeaturedMarketsEnabled     bool
+	SectionsEnabled            bool
+	DefaultRecommendationLimit int
+	CuratedRecommendationLimit int
+	IsPublished                bool
+	UpdatedBy                  string
+	Version                    uint
+}
+
+func (s *Service) GetPage(slug string) (*models.MarketDiscoveryPage, error) {
+	slug = normalizeSlug(slug)
+	if slug == "" {
+		return nil, errors.New("page slug is required")
+	}
+	page, err := s.repo.GetPageBySlug(slug)
+	if err == nil {
+		return page, nil
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return DefaultPage(slug), nil
+	}
+	return nil, err
+}
+
+func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscoveryPage, error) {
+	slug = normalizeSlug(slug)
+	if slug == "" {
+		return nil, errors.New("page slug is required")
+	}
+	page, err := s.GetPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	if in.Version != 0 && page.ID != 0 && in.Version != page.Version {
+		return nil, errors.New("version mismatch")
+	}
+
+	title, description, pageType, primaryTagSlug, searchScope, defaultLimit, curatedLimit, err := validateInput(slug, in)
+	if err != nil {
+		return nil, err
+	}
+
+	page.Slug = slug
+	page.Title = title
+	page.Description = description
+	page.PageType = pageType
+	page.PrimaryTagSlug = primaryTagSlug
+	page.SearchScope = searchScope
+	page.FeaturedTopicsEnabled = in.FeaturedTopicsEnabled
+	page.FeaturedMarketsEnabled = in.FeaturedMarketsEnabled
+	page.SectionsEnabled = in.SectionsEnabled
+	page.DefaultRecommendationLimit = defaultLimit
+	page.CuratedRecommendationLimit = curatedLimit
+	page.IsPublished = in.IsPublished
+	page.UpdatedBy = strings.TrimSpace(in.UpdatedBy)
+	if page.ID == 0 {
+		page.Version = 1
+	} else {
+		page.Version = page.Version + 1
+	}
+
+	if err := s.repo.SavePage(page); err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+func DefaultPage(slug string) *models.MarketDiscoveryPage {
+	slug = normalizeSlug(slug)
+	page := &models.MarketDiscoveryPage{
+		Slug:                       slug,
+		Title:                      "Markets",
+		Description:                "Browse and search prediction markets.",
+		PageType:                   PageTypeTop,
+		SearchScope:                SearchScopeAll,
+		FeaturedTopicsEnabled:      false,
+		FeaturedMarketsEnabled:     false,
+		SectionsEnabled:            false,
+		DefaultRecommendationLimit: 20,
+		CuratedRecommendationLimit: 5,
+		IsPublished:                true,
+		Version:                    1,
+	}
+	if slug == PageSlugTopicTemplate {
+		page.Title = "Topic Markets"
+		page.Description = "Browse and search markets in this topic."
+		page.PageType = PageTypeSecondary
+		page.SearchScope = SearchScopeTag
+		page.FeaturedMarketsEnabled = true
+		page.SectionsEnabled = true
+	}
+	return page
+}
+
+func validateInput(slug string, in UpdateInput) (string, string, string, string, string, int, int, error) {
+	title := strings.Join(strings.Fields(strings.TrimSpace(in.Title)), " ")
+	if title == "" {
+		title = DefaultPage(slug).Title
+	}
+	if len([]rune(title)) > MaxTitleLength {
+		return "", "", "", "", "", 0, 0, errors.New("title is too long")
+	}
+	description := strings.Join(strings.Fields(strings.TrimSpace(in.Description)), " ")
+	if len([]rune(description)) > MaxDescriptionLength {
+		return "", "", "", "", "", 0, 0, errors.New("description is too long")
+	}
+	pageType := strings.ToLower(strings.TrimSpace(in.PageType))
+	if pageType == "" {
+		pageType = DefaultPage(slug).PageType
+	}
+	if pageType != PageTypeTop && pageType != PageTypeSecondary {
+		return "", "", "", "", "", 0, 0, errors.New("invalid page type")
+	}
+	searchScope := strings.ToLower(strings.TrimSpace(in.SearchScope))
+	if searchScope == "" {
+		searchScope = DefaultPage(slug).SearchScope
+	}
+	if searchScope != SearchScopeAll && searchScope != SearchScopeTag {
+		return "", "", "", "", "", 0, 0, errors.New("invalid search scope")
+	}
+	defaultLimit := clampRecommendationLimit(in.DefaultRecommendationLimit, DefaultPage(slug).DefaultRecommendationLimit)
+	curatedLimit := clampRecommendationLimit(in.CuratedRecommendationLimit, DefaultPage(slug).CuratedRecommendationLimit)
+	return title, description, pageType, normalizeSlug(in.PrimaryTagSlug), searchScope, defaultLimit, curatedLimit, nil
+}
+
+func clampRecommendationLimit(value int, fallback int) int {
+	if value == 0 {
+		value = fallback
+	}
+	if value < MinRecommendation {
+		return MinRecommendation
+	}
+	if value > MaxRecommendation {
+		return MaxRecommendation
+	}
+	return value
+}
+
+func normalizeSlug(value string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(value)), "-")
+}

--- a/backend/handlers/cms/marketdiscovery/service.go
+++ b/backend/handlers/cms/marketdiscovery/service.go
@@ -51,7 +51,6 @@ type UpdateInput struct {
 	SectionsEnabled            bool
 	DefaultRecommendationLimit int
 	CuratedRecommendationLimit int
-	IsPublished                bool
 	UpdatedBy                  string
 	Version                    uint
 }
@@ -142,7 +141,6 @@ func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscove
 	page.SectionsEnabled = in.SectionsEnabled
 	page.DefaultRecommendationLimit = defaultLimit
 	page.CuratedRecommendationLimit = curatedLimit
-	page.IsPublished = in.IsPublished
 	page.UpdatedBy = strings.TrimSpace(in.UpdatedBy)
 	if page.ID == 0 {
 		page.Version = 1
@@ -227,7 +225,6 @@ func DefaultPage(slug string) *models.MarketDiscoveryPage {
 		SectionsEnabled:            false,
 		DefaultRecommendationLimit: 20,
 		CuratedRecommendationLimit: 5,
-		IsPublished:                true,
 		Version:                    1,
 	}
 	if slug == PageSlugTopicTemplate {

--- a/backend/handlers/cms/marketdiscovery/service.go
+++ b/backend/handlers/cms/marketdiscovery/service.go
@@ -21,8 +21,15 @@ const (
 
 	MaxTitleLength       = 160
 	MaxDescriptionLength = 500
+	MaxSlugLength        = 96
+	MaxSectionsPerPage   = 24
+	MaxPinsPerPage       = 48
 	MinRecommendation    = 1
 	MaxRecommendation    = 50
+
+	ScopeTypePage        = "page"
+	PinTypeMarket        = "market"
+	PinTypeDiscoveryPage = "discovery_page"
 )
 
 type Service struct {
@@ -49,6 +56,29 @@ type UpdateInput struct {
 	Version                    uint
 }
 
+type SectionInput struct {
+	Slug          string
+	Title         string
+	Description   string
+	TagFilterSlug string
+	SortOrder     int
+	IsActive      bool
+}
+
+type PinInput struct {
+	PinType        string
+	MarketID       int64
+	TargetPageSlug string
+	Label          string
+	SortOrder      int
+}
+
+type PageComposition struct {
+	Page     *models.MarketDiscoveryPage
+	Sections []models.MarketDiscoverySection
+	Pins     []models.MarketDiscoveryPin
+}
+
 func (s *Service) GetPage(slug string) (*models.MarketDiscoveryPage, error) {
 	slug = normalizeSlug(slug)
 	if slug == "" {
@@ -62,6 +92,25 @@ func (s *Service) GetPage(slug string) (*models.MarketDiscoveryPage, error) {
 		return DefaultPage(slug), nil
 	}
 	return nil, err
+}
+
+func (s *Service) GetComposition(slug string) (*PageComposition, error) {
+	page, err := s.GetPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	if page.ID == 0 {
+		return &PageComposition{Page: page, Sections: []models.MarketDiscoverySection{}, Pins: []models.MarketDiscoveryPin{}}, nil
+	}
+	sections, err := s.repo.ListSections(page.ID)
+	if err != nil {
+		return nil, err
+	}
+	pins, err := s.repo.ListPins(page.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &PageComposition{Page: page, Sections: sections, Pins: pins}, nil
 }
 
 func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscoveryPage, error) {
@@ -107,6 +156,64 @@ func (s *Service) UpdatePage(slug string, in UpdateInput) (*models.MarketDiscove
 	return page, nil
 }
 
+func (s *Service) ReplaceSections(slug string, inputs []SectionInput) (*PageComposition, error) {
+	if len(inputs) > MaxSectionsPerPage {
+		return nil, errors.New("too many sections")
+	}
+	page, err := s.ensurePersistedPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	sections := make([]models.MarketDiscoverySection, 0, len(inputs))
+	for index, input := range inputs {
+		section, err := sectionFromInput(input, index)
+		if err != nil {
+			return nil, err
+		}
+		sections = append(sections, section)
+	}
+	if err := s.repo.ReplaceSections(page.ID, sections); err != nil {
+		return nil, err
+	}
+	return s.GetComposition(page.Slug)
+}
+
+func (s *Service) ReplacePins(slug string, inputs []PinInput, actorUsername string) (*PageComposition, error) {
+	if len(inputs) > MaxPinsPerPage {
+		return nil, errors.New("too many pins")
+	}
+	page, err := s.ensurePersistedPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	pins := make([]models.MarketDiscoveryPin, 0, len(inputs))
+	for index, input := range inputs {
+		pin, err := pinFromInput(input, index, actorUsername)
+		if err != nil {
+			return nil, err
+		}
+		pins = append(pins, pin)
+	}
+	if err := s.repo.ReplacePins(page.ID, pins); err != nil {
+		return nil, err
+	}
+	return s.GetComposition(page.Slug)
+}
+
+func (s *Service) ensurePersistedPage(slug string) (*models.MarketDiscoveryPage, error) {
+	page, err := s.GetPage(slug)
+	if err != nil {
+		return nil, err
+	}
+	if page.ID != 0 {
+		return page, nil
+	}
+	if err := s.repo.SavePage(page); err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
 func DefaultPage(slug string) *models.MarketDiscoveryPage {
 	slug = normalizeSlug(slug)
 	page := &models.MarketDiscoveryPage{
@@ -132,6 +239,78 @@ func DefaultPage(slug string) *models.MarketDiscoveryPage {
 		page.SectionsEnabled = true
 	}
 	return page
+}
+
+func sectionFromInput(input SectionInput, index int) (models.MarketDiscoverySection, error) {
+	title := strings.Join(strings.Fields(strings.TrimSpace(input.Title)), " ")
+	if title == "" {
+		return models.MarketDiscoverySection{}, errors.New("section title is required")
+	}
+	if len([]rune(title)) > MaxTitleLength {
+		return models.MarketDiscoverySection{}, errors.New("section title is too long")
+	}
+	description := strings.Join(strings.Fields(strings.TrimSpace(input.Description)), " ")
+	if len([]rune(description)) > MaxDescriptionLength {
+		return models.MarketDiscoverySection{}, errors.New("section description is too long")
+	}
+	slug := normalizeSlug(input.Slug)
+	if slug == "" {
+		slug = slugFromTitle(title)
+	}
+	if len([]rune(slug)) > MaxSlugLength {
+		return models.MarketDiscoverySection{}, errors.New("section slug is too long")
+	}
+	sortOrder := input.SortOrder
+	if sortOrder == 0 {
+		sortOrder = index + 1
+	}
+	return models.MarketDiscoverySection{
+		Slug:          slug,
+		Title:         title,
+		Description:   description,
+		TagFilterSlug: normalizeSlug(input.TagFilterSlug),
+		SortOrder:     sortOrder,
+		IsActive:      input.IsActive,
+	}, nil
+}
+
+func pinFromInput(input PinInput, index int, actorUsername string) (models.MarketDiscoveryPin, error) {
+	pinType := strings.ToLower(strings.TrimSpace(input.PinType))
+	if pinType == "" {
+		pinType = PinTypeMarket
+	}
+	if pinType != PinTypeMarket && pinType != PinTypeDiscoveryPage {
+		return models.MarketDiscoveryPin{}, errors.New("invalid pin type")
+	}
+	label := strings.Join(strings.Fields(strings.TrimSpace(input.Label)), " ")
+	if len([]rune(label)) > MaxTitleLength {
+		return models.MarketDiscoveryPin{}, errors.New("pin label is too long")
+	}
+	sortOrder := input.SortOrder
+	if sortOrder == 0 {
+		sortOrder = index + 1
+	}
+	pin := models.MarketDiscoveryPin{
+		ScopeType: ScopeTypePage,
+		PinType:   pinType,
+		Label:     label,
+		SortOrder: sortOrder,
+		CreatedBy: strings.TrimSpace(actorUsername),
+	}
+	switch pinType {
+	case PinTypeMarket:
+		if input.MarketID <= 0 {
+			return models.MarketDiscoveryPin{}, errors.New("market pin requires market id")
+		}
+		pin.MarketID = &input.MarketID
+	case PinTypeDiscoveryPage:
+		targetPageSlug := normalizeSlug(input.TargetPageSlug)
+		if targetPageSlug == "" {
+			return models.MarketDiscoveryPin{}, errors.New("discovery page pin requires target page slug")
+		}
+		pin.TargetPageSlug = targetPageSlug
+	}
+	return pin, nil
 }
 
 func validateInput(slug string, in UpdateInput) (string, string, string, string, string, int, int, error) {
@@ -180,4 +359,22 @@ func clampRecommendationLimit(value int, fallback int) int {
 
 func normalizeSlug(value string) string {
 	return strings.Trim(strings.ToLower(strings.TrimSpace(value)), "-")
+}
+
+func slugFromTitle(title string) string {
+	title = strings.ToLower(strings.TrimSpace(title))
+	var builder strings.Builder
+	lastHyphen := false
+	for _, r := range title {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen {
+			builder.WriteRune('-')
+			lastHyphen = true
+		}
+	}
+	return normalizeSlug(builder.String())
 }

--- a/backend/handlers/cms/marketdiscovery/service.go
+++ b/backend/handlers/cms/marketdiscovery/service.go
@@ -237,6 +237,14 @@ func DefaultPage(slug string) *models.MarketDiscoveryPage {
 		page.SearchScope = SearchScopeTag
 		page.FeaturedMarketsEnabled = true
 		page.SectionsEnabled = true
+	} else if slug != PageSlugMarkets {
+		page.Title = titleFromSlug(slug)
+		page.Description = "Browse and search markets in this topic."
+		page.PageType = PageTypeSecondary
+		page.PrimaryTagSlug = slug
+		page.SearchScope = SearchScopeTag
+		page.FeaturedMarketsEnabled = true
+		page.SectionsEnabled = true
 	}
 	return page
 }
@@ -377,4 +385,17 @@ func slugFromTitle(title string) string {
 		}
 	}
 	return normalizeSlug(builder.String())
+}
+
+func titleFromSlug(slug string) string {
+	parts := strings.Fields(strings.ReplaceAll(normalizeSlug(slug), "-", " "))
+	for i, part := range parts {
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	if len(parts) == 0 {
+		return "Topic Markets"
+	}
+	return strings.Join(parts, " ")
 }

--- a/backend/handlers/cms/marketdiscovery/service_test.go
+++ b/backend/handlers/cms/marketdiscovery/service_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 type mockRepository struct {
-	page     *models.MarketDiscoveryPage
-	sections []models.MarketDiscoverySection
-	pins     []models.MarketDiscoveryPin
-	saveErr  error
-	getErr   error
+	page    *models.MarketDiscoveryPage
+	pins    []models.MarketDiscoveryPin
+	saveErr error
+	getErr  error
 }
 
 func (m *mockRepository) GetPageBySlug(string) (*models.MarketDiscoveryPage, error) {
@@ -35,15 +34,6 @@ func (m *mockRepository) SavePage(page *models.MarketDiscoveryPage) error {
 		page.ID = 1
 	}
 	m.page = page
-	return nil
-}
-
-func (m *mockRepository) ListSections(uint) ([]models.MarketDiscoverySection, error) {
-	return m.sections, nil
-}
-
-func (m *mockRepository) ReplaceSections(_ uint, sections []models.MarketDiscoverySection) error {
-	m.sections = sections
 	return nil
 }
 
@@ -118,23 +108,6 @@ func TestUpdatePagePropagatesRepositoryError(t *testing.T) {
 	})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("UpdatePage error = %v, want %v", err, wantErr)
-	}
-}
-
-func TestReplaceSectionsPersistsOrderedSections(t *testing.T) {
-	repo := &mockRepository{}
-	svc := NewService(repo)
-
-	composition, err := svc.ReplaceSections(PageSlugMarkets, []SectionInput{{
-		Title:       "Politics",
-		Description: "Political markets",
-		IsActive:    true,
-	}})
-	if err != nil {
-		t.Fatalf("ReplaceSections returned error: %v", err)
-	}
-	if len(composition.Sections) != 1 || composition.Sections[0].Slug != "politics" || composition.Sections[0].SortOrder != 1 {
-		t.Fatalf("unexpected sections: %+v", composition.Sections)
 	}
 }
 

--- a/backend/handlers/cms/marketdiscovery/service_test.go
+++ b/backend/handlers/cms/marketdiscovery/service_test.go
@@ -1,0 +1,100 @@
+package marketdiscovery
+
+import (
+	"errors"
+	"testing"
+
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+type mockRepository struct {
+	page    *models.MarketDiscoveryPage
+	saveErr error
+	getErr  error
+}
+
+func (m *mockRepository) GetPageBySlug(string) (*models.MarketDiscoveryPage, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if m.page == nil {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return m.page, nil
+}
+
+func (m *mockRepository) SavePage(page *models.MarketDiscoveryPage) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.page = page
+	return nil
+}
+
+func TestGetPageReturnsDefaultWhenMissing(t *testing.T) {
+	svc := NewService(&mockRepository{})
+
+	page, err := svc.GetPage(PageSlugMarkets)
+	if err != nil {
+		t.Fatalf("GetPage returned error: %v", err)
+	}
+	if page.Slug != PageSlugMarkets || page.PageType != PageTypeTop || page.DefaultRecommendationLimit != 20 {
+		t.Fatalf("unexpected default page: %+v", page)
+	}
+}
+
+func TestUpdatePagePersistsLayout(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo)
+
+	page, err := svc.UpdatePage(PageSlugMarkets, UpdateInput{
+		Title:                      "Forecast Markets",
+		Description:                "Curated markets.",
+		PageType:                   PageTypeTop,
+		SearchScope:                SearchScopeAll,
+		FeaturedTopicsEnabled:      true,
+		FeaturedMarketsEnabled:     true,
+		DefaultRecommendationLimit: 30,
+		CuratedRecommendationLimit: 7,
+		IsPublished:                true,
+		UpdatedBy:                  "admin",
+	})
+	if err != nil {
+		t.Fatalf("UpdatePage returned error: %v", err)
+	}
+	if page.Title != "Forecast Markets" || !page.FeaturedTopicsEnabled || page.CuratedRecommendationLimit != 7 {
+		t.Fatalf("unexpected saved page: %+v", page)
+	}
+	if repo.page == nil || repo.page.UpdatedBy != "admin" {
+		t.Fatalf("expected saved page with UpdatedBy admin, got %+v", repo.page)
+	}
+}
+
+func TestUpdatePageRejectsInvalidSearchScope(t *testing.T) {
+	svc := NewService(&mockRepository{})
+
+	_, err := svc.UpdatePage(PageSlugMarkets, UpdateInput{
+		Title:       "Markets",
+		PageType:    PageTypeTop,
+		SearchScope: "everywhere",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestUpdatePagePropagatesRepositoryError(t *testing.T) {
+	wantErr := errors.New("database unavailable")
+	svc := NewService(&mockRepository{saveErr: wantErr})
+
+	_, err := svc.UpdatePage(PageSlugMarkets, UpdateInput{
+		Title:       "Markets",
+		PageType:    PageTypeTop,
+		SearchScope: SearchScopeAll,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("UpdatePage error = %v, want %v", err, wantErr)
+	}
+}

--- a/backend/handlers/cms/marketdiscovery/service_test.go
+++ b/backend/handlers/cms/marketdiscovery/service_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 type mockRepository struct {
-	page    *models.MarketDiscoveryPage
-	saveErr error
-	getErr  error
+	page     *models.MarketDiscoveryPage
+	sections []models.MarketDiscoverySection
+	pins     []models.MarketDiscoveryPin
+	saveErr  error
+	getErr   error
 }
 
 func (m *mockRepository) GetPageBySlug(string) (*models.MarketDiscoveryPage, error) {
@@ -29,7 +31,28 @@ func (m *mockRepository) SavePage(page *models.MarketDiscoveryPage) error {
 	if m.saveErr != nil {
 		return m.saveErr
 	}
+	if page.ID == 0 {
+		page.ID = 1
+	}
 	m.page = page
+	return nil
+}
+
+func (m *mockRepository) ListSections(uint) ([]models.MarketDiscoverySection, error) {
+	return m.sections, nil
+}
+
+func (m *mockRepository) ReplaceSections(_ uint, sections []models.MarketDiscoverySection) error {
+	m.sections = sections
+	return nil
+}
+
+func (m *mockRepository) ListPins(uint) ([]models.MarketDiscoveryPin, error) {
+	return m.pins, nil
+}
+
+func (m *mockRepository) ReplacePins(_ uint, pins []models.MarketDiscoveryPin) error {
+	m.pins = pins
 	return nil
 }
 
@@ -96,5 +119,53 @@ func TestUpdatePagePropagatesRepositoryError(t *testing.T) {
 	})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("UpdatePage error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestReplaceSectionsPersistsOrderedSections(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo)
+
+	composition, err := svc.ReplaceSections(PageSlugMarkets, []SectionInput{{
+		Title:       "Politics",
+		Description: "Political markets",
+		IsActive:    true,
+	}})
+	if err != nil {
+		t.Fatalf("ReplaceSections returned error: %v", err)
+	}
+	if len(composition.Sections) != 1 || composition.Sections[0].Slug != "politics" || composition.Sections[0].SortOrder != 1 {
+		t.Fatalf("unexpected sections: %+v", composition.Sections)
+	}
+}
+
+func TestReplacePinsPersistsMarketAndTopicPins(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo)
+
+	composition, err := svc.ReplacePins(PageSlugMarkets, []PinInput{
+		{PinType: PinTypeMarket, MarketID: 42, Label: "Featured market"},
+		{PinType: PinTypeDiscoveryPage, TargetPageSlug: "politics", Label: "Politics"},
+	}, "admin")
+	if err != nil {
+		t.Fatalf("ReplacePins returned error: %v", err)
+	}
+	if len(composition.Pins) != 2 {
+		t.Fatalf("expected two pins, got %+v", composition.Pins)
+	}
+	if composition.Pins[0].MarketID == nil || *composition.Pins[0].MarketID != 42 {
+		t.Fatalf("expected market pin, got %+v", composition.Pins[0])
+	}
+	if composition.Pins[1].TargetPageSlug != "politics" || composition.Pins[1].CreatedBy != "admin" {
+		t.Fatalf("expected topic pin, got %+v", composition.Pins[1])
+	}
+}
+
+func TestReplacePinsRejectsInvalidMarketPin(t *testing.T) {
+	svc := NewService(&mockRepository{})
+
+	_, err := svc.ReplacePins(PageSlugMarkets, []PinInput{{PinType: PinTypeMarket}}, "admin")
+	if err == nil {
+		t.Fatalf("expected validation error")
 	}
 }

--- a/backend/handlers/cms/marketdiscovery/service_test.go
+++ b/backend/handlers/cms/marketdiscovery/service_test.go
@@ -81,7 +81,6 @@ func TestUpdatePagePersistsLayout(t *testing.T) {
 		FeaturedMarketsEnabled:     true,
 		DefaultRecommendationLimit: 30,
 		CuratedRecommendationLimit: 7,
-		IsPublished:                true,
 		UpdatedBy:                  "admin",
 	})
 	if err != nil {

--- a/backend/handlers/markets/createmarket.go
+++ b/backend/handlers/markets/createmarket.go
@@ -207,6 +207,7 @@ func toDomainCreateRequest(req dto.CreateMarketRequest) dmarkets.MarketCreateReq
 		ResolutionDateTime: req.ResolutionDateTime,
 		YesLabel:           req.YesLabel,
 		NoLabel:            req.NoLabel,
+		TagSlugs:           req.TagSlugs,
 	}
 }
 
@@ -225,6 +226,7 @@ func toCreateMarketResponse(market *dmarkets.Market) dto.CreateMarketResponse {
 		LifecycleStatus:    market.LifecycleStatus,
 		ProposalCost:       market.ProposalCost,
 		CreatedAt:          market.CreatedAt,
+		Tags:               marketTagResponsesFromDomain(market.Tags),
 	}
 }
 

--- a/backend/handlers/markets/dto/requests.go
+++ b/backend/handlers/markets/dto/requests.go
@@ -12,6 +12,7 @@ type CreateMarketRequest struct {
 	ResolutionDateTime time.Time `json:"resolutionDateTime" validate:"required"`
 	YesLabel           string    `json:"yesLabel" validate:"omitempty,max=20"`
 	NoLabel            string    `json:"noLabel" validate:"omitempty,max=20"`
+	TagSlugs           []string  `json:"tagSlugs" validate:"omitempty,max=5"`
 }
 
 // UpdateLabelsRequest represents the HTTP request body for updating market labels

--- a/backend/handlers/markets/dto/responses.go
+++ b/backend/handlers/markets/dto/responses.go
@@ -6,44 +6,61 @@ import (
 
 // MarketResponse represents the HTTP response for a market
 type MarketResponse struct {
-	ID                 int64      `json:"id"`
-	QuestionTitle      string     `json:"questionTitle"`
-	Description        string     `json:"description"`
-	OutcomeType        string     `json:"outcomeType"`
-	ResolutionDateTime time.Time  `json:"resolutionDateTime"`
-	CreatorUsername    string     `json:"creatorUsername"`
-	StewardUsername    string     `json:"stewardUsername"`
-	YesLabel           string     `json:"yesLabel"`
-	NoLabel            string     `json:"noLabel"`
-	Status             string     `json:"status"`
-	LifecycleStatus    string     `json:"lifecycleStatus,omitempty"`
-	ApprovedBy         string     `json:"approvedBy,omitempty"`
-	ApprovedAt         *time.Time `json:"approvedAt,omitempty"`
-	RejectedBy         string     `json:"rejectedBy,omitempty"`
-	RejectedAt         *time.Time `json:"rejectedAt,omitempty"`
-	RejectionReason    string     `json:"rejectionReason,omitempty"`
-	ProposalCost       int64      `json:"proposalCost,omitempty"`
-	IsResolved         bool       `json:"isResolved"`
-	ResolutionResult   string     `json:"resolutionResult"`
-	CreatedAt          time.Time  `json:"createdAt"`
-	UpdatedAt          time.Time  `json:"updatedAt"`
+	ID                 int64               `json:"id"`
+	QuestionTitle      string              `json:"questionTitle"`
+	Description        string              `json:"description"`
+	OutcomeType        string              `json:"outcomeType"`
+	ResolutionDateTime time.Time           `json:"resolutionDateTime"`
+	CreatorUsername    string              `json:"creatorUsername"`
+	StewardUsername    string              `json:"stewardUsername"`
+	YesLabel           string              `json:"yesLabel"`
+	NoLabel            string              `json:"noLabel"`
+	Status             string              `json:"status"`
+	LifecycleStatus    string              `json:"lifecycleStatus,omitempty"`
+	ApprovedBy         string              `json:"approvedBy,omitempty"`
+	ApprovedAt         *time.Time          `json:"approvedAt,omitempty"`
+	RejectedBy         string              `json:"rejectedBy,omitempty"`
+	RejectedAt         *time.Time          `json:"rejectedAt,omitempty"`
+	RejectionReason    string              `json:"rejectionReason,omitempty"`
+	ProposalCost       int64               `json:"proposalCost,omitempty"`
+	IsResolved         bool                `json:"isResolved"`
+	ResolutionResult   string              `json:"resolutionResult"`
+	CreatedAt          time.Time           `json:"createdAt"`
+	UpdatedAt          time.Time           `json:"updatedAt"`
+	Tags               []MarketTagResponse `json:"tags,omitempty"`
 }
 
 // CreateMarketResponse represents the HTTP response after creating a market
 type CreateMarketResponse struct {
-	ID                 int64     `json:"id"`
-	QuestionTitle      string    `json:"questionTitle"`
-	Description        string    `json:"description"`
-	OutcomeType        string    `json:"outcomeType"`
-	ResolutionDateTime time.Time `json:"resolutionDateTime"`
-	CreatorUsername    string    `json:"creatorUsername"`
-	StewardUsername    string    `json:"stewardUsername"`
-	YesLabel           string    `json:"yesLabel"`
-	NoLabel            string    `json:"noLabel"`
-	Status             string    `json:"status"`
-	LifecycleStatus    string    `json:"lifecycleStatus,omitempty"`
-	ProposalCost       int64     `json:"proposalCost,omitempty"`
-	CreatedAt          time.Time `json:"createdAt"`
+	ID                 int64               `json:"id"`
+	QuestionTitle      string              `json:"questionTitle"`
+	Description        string              `json:"description"`
+	OutcomeType        string              `json:"outcomeType"`
+	ResolutionDateTime time.Time           `json:"resolutionDateTime"`
+	CreatorUsername    string              `json:"creatorUsername"`
+	StewardUsername    string              `json:"stewardUsername"`
+	YesLabel           string              `json:"yesLabel"`
+	NoLabel            string              `json:"noLabel"`
+	Status             string              `json:"status"`
+	LifecycleStatus    string              `json:"lifecycleStatus,omitempty"`
+	ProposalCost       int64               `json:"proposalCost,omitempty"`
+	CreatedAt          time.Time           `json:"createdAt"`
+	Tags               []MarketTagResponse `json:"tags,omitempty"`
+}
+
+type MarketTagResponse struct {
+	ID          int64  `json:"id"`
+	Slug        string `json:"slug"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description,omitempty"`
+	ColorKey    string `json:"colorKey,omitempty"`
+	SortOrder   int    `json:"sortOrder"`
+	IsActive    bool   `json:"isActive"`
+}
+
+type MarketTagsResponse struct {
+	Tags  []MarketTagResponse `json:"tags"`
+	Total int                 `json:"total"`
 }
 
 // CreatorResponse represents the creator information for frontend display
@@ -65,21 +82,22 @@ type MarketOverviewResponse struct {
 
 // PublicMarketResponse represents the legacy public market payload.
 type PublicMarketResponse struct {
-	ID                      int64     `json:"id"`
-	QuestionTitle           string    `json:"questionTitle"`
-	Description             string    `json:"description"`
-	OutcomeType             string    `json:"outcomeType"`
-	ResolutionDateTime      time.Time `json:"resolutionDateTime"`
-	FinalResolutionDateTime time.Time `json:"finalResolutionDateTime"`
-	UTCOffset               int       `json:"utcOffset"`
-	IsResolved              bool      `json:"isResolved"`
-	ResolutionResult        string    `json:"resolutionResult"`
-	InitialProbability      float64   `json:"initialProbability"`
-	CreatorUsername         string    `json:"creatorUsername"`
-	StewardUsername         string    `json:"stewardUsername"`
-	CreatedAt               time.Time `json:"createdAt"`
-	YesLabel                string    `json:"yesLabel"`
-	NoLabel                 string    `json:"noLabel"`
+	ID                      int64               `json:"id"`
+	QuestionTitle           string              `json:"questionTitle"`
+	Description             string              `json:"description"`
+	OutcomeType             string              `json:"outcomeType"`
+	ResolutionDateTime      time.Time           `json:"resolutionDateTime"`
+	FinalResolutionDateTime time.Time           `json:"finalResolutionDateTime"`
+	UTCOffset               int                 `json:"utcOffset"`
+	IsResolved              bool                `json:"isResolved"`
+	ResolutionResult        string              `json:"resolutionResult"`
+	InitialProbability      float64             `json:"initialProbability"`
+	CreatorUsername         string              `json:"creatorUsername"`
+	StewardUsername         string              `json:"stewardUsername"`
+	CreatedAt               time.Time           `json:"createdAt"`
+	YesLabel                string              `json:"yesLabel"`
+	NoLabel                 string              `json:"noLabel"`
+	Tags                    []MarketTagResponse `json:"tags,omitempty"`
 }
 
 // ProbabilityChangeResponse represents WPAM probability history.

--- a/backend/handlers/markets/handler.go
+++ b/backend/handlers/markets/handler.go
@@ -90,6 +90,7 @@ func (h *Handler) CreateMarket(w http.ResponseWriter, r *http.Request) {
 		ResolutionDateTime: req.ResolutionDateTime,
 		YesLabel:           req.YesLabel,
 		NoLabel:            req.NoLabel,
+		TagSlugs:           req.TagSlugs,
 	}
 
 	market, err := h.service.CreateMarket(r.Context(), createReq, user.Username)

--- a/backend/handlers/markets/handler.go
+++ b/backend/handlers/markets/handler.go
@@ -191,7 +191,7 @@ func (h *Handler) ListMarkets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var markets []*dmarkets.Market
-	if params.status != "" && params.filters.CreatedBy == "" {
+	if params.status != "" && params.filters.CreatedBy == "" && params.filters.TagSlug == "" {
 		page := dmarkets.Page{Limit: params.limit, Offset: params.offset}
 		markets, err = h.service.ListByStatus(r.Context(), params.status, page)
 	} else {

--- a/backend/handlers/markets/handler_contract_test.go
+++ b/backend/handlers/markets/handler_contract_test.go
@@ -270,6 +270,60 @@ func TestHandlerListMarkets_UsesCreatedByFilterWhenStatusProvided(t *testing.T) 
 	}
 }
 
+func TestHandlerListMarkets_UsesTagFilterWhenStatusProvided(t *testing.T) {
+	now := time.Now().UTC()
+	market := &dmarkets.Market{
+		ID:                 12,
+		QuestionTitle:      "Tagged active market",
+		Description:        "desc",
+		OutcomeType:        "BINARY",
+		ResolutionDateTime: now.Add(time.Hour),
+		CreatorUsername:    "alice",
+		YesLabel:           "YES",
+		NoLabel:            "NO",
+		Status:             "active",
+		CreatedAt:          now.Add(-24 * time.Hour),
+		UpdatedAt:          now,
+		Tags: []dmarkets.MarketTag{
+			{Slug: "one", DisplayName: "One", IsActive: true},
+		},
+	}
+
+	service := &contractServiceMock{
+		listFn: func(ctx context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error) {
+			want := dmarkets.ListFilters{Status: "active", TagSlug: "one", Limit: 5, Offset: 2}
+			if filters != want {
+				t.Fatalf("expected filters %+v, got %+v", want, filters)
+			}
+			return []*dmarkets.Market{market}, nil
+		},
+		listByStatusFn: func(ctx context.Context, status string, p dmarkets.Page) ([]*dmarkets.Market, error) {
+			t.Fatalf("expected status+tag request to use ListMarkets, got ListByStatus(%q, %+v)", status, p)
+			return nil, nil
+		},
+		detailsFn: func(ctx context.Context, marketID int64) (*dmarkets.MarketOverview, error) {
+			return newOverview(market), nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/markets?status=active&tagSlug=one&limit=5&offset=2", nil)
+	rr := httptest.NewRecorder()
+
+	newContractHandler(service, nil).ListMarkets(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp dto.ListMarketsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Markets) != 1 || resp.Markets[0].Market.ID != 12 {
+		t.Fatalf("unexpected list response: %+v", resp)
+	}
+}
+
 func TestHandlerSearchMarkets_SupportsLegacyQAndInvalidRequestFailure(t *testing.T) {
 	now := time.Now().UTC()
 	market := &dmarkets.Market{

--- a/backend/handlers/markets/listmarkets.go
+++ b/backend/handlers/markets/listmarkets.go
@@ -40,6 +40,7 @@ func parseListMarketsParams(r *http.Request) (listMarketsParams, error) {
 		filters: dmarkets.ListFilters{
 			Status:    status,
 			CreatedBy: strings.TrimSpace(r.URL.Query().Get("created_by")),
+			TagSlug:   normalizeTagSlugParam(r.URL.Query().Get("tagSlug")),
 			Limit:     page.Limit,
 			Offset:    page.Offset,
 		},
@@ -77,6 +78,9 @@ func parseListPage(r *http.Request) dmarkets.Page {
 }
 
 func fetchMarketsByStatus(r *http.Request, svc dmarkets.ServiceInterface, params listMarketsParams) ([]*dmarkets.Market, error) {
+	if params.filters.TagSlug != "" || params.filters.CreatedBy != "" {
+		return svc.ListMarkets(r.Context(), params.filters)
+	}
 	return svc.ListByStatus(r.Context(), params.filters.Status, params.page)
 }
 

--- a/backend/handlers/markets/market_tags.go
+++ b/backend/handlers/markets/market_tags.go
@@ -1,0 +1,57 @@
+package marketshandlers
+
+import (
+	"context"
+	"net/http"
+
+	"socialpredict/handlers"
+	"socialpredict/handlers/markets/dto"
+	dmarkets "socialpredict/internal/domain/markets"
+)
+
+type marketTagLister interface {
+	ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error)
+}
+
+func ListMarketTagsHandler(svc marketTagLister) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			_ = handlers.WriteFailure(w, http.StatusMethodNotAllowed, handlers.ReasonMethodNotAllowed)
+			return
+		}
+		if svc == nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		tags, err := svc.ListMarketTags(r.Context(), false)
+		if err != nil {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		response := dto.MarketTagsResponse{
+			Tags:  marketTagResponsesFromDomain(tags),
+			Total: len(tags),
+		}
+		_ = handlers.WriteResult(w, http.StatusOK, response)
+	}
+}
+
+func marketTagResponsesFromDomain(tags []dmarkets.MarketTag) []dto.MarketTagResponse {
+	responses := make([]dto.MarketTagResponse, 0, len(tags))
+	for _, tag := range tags {
+		responses = append(responses, marketTagResponseFromDomain(tag))
+	}
+	return responses
+}
+
+func marketTagResponseFromDomain(tag dmarkets.MarketTag) dto.MarketTagResponse {
+	return dto.MarketTagResponse{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+	}
+}

--- a/backend/handlers/markets/overview_helpers.go
+++ b/backend/handlers/markets/overview_helpers.go
@@ -71,6 +71,7 @@ func marketToResponse(market *dmarkets.Market) *dto.MarketResponse {
 		ResolutionResult:   market.ResolutionResult,
 		CreatedAt:          market.CreatedAt,
 		UpdatedAt:          market.UpdatedAt,
+		Tags:               marketTagResponsesFromDomain(market.Tags),
 	}
 }
 
@@ -105,6 +106,7 @@ func publicMarketResponseFromDomain(market *dmarkets.Market) dto.PublicMarketRes
 		CreatedAt:               market.CreatedAt,
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,
+		Tags:                    marketTagResponsesFromDomain(market.Tags),
 	}
 }
 

--- a/backend/handlers/markets/searchmarkets.go
+++ b/backend/handlers/markets/searchmarkets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"socialpredict/handlers"
 	"socialpredict/handlers/markets/dto"
@@ -120,10 +121,15 @@ func parseSearchFilters(r *http.Request) (dmarkets.SearchFilters, *httpError) {
 	}
 
 	return dmarkets.SearchFilters{
-		Status: status,
-		Limit:  parseLimit(r.URL.Query().Get("limit")),
-		Offset: parseOffset(r.URL.Query().Get("offset")),
+		Status:  status,
+		TagSlug: normalizeTagSlugParam(r.URL.Query().Get("tagSlug")),
+		Limit:   parseLimit(r.URL.Query().Get("limit")),
+		Offset:  parseOffset(r.URL.Query().Get("offset")),
 	}, nil
+}
+
+func normalizeTagSlugParam(value string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(value)), "-")
 }
 
 func searchMarkets(ctx context.Context, svc dmarkets.ServiceInterface, params searchRequestParams) (*dmarkets.SearchResults, error) {

--- a/backend/internal/domain/markets/market_creation.go
+++ b/backend/internal/domain/markets/market_creation.go
@@ -20,6 +20,10 @@ func (s *Service) CreateMarket(ctx context.Context, req MarketCreateRequest, cre
 	}
 
 	labels := s.creationPolicy.NormalizeLabels(req.YesLabel, req.NoLabel)
+	tagSlugs, err := s.validateCreateTagSlugs(ctx, req.TagSlugs)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := s.userService.ValidateUserExists(ctx, creatorUsername); err != nil {
 		return nil, ErrUserNotFound
@@ -40,6 +44,10 @@ func (s *Service) CreateMarket(ctx context.Context, req MarketCreateRequest, cre
 	}
 
 	if err := s.repo.Create(ctx, market); err != nil {
+		return nil, err
+	}
+
+	if err := s.assignTagsToMarket(ctx, market, tagSlugs, creatorUsername); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/domain/markets/market_tags.go
+++ b/backend/internal/domain/markets/market_tags.go
@@ -1,0 +1,254 @@
+package markets
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	MaxMarketTagSlugLength          = 64
+	MaxMarketTagDisplayNameLength   = 120
+	MaxMarketTagDescriptionLength   = 500
+	MaxMarketTagColorKeyLength      = 40
+	MaxMarketTagsPerMarket          = 5
+	MarketTagAssignmentSourceCreate = "moderator_create"
+)
+
+var (
+	marketTagSlugPattern     = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	marketTagColorKeyPattern = regexp.MustCompile(`^[a-z0-9_-]*$`)
+)
+
+// MarketTag is an admin-managed taxonomy label that can be attached to markets.
+type MarketTag struct {
+	ID          int64
+	Slug        string
+	DisplayName string
+	Description string
+	ColorKey    string
+	SortOrder   int
+	IsActive    bool
+	CreatedBy   string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// MarketTagRequest captures create/update input for a tag.
+type MarketTagRequest struct {
+	Slug        string
+	DisplayName string
+	Description string
+	ColorKey    string
+	SortOrder   int
+	IsActive    *bool
+}
+
+// MarketTagRepository persists market taxonomy tags and assignments.
+type MarketTagRepository interface {
+	ListMarketTags(ctx context.Context, includeInactive bool) ([]MarketTag, error)
+	CreateMarketTag(ctx context.Context, tag MarketTag) (*MarketTag, error)
+	UpdateMarketTag(ctx context.Context, slug string, update MarketTagRequest) (*MarketTag, error)
+	SetMarketTags(ctx context.Context, marketID int64, tagSlugs []string, assignedBy string, source string, assignedAt time.Time) ([]MarketTag, error)
+}
+
+func (s *Service) ListMarketTags(ctx context.Context, includeInactive bool) ([]MarketTag, error) {
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	return repo.ListMarketTags(ctx, includeInactive)
+}
+
+func (s *Service) CreateMarketTag(ctx context.Context, req MarketTagRequest, actorUsername string) (*MarketTag, error) {
+	tag, err := normalizeMarketTagRequest(req, actorUsername)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	return repo.CreateMarketTag(ctx, tag)
+}
+
+func (s *Service) UpdateMarketTag(ctx context.Context, slug string, req MarketTagRequest) (*MarketTag, error) {
+	slug = NormalizeMarketTagSlug(slug)
+	if slug == "" {
+		return nil, ErrInvalidInput
+	}
+	if err := validateMarketTagRequest(req, false); err != nil {
+		return nil, err
+	}
+	req.Slug = NormalizeMarketTagSlug(req.Slug)
+	if req.Slug != "" && req.Slug != slug {
+		return nil, ErrInvalidInput
+	}
+	req.Description = strings.TrimSpace(req.Description)
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
+	req.ColorKey = strings.TrimSpace(strings.ToLower(req.ColorKey))
+
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	return repo.UpdateMarketTag(ctx, slug, req)
+}
+
+func (s *Service) assignTagsToMarket(ctx context.Context, market *Market, tagSlugs []string, assignedBy string) error {
+	normalized, err := NormalizeMarketTagSlugs(tagSlugs)
+	if err != nil {
+		return err
+	}
+	if len(normalized) == 0 {
+		market.Tags = []MarketTag{}
+		return nil
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return err
+	}
+	tags, err := repo.SetMarketTags(ctx, market.ID, normalized, assignedBy, MarketTagAssignmentSourceCreate, s.clock.Now())
+	if err != nil {
+		return err
+	}
+	market.Tags = tags
+	return nil
+}
+
+func (s *Service) validateCreateTagSlugs(ctx context.Context, tagSlugs []string) ([]string, error) {
+	normalized, err := NormalizeMarketTagSlugs(tagSlugs)
+	if err != nil {
+		return nil, err
+	}
+	if len(normalized) == 0 {
+		return []string{}, nil
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	activeTags, err := repo.ListMarketTags(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	activeBySlug := make(map[string]bool, len(activeTags))
+	for _, tag := range activeTags {
+		activeBySlug[tag.Slug] = tag.IsActive
+	}
+	for _, slug := range normalized {
+		if !activeBySlug[slug] {
+			return nil, ErrInvalidInput
+		}
+	}
+	return normalized, nil
+}
+
+func (s *Service) marketTagRepository() (MarketTagRepository, error) {
+	if s == nil || s.repo == nil {
+		return nil, ErrInvalidInput
+	}
+	repo, ok := s.repo.(MarketTagRepository)
+	if !ok {
+		return nil, ErrInvalidInput
+	}
+	return repo, nil
+}
+
+func normalizeMarketTagRequest(req MarketTagRequest, actorUsername string) (MarketTag, error) {
+	if req.Slug == "" {
+		req.Slug = slugFromDisplayName(req.DisplayName)
+	}
+	if err := validateMarketTagRequest(req, true); err != nil {
+		return MarketTag{}, err
+	}
+	active := true
+	if req.IsActive != nil {
+		active = *req.IsActive
+	}
+	return MarketTag{
+		Slug:        NormalizeMarketTagSlug(req.Slug),
+		DisplayName: strings.TrimSpace(req.DisplayName),
+		Description: strings.TrimSpace(req.Description),
+		ColorKey:    strings.TrimSpace(strings.ToLower(req.ColorKey)),
+		SortOrder:   req.SortOrder,
+		IsActive:    active,
+		CreatedBy:   strings.TrimSpace(actorUsername),
+	}, nil
+}
+
+func validateMarketTagRequest(req MarketTagRequest, requireDisplayName bool) error {
+	slug := NormalizeMarketTagSlug(req.Slug)
+	displayName := strings.TrimSpace(req.DisplayName)
+	description := strings.TrimSpace(req.Description)
+	colorKey := strings.TrimSpace(strings.ToLower(req.ColorKey))
+
+	if slug != "" && (len(slug) > MaxMarketTagSlugLength || !marketTagSlugPattern.MatchString(slug)) {
+		return ErrInvalidInput
+	}
+	if requireDisplayName && displayName == "" {
+		return ErrInvalidInput
+	}
+	if displayName != "" && len(displayName) > MaxMarketTagDisplayNameLength {
+		return ErrInvalidInput
+	}
+	if len(description) > MaxMarketTagDescriptionLength {
+		return ErrInvalidInput
+	}
+	if len(colorKey) > MaxMarketTagColorKeyLength || !marketTagColorKeyPattern.MatchString(colorKey) {
+		return ErrInvalidInput
+	}
+	return nil
+}
+
+// NormalizeMarketTagSlug canonicalizes a tag slug for storage and comparisons.
+func NormalizeMarketTagSlug(slug string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(slug)), "-")
+}
+
+// NormalizeMarketTagSlugs canonicalizes, validates, de-duplicates, and sorts tag slugs.
+func NormalizeMarketTagSlugs(slugs []string) ([]string, error) {
+	if len(slugs) == 0 {
+		return []string{}, nil
+	}
+	seen := make(map[string]bool, len(slugs))
+	normalized := make([]string, 0, len(slugs))
+	for _, raw := range slugs {
+		slug := NormalizeMarketTagSlug(raw)
+		if slug == "" {
+			continue
+		}
+		if len(slug) > MaxMarketTagSlugLength || !marketTagSlugPattern.MatchString(slug) {
+			return nil, ErrInvalidInput
+		}
+		if !seen[slug] {
+			seen[slug] = true
+			normalized = append(normalized, slug)
+		}
+	}
+	if len(normalized) > MaxMarketTagsPerMarket {
+		return nil, ErrInvalidInput
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func slugFromDisplayName(displayName string) string {
+	displayName = strings.ToLower(strings.TrimSpace(displayName))
+	var builder strings.Builder
+	lastHyphen := false
+	for _, r := range displayName {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen {
+			builder.WriteRune('-')
+			lastHyphen = true
+		}
+	}
+	return NormalizeMarketTagSlug(builder.String())
+}

--- a/backend/internal/domain/markets/market_tags.go
+++ b/backend/internal/domain/markets/market_tags.go
@@ -15,6 +15,7 @@ const (
 	MaxMarketTagColorKeyLength      = 40
 	MaxMarketTagsPerMarket          = 5
 	MarketTagAssignmentSourceCreate = "moderator_create"
+	MarketTagAssignmentSourceAdmin  = "admin_adjust"
 )
 
 var (
@@ -95,6 +96,38 @@ func (s *Service) UpdateMarketTag(ctx context.Context, slug string, req MarketTa
 		return nil, err
 	}
 	return repo.UpdateMarketTag(ctx, slug, req)
+}
+
+func (s *Service) UpdateMarketTags(ctx context.Context, marketID int64, tagSlugs []string, actorUsername string) (*Market, error) {
+	if marketID <= 0 || strings.TrimSpace(actorUsername) == "" {
+		return nil, ErrInvalidInput
+	}
+
+	market, err := s.GetMarket(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch NormalizeLifecycleStatus(market.LifecycleStatus) {
+	case MarketLifecycleProposed, MarketLifecyclePublished:
+	default:
+		return nil, ErrInvalidState
+	}
+
+	normalized, err := s.validateCreateTagSlugs(ctx, tagSlugs)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := s.marketTagRepository()
+	if err != nil {
+		return nil, err
+	}
+	tags, err := repo.SetMarketTags(ctx, marketID, normalized, actorUsername, MarketTagAssignmentSourceAdmin, s.clock.Now())
+	if err != nil {
+		return nil, err
+	}
+	market.Tags = tags
+	return market, nil
 }
 
 func (s *Service) assignTagsToMarket(ctx context.Context, market *Market, tagSlugs []string, assignedBy string) error {

--- a/backend/internal/domain/markets/models.go
+++ b/backend/internal/domain/markets/models.go
@@ -33,6 +33,7 @@ type Market struct {
 	InitialProbability      float64
 	UTCOffset               int
 	StewardshipAudits       []MarketStewardshipAuditRecord
+	Tags                    []MarketTag
 }
 
 // CreatedBy reports whether the market belongs to the supplied creator username.
@@ -87,6 +88,7 @@ type MarketCreateRequest struct {
 	ResolutionDateTime time.Time
 	YesLabel           string
 	NoLabel            string
+	TagSlugs           []string
 }
 
 // HasCustomLabels reports whether the create request includes either custom label.
@@ -194,6 +196,7 @@ type PublicMarket struct {
 	NoLabel                 string
 	Status                  string
 	LifecycleStatus         string
+	Tags                    []MarketTag
 }
 
 // Resolved reports whether the public market already has a terminal resolution.
@@ -228,6 +231,7 @@ func copyPublicMarket(target *PublicMarket, market *Market) *PublicMarket {
 		NoLabel:                 market.NoLabel,
 		Status:                  market.Status,
 		LifecycleStatus:         market.LifecycleStatus,
+		Tags:                    append([]MarketTag(nil), market.Tags...),
 	}
 
 	return target

--- a/backend/internal/domain/markets/service.go
+++ b/backend/internal/domain/markets/service.go
@@ -166,15 +166,17 @@ type ListFilters struct {
 	Status    string
 	Query     string
 	CreatedBy string
+	TagSlug   string
 	Limit     int
 	Offset    int
 }
 
 // SearchFilters represents filters for searching markets.
 type SearchFilters struct {
-	Status string
-	Limit  int
-	Offset int
+	Status  string
+	TagSlug string
+	Limit   int
+	Offset  int
 }
 
 // SearchResults represents the result of a market search with fallback.

--- a/backend/internal/domain/markets/service_policies.go
+++ b/backend/internal/domain/markets/service_policies.go
@@ -235,9 +235,10 @@ func (defaultSearchPolicy) NewSearchResults(query string, status string, primary
 
 func (defaultSearchPolicy) BuildFallbackFilters(primary SearchFilters) SearchFilters {
 	return SearchFilters{
-		Status: "",
-		Limit:  primary.Limit * 2,
-		Offset: 0,
+		Status:  "",
+		TagSlug: primary.TagSlug,
+		Limit:   primary.Limit * 2,
+		Offset:  0,
 	}
 }
 

--- a/backend/internal/domain/markets/service_probability_test.go
+++ b/backend/internal/domain/markets/service_probability_test.go
@@ -28,6 +28,10 @@ type projectionRepo struct {
 	approveMarketFunc            func(context.Context, int64, string, time.Time) error
 	rejectMarketFunc             func(context.Context, int64, string, time.Time, string) error
 	reassignMarketStewardFunc    func(context.Context, int64, string, string, string, string, time.Time) error
+	listMarketTagsFunc           func(context.Context, bool) ([]markets.MarketTag, error)
+	createMarketTagFunc          func(context.Context, markets.MarketTag) (*markets.MarketTag, error)
+	updateMarketTagFunc          func(context.Context, string, markets.MarketTagRequest) (*markets.MarketTag, error)
+	setMarketTagsFunc            func(context.Context, int64, []string, string, string, time.Time) ([]markets.MarketTag, error)
 }
 
 func newProjectionRepo(opts ...func(*projectionRepo)) *projectionRepo {
@@ -71,6 +75,18 @@ func newProjectionRepo(opts ...func(*projectionRepo)) *projectionRepo {
 		},
 		reassignMarketStewardFunc: func(context.Context, int64, string, string, string, string, time.Time) error {
 			return errUnexpectedMarketsTestCall
+		},
+		listMarketTagsFunc: func(context.Context, bool) ([]markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
+		},
+		createMarketTagFunc: func(context.Context, markets.MarketTag) (*markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
+		},
+		updateMarketTagFunc: func(context.Context, string, markets.MarketTagRequest) (*markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
+		},
+		setMarketTagsFunc: func(context.Context, int64, []string, string, string, time.Time) ([]markets.MarketTag, error) {
+			return nil, errUnexpectedMarketsTestCall
 		},
 	}
 	for _, opt := range opts {
@@ -160,6 +176,34 @@ func (r *projectionRepo) ReassignMarketSteward(ctx context.Context, id int64, fr
 		return errUnexpectedMarketsTestCall
 	}
 	return r.reassignMarketStewardFunc(ctx, id, fromStewardUsername, toStewardUsername, actorUsername, reason, changedAt)
+}
+
+func (r *projectionRepo) ListMarketTags(ctx context.Context, includeInactive bool) ([]markets.MarketTag, error) {
+	if r.listMarketTagsFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.listMarketTagsFunc(ctx, includeInactive)
+}
+
+func (r *projectionRepo) CreateMarketTag(ctx context.Context, tag markets.MarketTag) (*markets.MarketTag, error) {
+	if r.createMarketTagFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.createMarketTagFunc(ctx, tag)
+}
+
+func (r *projectionRepo) UpdateMarketTag(ctx context.Context, slug string, update markets.MarketTagRequest) (*markets.MarketTag, error) {
+	if r.updateMarketTagFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.updateMarketTagFunc(ctx, slug, update)
+}
+
+func (r *projectionRepo) SetMarketTags(ctx context.Context, marketID int64, tagSlugs []string, assignedBy string, source string, assignedAt time.Time) ([]markets.MarketTag, error) {
+	if r.setMarketTagsFunc == nil {
+		return nil, errUnexpectedMarketsTestCall
+	}
+	return r.setMarketTagsFunc(ctx, marketID, tagSlugs, assignedBy, source, assignedAt)
 }
 
 func (r *projectionRepo) GetUserPosition(ctx context.Context, marketID int64, username string) (*markets.UserPosition, error) {

--- a/backend/internal/domain/markets/service_search_test.go
+++ b/backend/internal/domain/markets/service_search_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	markets "socialpredict/internal/domain/markets"
+	"socialpredict/models"
 	"socialpredict/models/modelstesting"
 
 	"gorm.io/gorm"
@@ -27,6 +28,27 @@ func seedSearchMarkets(t *testing.T, db *gorm.DB, username string) {
 		if err := db.Create(market).Error; err != nil {
 			t.Fatalf("seed market: %v", err)
 		}
+	}
+}
+
+func assignSearchMarketTag(t *testing.T, db *gorm.DB, marketID int64, slug string) {
+	t.Helper()
+
+	tag := models.MarketTag{
+		Slug:        slug,
+		DisplayName: slug,
+		IsActive:    true,
+	}
+	if err := db.Create(&tag).Error; err != nil {
+		t.Fatalf("create market tag: %v", err)
+	}
+	assignment := models.MarketTagAssignment{
+		MarketID: marketID,
+		TagID:    tag.ID,
+		Source:   markets.MarketTagAssignmentSourceAdmin,
+	}
+	if err := db.Create(&assignment).Error; err != nil {
+		t.Fatalf("create market tag assignment: %v", err)
 	}
 }
 
@@ -125,6 +147,43 @@ func TestServiceSearchMarketsFiltersByStatus(t *testing.T) {
 				t.Fatalf("expected fallback results, got none")
 			}
 		})
+	}
+}
+
+func TestServiceSearchAndListMarketsFilterByTagSlug(t *testing.T) {
+	service, db, _ := setupServiceWithDB(t)
+
+	user := modelstesting.GenerateUser("tag_filter_user", 0)
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	seedSearchMarkets(t, db, user.Username)
+	assignSearchMarketTag(t, db, 1, "bitcoin")
+	assignSearchMarketTag(t, db, 4, "stocks")
+
+	searchResult, err := service.SearchMarkets(context.Background(), "bitcoin", markets.SearchFilters{
+		Status:  "all",
+		TagSlug: "bitcoin",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMarkets returned error: %v", err)
+	}
+	if len(searchResult.PrimaryResults) != 1 || searchResult.PrimaryResults[0].ID != 1 {
+		t.Fatalf("expected only bitcoin-tagged search result, got %+v", searchResult.PrimaryResults)
+	}
+
+	listResult, err := service.ListMarkets(context.Background(), markets.ListFilters{
+		Status:  "active",
+		TagSlug: "stocks",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListMarkets returned error: %v", err)
+	}
+	if len(listResult) != 1 || listResult[0].ID != 4 {
+		t.Fatalf("expected only stocks-tagged list result, got %+v", listResult)
 	}
 }
 

--- a/backend/internal/domain/markets/service_tags_test.go
+++ b/backend/internal/domain/markets/service_tags_test.go
@@ -1,0 +1,141 @@
+package markets_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	markets "socialpredict/internal/domain/markets"
+	dusers "socialpredict/internal/domain/users"
+)
+
+func TestCreateMarketAssignsValidatedActiveTags(t *testing.T) {
+	now := marketsTestTime()
+	var assignedMarketID int64
+	var assignedSlugs []string
+	var assignedBy string
+	var assignmentSource string
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.listMarketTagsFunc = func(_ context.Context, includeInactive bool) ([]markets.MarketTag, error) {
+			if includeInactive {
+				t.Fatalf("create validation should request active tags only")
+			}
+			return []markets.MarketTag{
+				{ID: 1, Slug: "politics", DisplayName: "Politics", IsActive: true},
+				{ID: 2, Slug: "sports", DisplayName: "Sports", IsActive: true},
+			}, nil
+		}
+		repo.createFunc = func(_ context.Context, market *markets.Market) error {
+			market.ID = 123
+			return nil
+		}
+		repo.setMarketTagsFunc = func(_ context.Context, marketID int64, tagSlugs []string, by string, source string, assignedAt time.Time) ([]markets.MarketTag, error) {
+			assignedMarketID = marketID
+			assignedSlugs = append([]string(nil), tagSlugs...)
+			assignedBy = by
+			assignmentSource = source
+			if !assignedAt.Equal(now) {
+				t.Fatalf("assignedAt = %s, want %s", assignedAt, now)
+			}
+			return []markets.MarketTag{{ID: 1, Slug: "politics", DisplayName: "Politics", IsActive: true}}, nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*dusers.PublicUser, error) {
+			return &dusers.PublicUser{Username: username, UserType: string(dusers.UserTypeModerator), ModeratorStatus: dusers.ModeratorStatusActive}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{GameMode: "moderator", MarketApprovalRequired: true})
+
+	req := validCreateRequest(now)
+	req.TagSlugs = []string{"Politics", "sports", "politics"}
+	market, err := service.CreateMarket(context.Background(), req, "moderator")
+	if err != nil {
+		t.Fatalf("CreateMarket returned error: %v", err)
+	}
+	if assignedMarketID != 123 || assignedBy != "moderator" || assignmentSource != markets.MarketTagAssignmentSourceCreate {
+		t.Fatalf("unexpected assignment metadata id=%d by=%q source=%q", assignedMarketID, assignedBy, assignmentSource)
+	}
+	if !reflect.DeepEqual(assignedSlugs, []string{"politics", "sports"}) {
+		t.Fatalf("assigned slugs = %+v", assignedSlugs)
+	}
+	if len(market.Tags) != 1 || market.Tags[0].Slug != "politics" {
+		t.Fatalf("expected returned market tags, got %+v", market.Tags)
+	}
+}
+
+func TestCreateMarketRejectsUnknownOrInactiveTagBeforeCreate(t *testing.T) {
+	now := marketsTestTime()
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.listMarketTagsFunc = func(context.Context, bool) ([]markets.MarketTag, error) {
+			return []markets.MarketTag{{ID: 1, Slug: "active", DisplayName: "Active", IsActive: true}}, nil
+		}
+		repo.createFunc = func(context.Context, *markets.Market) error {
+			t.Fatalf("market should not be created when tags are invalid")
+			return nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*dusers.PublicUser, error) {
+			return &dusers.PublicUser{Username: username, UserType: string(dusers.UserTypeModerator), ModeratorStatus: dusers.ModeratorStatusActive}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(now), markets.Config{GameMode: "moderator", MarketApprovalRequired: true})
+
+	req := validCreateRequest(now)
+	req.TagSlugs = []string{"missing"}
+	_, err := service.CreateMarket(context.Background(), req, "moderator")
+	if !errors.Is(err, markets.ErrInvalidInput) {
+		t.Fatalf("CreateMarket error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestCreateAndUpdateMarketTagNormalizeAndValidate(t *testing.T) {
+	now := marketsTestTime()
+	var createdBy string
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.createMarketTagFunc = func(_ context.Context, tag markets.MarketTag) (*markets.MarketTag, error) {
+			createdBy = tag.CreatedBy
+			if tag.Slug != "public-health" || tag.DisplayName != "Public Health" || !tag.IsActive {
+				t.Fatalf("unexpected create tag: %+v", tag)
+			}
+			tag.ID = 7
+			return &tag, nil
+		}
+		repo.updateMarketTagFunc = func(_ context.Context, slug string, req markets.MarketTagRequest) (*markets.MarketTag, error) {
+			if slug != "public-health" || req.DisplayName != "Health" || req.IsActive == nil || *req.IsActive {
+				t.Fatalf("unexpected update args slug=%q req=%+v", slug, req)
+			}
+			return &markets.MarketTag{ID: 7, Slug: slug, DisplayName: req.DisplayName, IsActive: *req.IsActive}, nil
+		}
+	})
+	service := markets.NewService(repo, newNoopUserService(), newFixedClock(now), markets.Config{})
+
+	created, err := service.CreateMarketTag(context.Background(), markets.MarketTagRequest{DisplayName: "Public Health"}, "admin")
+	if err != nil {
+		t.Fatalf("CreateMarketTag returned error: %v", err)
+	}
+	if created.ID != 7 || createdBy != "admin" {
+		t.Fatalf("unexpected created tag: %+v by=%q", created, createdBy)
+	}
+
+	active := false
+	updated, err := service.UpdateMarketTag(context.Background(), "Public-Health", markets.MarketTagRequest{DisplayName: "Health", IsActive: &active})
+	if err != nil {
+		t.Fatalf("UpdateMarketTag returned error: %v", err)
+	}
+	if updated.DisplayName != "Health" || updated.IsActive {
+		t.Fatalf("unexpected updated tag: %+v", updated)
+	}
+}
+
+func TestNormalizeMarketTagSlugsRejectsTooManyOrInvalidSlugs(t *testing.T) {
+	if _, err := markets.NormalizeMarketTagSlugs([]string{"valid", "not valid"}); !errors.Is(err, markets.ErrInvalidInput) {
+		t.Fatalf("invalid slug error = %v, want ErrInvalidInput", err)
+	}
+	if _, err := markets.NormalizeMarketTagSlugs([]string{"a", "b", "c", "d", "e", "f"}); !errors.Is(err, markets.ErrInvalidInput) {
+		t.Fatalf("too many tags error = %v, want ErrInvalidInput", err)
+	}
+}

--- a/backend/internal/domain/markets/service_tags_test.go
+++ b/backend/internal/domain/markets/service_tags_test.go
@@ -131,6 +131,72 @@ func TestCreateAndUpdateMarketTagNormalizeAndValidate(t *testing.T) {
 	}
 }
 
+func TestUpdateMarketTagsRewritesProposedOrPublishedAssignments(t *testing.T) {
+	now := marketsTestTime()
+	var assignedMarketID int64
+	var assignedSlugs []string
+	var assignedBy string
+	var assignmentSource string
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.getByIDFunc = func(_ context.Context, marketID int64) (*markets.Market, error) {
+			return &markets.Market{ID: marketID, LifecycleStatus: markets.MarketLifecyclePublished, Status: markets.MarketStatusActive}, nil
+		}
+		repo.listMarketTagsFunc = func(_ context.Context, includeInactive bool) ([]markets.MarketTag, error) {
+			if includeInactive {
+				t.Fatalf("admin market tag assignment validation should request active tags only")
+			}
+			return []markets.MarketTag{
+				{ID: 1, Slug: "policy", DisplayName: "Policy", IsActive: true},
+				{ID: 2, Slug: "sports", DisplayName: "Sports", IsActive: true},
+			}, nil
+		}
+		repo.setMarketTagsFunc = func(_ context.Context, marketID int64, tagSlugs []string, by string, source string, assignedAt time.Time) ([]markets.MarketTag, error) {
+			assignedMarketID = marketID
+			assignedSlugs = append([]string(nil), tagSlugs...)
+			assignedBy = by
+			assignmentSource = source
+			if !assignedAt.Equal(now) {
+				t.Fatalf("assignedAt = %s, want %s", assignedAt, now)
+			}
+			return []markets.MarketTag{{ID: 1, Slug: "policy", DisplayName: "Policy", IsActive: true}}, nil
+		}
+	})
+	service := markets.NewService(repo, newNoopUserService(), newFixedClock(now), markets.Config{})
+
+	market, err := service.UpdateMarketTags(context.Background(), 99, []string{"sports", "policy"}, "admin")
+	if err != nil {
+		t.Fatalf("UpdateMarketTags returned error: %v", err)
+	}
+	if assignedMarketID != 99 || assignedBy != "admin" || assignmentSource != markets.MarketTagAssignmentSourceAdmin {
+		t.Fatalf("unexpected assignment metadata id=%d by=%q source=%q", assignedMarketID, assignedBy, assignmentSource)
+	}
+	if !reflect.DeepEqual(assignedSlugs, []string{"policy", "sports"}) {
+		t.Fatalf("assigned slugs = %+v", assignedSlugs)
+	}
+	if len(market.Tags) != 1 || market.Tags[0].Slug != "policy" {
+		t.Fatalf("expected returned market tags, got %+v", market.Tags)
+	}
+}
+
+func TestUpdateMarketTagsRejectsRejectedMarkets(t *testing.T) {
+	now := marketsTestTime()
+	repo := newProjectionRepo(func(repo *projectionRepo) {
+		repo.getByIDFunc = func(_ context.Context, marketID int64) (*markets.Market, error) {
+			return &markets.Market{ID: marketID, LifecycleStatus: markets.MarketLifecycleRejected, Status: markets.MarketLifecycleRejected}, nil
+		}
+		repo.listMarketTagsFunc = func(context.Context, bool) ([]markets.MarketTag, error) {
+			t.Fatalf("rejected market should fail before tag validation")
+			return nil, nil
+		}
+	})
+	service := markets.NewService(repo, newNoopUserService(), newFixedClock(now), markets.Config{})
+
+	_, err := service.UpdateMarketTags(context.Background(), 99, []string{"policy"}, "admin")
+	if !errors.Is(err, markets.ErrInvalidState) {
+		t.Fatalf("UpdateMarketTags error = %v, want ErrInvalidState", err)
+	}
+}
+
 func TestNormalizeMarketTagSlugsRejectsTooManyOrInvalidSlugs(t *testing.T) {
 	if _, err := markets.NormalizeMarketTagSlugs([]string{"valid", "not valid"}); !errors.Is(err, markets.ErrInvalidInput) {
 		t.Fatalf("invalid slug error = %v, want ErrInvalidInput", err)

--- a/backend/internal/domain/users/service.go
+++ b/backend/internal/domain/users/service.go
@@ -110,6 +110,7 @@ type ServiceDependencies struct {
 // ListFilters represents filters for listing users
 type ListFilters struct {
 	UserType string
+	Query    string
 	Limit    int
 	Offset   int
 }

--- a/backend/internal/repository/markets/market_tags.go
+++ b/backend/internal/repository/markets/market_tags.go
@@ -1,0 +1,213 @@
+package markets
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	dmarkets "socialpredict/internal/domain/markets"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+func (r *GormRepository) ListMarketTags(ctx context.Context, includeInactive bool) ([]dmarkets.MarketTag, error) {
+	query := r.db.WithContext(ctx).Model(&models.MarketTag{})
+	if !includeInactive {
+		query = query.Where("is_active = ?", true)
+	}
+	query = query.Order("sort_order ASC, display_name ASC, slug ASC")
+
+	var tags []models.MarketTag
+	if err := query.Find(&tags).Error; err != nil {
+		return nil, err
+	}
+	return modelTagsToDomain(tags), nil
+}
+
+func (r *GormRepository) CreateMarketTag(ctx context.Context, tag dmarkets.MarketTag) (*dmarkets.MarketTag, error) {
+	dbTag := domainTagToModel(tag)
+	if err := r.db.WithContext(ctx).
+		Select("Slug", "DisplayName", "Description", "ColorKey", "SortOrder", "IsActive", "CreatedBy").
+		Create(&dbTag).Error; err != nil {
+		return nil, err
+	}
+	if !tag.IsActive {
+		if err := r.db.WithContext(ctx).Model(&models.MarketTag{}).
+			Where("id = ?", dbTag.ID).
+			Update("is_active", false).Error; err != nil {
+			return nil, err
+		}
+		if err := r.db.WithContext(ctx).First(&dbTag, dbTag.ID).Error; err != nil {
+			return nil, err
+		}
+	}
+	out := modelTagToDomain(dbTag)
+	return &out, nil
+}
+
+func (r *GormRepository) UpdateMarketTag(ctx context.Context, slug string, update dmarkets.MarketTagRequest) (*dmarkets.MarketTag, error) {
+	updates := map[string]any{
+		"updated_at": time.Now(),
+	}
+	if update.DisplayName != "" {
+		updates["display_name"] = update.DisplayName
+	}
+	updates["description"] = update.Description
+	updates["color_key"] = update.ColorKey
+	updates["sort_order"] = update.SortOrder
+	if update.IsActive != nil {
+		updates["is_active"] = *update.IsActive
+	}
+
+	result := r.db.WithContext(ctx).Model(&models.MarketTag{}).
+		Where("slug = ?", slug).
+		Updates(updates)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, dmarkets.ErrInvalidInput
+	}
+
+	var dbTag models.MarketTag
+	if err := r.db.WithContext(ctx).Where("slug = ?", slug).First(&dbTag).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, dmarkets.ErrInvalidInput
+		}
+		return nil, err
+	}
+	out := modelTagToDomain(dbTag)
+	return &out, nil
+}
+
+func (r *GormRepository) SetMarketTags(ctx context.Context, marketID int64, tagSlugs []string, assignedBy string, source string, assignedAt time.Time) ([]dmarkets.MarketTag, error) {
+	if marketID <= 0 {
+		return nil, dmarkets.ErrInvalidInput
+	}
+	normalized, err := dmarkets.NormalizeMarketTagSlugs(tagSlugs)
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []models.MarketTag
+	if len(normalized) > 0 {
+		if err := r.db.WithContext(ctx).
+			Where("slug IN ? AND is_active = ?", normalized, true).
+			Order("sort_order ASC, display_name ASC, slug ASC").
+			Find(&tags).Error; err != nil {
+			return nil, err
+		}
+		if len(tags) != len(normalized) {
+			return nil, dmarkets.ErrInvalidInput
+		}
+	}
+
+	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("market_id = ?", marketID).Delete(&models.MarketTagAssignment{}).Error; err != nil {
+			return err
+		}
+		for _, tag := range tags {
+			assignment := models.MarketTagAssignment{
+				MarketID:   marketID,
+				TagID:      tag.ID,
+				AssignedBy: assignedBy,
+				Source:     source,
+			}
+			assignment.CreatedAt = assignedAt
+			assignment.UpdatedAt = assignedAt
+			if err := tx.Create(&assignment).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return modelTagsToDomain(tags), nil
+}
+
+func (r *GormRepository) hydrateTagsForMarkets(ctx context.Context, markets []*dmarkets.Market) error {
+	if len(markets) == 0 {
+		return nil
+	}
+
+	marketIDs := make([]int64, 0, len(markets))
+	marketByID := make(map[int64]*dmarkets.Market, len(markets))
+	for _, market := range markets {
+		if market == nil {
+			continue
+		}
+		marketIDs = append(marketIDs, market.ID)
+		marketByID[market.ID] = market
+	}
+	if len(marketIDs) == 0 {
+		return nil
+	}
+
+	rows := []struct {
+		MarketID int64
+		models.MarketTag
+	}{}
+	if err := r.db.WithContext(ctx).
+		Table("market_tag_assignments").
+		Select("market_tag_assignments.market_id, market_tags.*").
+		Joins("JOIN market_tags ON market_tags.id = market_tag_assignments.tag_id").
+		Where("market_tag_assignments.market_id IN ?", marketIDs).
+		Order("market_tags.sort_order ASC, market_tags.display_name ASC, market_tags.slug ASC").
+		Scan(&rows).Error; err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+		market := marketByID[row.MarketID]
+		if market == nil {
+			continue
+		}
+		tag := modelTagToDomain(row.MarketTag)
+		market.Tags = append(market.Tags, tag)
+	}
+	for _, market := range markets {
+		if market != nil && market.Tags == nil {
+			market.Tags = []dmarkets.MarketTag{}
+		}
+	}
+	return nil
+}
+
+func domainTagToModel(tag dmarkets.MarketTag) models.MarketTag {
+	return models.MarketTag{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+		CreatedBy:   tag.CreatedBy,
+	}
+}
+
+func modelTagToDomain(tag models.MarketTag) dmarkets.MarketTag {
+	return dmarkets.MarketTag{
+		ID:          tag.ID,
+		Slug:        tag.Slug,
+		DisplayName: tag.DisplayName,
+		Description: tag.Description,
+		ColorKey:    tag.ColorKey,
+		SortOrder:   tag.SortOrder,
+		IsActive:    tag.IsActive,
+		CreatedBy:   tag.CreatedBy,
+		CreatedAt:   tag.CreatedAt,
+		UpdatedAt:   tag.UpdatedAt,
+	}
+}
+
+func modelTagsToDomain(tags []models.MarketTag) []dmarkets.MarketTag {
+	out := make([]dmarkets.MarketTag, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, modelTagToDomain(tag))
+	}
+	return out
+}

--- a/backend/internal/repository/markets/market_tags.go
+++ b/backend/internal/repository/markets/market_tags.go
@@ -104,7 +104,7 @@ func (r *GormRepository) SetMarketTags(ctx context.Context, marketID int64, tagS
 	}
 
 	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("market_id = ?", marketID).Delete(&models.MarketTagAssignment{}).Error; err != nil {
+		if err := tx.Unscoped().Where("market_id = ?", marketID).Delete(&models.MarketTagAssignment{}).Error; err != nil {
 			return err
 		}
 		for _, tag := range tags {

--- a/backend/internal/repository/markets/repository.go
+++ b/backend/internal/repository/markets/repository.go
@@ -120,8 +120,9 @@ func (r *GormRepository) List(ctx context.Context, filters dmarkets.ListFilters)
 
 	query = applyListStatusFilter(query, filters.Status)
 	query = applyCreatedByFilter(query, filters.CreatedBy)
+	query = applyTagSlugFilter(query, filters.TagSlug)
 	query = applyPagination(query, filters.Limit, filters.Offset)
-	query = query.Order("created_at DESC")
+	query = query.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := query.Find(&dbMarkets).Error; err != nil {
@@ -141,7 +142,7 @@ func (r *GormRepository) ListByStatus(ctx context.Context, status string, p dmar
 
 	query = applyStatusByResolution(query, status, time.Now())
 	query = applyPagination(query, p.Limit, p.Offset)
-	query = query.Order("created_at DESC")
+	query = query.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := query.Find(&dbMarkets).Error; err != nil {
@@ -164,7 +165,7 @@ func (r *GormRepository) ListByLifecycle(ctx context.Context, filters dmarkets.L
 	query = applyLifecycleSearchTerm(query, filters.Query)
 	query = applyCreatedByFilter(query, filters.CreatedBy)
 	query = applyPagination(query, filters.Limit, filters.Offset)
-	query = query.Order("created_at DESC")
+	query = query.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := query.Find(&dbMarkets).Error; err != nil {
@@ -227,6 +228,18 @@ func applyCreatedByFilter(query *gorm.DB, createdBy string) *gorm.DB {
 	return query.Where("creator_username = ?", createdBy)
 }
 
+func applyTagSlugFilter(query *gorm.DB, tagSlug string) *gorm.DB {
+	tagSlug = strings.Trim(strings.ToLower(strings.TrimSpace(tagSlug)), "-")
+	if tagSlug == "" {
+		return query
+	}
+	return query.
+		Joins("JOIN market_tag_assignments ON market_tag_assignments.market_id = markets.id AND market_tag_assignments.deleted_at IS NULL").
+		Joins("JOIN market_tags ON market_tags.id = market_tag_assignments.tag_id AND market_tags.deleted_at IS NULL").
+		Where("market_tags.slug = ?", tagSlug).
+		Distinct("markets.*")
+}
+
 func applyStatusByResolution(query *gorm.DB, status string, now time.Time) *gorm.DB {
 	switch status {
 	case dmarkets.MarketStatusActive:
@@ -246,8 +259,9 @@ func (r *GormRepository) Search(ctx context.Context, query string, filters dmark
 
 	dbQuery = applySearchTerm(dbQuery, query)
 	dbQuery = applyStatusFilter(dbQuery, filters.Status)
+	dbQuery = applyTagSlugFilter(dbQuery, filters.TagSlug)
 	dbQuery = applyPagination(dbQuery, filters.Limit, filters.Offset)
-	dbQuery = dbQuery.Order("created_at DESC")
+	dbQuery = dbQuery.Order("markets.created_at DESC")
 
 	var dbMarkets []models.Market
 	if err := dbQuery.Find(&dbMarkets).Error; err != nil {
@@ -264,7 +278,7 @@ func (r *GormRepository) Search(ctx context.Context, query string, filters dmark
 func applySearchTerm(dbQuery *gorm.DB, query string) *gorm.DB {
 	searchTerm := strings.ToLower(query)
 	searchPattern := "%" + searchTerm + "%"
-	return dbQuery.Where("(LOWER(question_title) LIKE ? OR LOWER(description) LIKE ?)", searchPattern, searchPattern)
+	return dbQuery.Where("(LOWER(markets.question_title) LIKE ? OR LOWER(markets.description) LIKE ?)", searchPattern, searchPattern)
 }
 
 func applyStatusFilter(dbQuery *gorm.DB, status string) *gorm.DB {

--- a/backend/internal/repository/markets/repository.go
+++ b/backend/internal/repository/markets/repository.go
@@ -50,7 +50,11 @@ func (r *GormRepository) GetByID(ctx context.Context, id int64) (*dmarkets.Marke
 		return nil, err
 	}
 
-	return r.modelToDomain(&dbMarket), nil
+	market := r.modelToDomain(&dbMarket)
+	if err := r.hydrateTagsForMarkets(ctx, []*dmarkets.Market{market}); err != nil {
+		return nil, err
+	}
+	return market, nil
 }
 
 // GetPublicMarket retrieves a market with public-facing attributes.
@@ -63,6 +67,10 @@ func (r *GormRepository) GetPublicMarket(ctx context.Context, marketID int64) (*
 		return nil, err
 	}
 
+	domainMarket := r.modelToDomain(&market)
+	if err := r.hydrateTagsForMarkets(ctx, []*dmarkets.Market{domainMarket}); err != nil {
+		return nil, err
+	}
 	return &dmarkets.PublicMarket{
 		ID:                      market.ID,
 		QuestionTitle:           market.QuestionTitle,
@@ -75,12 +83,13 @@ func (r *GormRepository) GetPublicMarket(ctx context.Context, marketID int64) (*
 		ResolutionResult:        market.ResolutionResult,
 		InitialProbability:      market.InitialProbability,
 		CreatorUsername:         market.CreatorUsername,
-		StewardUsername:         r.modelToDomain(&market).CurrentStewardUsername(),
+		StewardUsername:         domainMarket.CurrentStewardUsername(),
 		CreatedAt:               market.CreatedAt,
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,
-		Status:                  r.modelToDomain(&market).Status,
+		Status:                  domainMarket.Status,
 		LifecycleStatus:         dmarkets.NormalizeLifecycleStatus(market.LifecycleStatus),
+		Tags:                    domainMarket.Tags,
 	}, nil
 }
 
@@ -119,7 +128,11 @@ func (r *GormRepository) List(ctx context.Context, filters dmarkets.ListFilters)
 		return nil, err
 	}
 
-	return r.mapMarkets(dbMarkets), nil
+	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
+	return markets, nil
 }
 
 // ListByStatus retrieves markets filtered by status with pagination
@@ -135,7 +148,11 @@ func (r *GormRepository) ListByStatus(ctx context.Context, status string, p dmar
 		return nil, err
 	}
 
-	return r.mapMarkets(dbMarkets), nil
+	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
+	return markets, nil
 }
 
 // ListByLifecycle retrieves lifecycle queues that are intentionally excluded
@@ -155,6 +172,9 @@ func (r *GormRepository) ListByLifecycle(ctx context.Context, filters dmarkets.L
 	}
 
 	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
 	if err := r.hydrateStewardshipAudits(ctx, markets); err != nil {
 		return nil, err
 	}
@@ -234,7 +254,11 @@ func (r *GormRepository) Search(ctx context.Context, query string, filters dmark
 		return nil, err
 	}
 
-	return r.mapMarkets(dbMarkets), nil
+	markets := r.mapMarkets(dbMarkets)
+	if err := r.hydrateTagsForMarkets(ctx, markets); err != nil {
+		return nil, err
+	}
+	return markets, nil
 }
 
 func applySearchTerm(dbQuery *gorm.DB, query string) *gorm.DB {
@@ -647,6 +671,7 @@ func (r *GormRepository) modelToDomain(dbMarket *models.Market) *dmarkets.Market
 		UpdatedAt:               dbMarket.UpdatedAt,
 		InitialProbability:      dbMarket.InitialProbability,
 		UTCOffset:               dbMarket.UTCOffset,
+		Tags:                    []dmarkets.MarketTag{},
 	}
 }
 

--- a/backend/internal/repository/markets/repository_test.go
+++ b/backend/internal/repository/markets/repository_test.go
@@ -563,3 +563,89 @@ func TestGormRepositoryListByLifecycleAllExcludesRejectedAndSearchesOperationalM
 		}
 	}
 }
+
+func TestGormRepositoryMarketTagsCreateListUpdateAssignAndHydrate(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("tag_creator", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+	market := modelstesting.GenerateMarket(801, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+
+	politics, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "politics", DisplayName: "Politics", IsActive: true, SortOrder: 2, CreatedBy: "admin"})
+	if err != nil {
+		t.Fatalf("CreateMarketTag politics: %v", err)
+	}
+	if _, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "sports", DisplayName: "Sports", IsActive: true, SortOrder: 1, CreatedBy: "admin"}); err != nil {
+		t.Fatalf("CreateMarketTag sports: %v", err)
+	}
+
+	activeTags, err := repo.ListMarketTags(ctx, false)
+	if err != nil {
+		t.Fatalf("ListMarketTags returned error: %v", err)
+	}
+	if len(activeTags) != 2 || activeTags[0].Slug != "sports" || activeTags[1].Slug != "politics" {
+		t.Fatalf("expected sorted active tags, got %+v", activeTags)
+	}
+
+	inactive := false
+	updated, err := repo.UpdateMarketTag(ctx, politics.Slug, dmarkets.MarketTagRequest{DisplayName: "Civic life", IsActive: &inactive})
+	if err != nil {
+		t.Fatalf("UpdateMarketTag returned error: %v", err)
+	}
+	if updated.DisplayName != "Civic life" || updated.IsActive {
+		t.Fatalf("unexpected updated tag: %+v", updated)
+	}
+
+	assigned, err := repo.SetMarketTags(ctx, market.ID, []string{"sports"}, creator.Username, dmarkets.MarketTagAssignmentSourceCreate, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SetMarketTags returned error: %v", err)
+	}
+	if len(assigned) != 1 || assigned[0].Slug != "sports" {
+		t.Fatalf("unexpected assigned tags: %+v", assigned)
+	}
+
+	got, err := repo.GetByID(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0].Slug != "sports" {
+		t.Fatalf("expected hydrated tag on GetByID, got %+v", got.Tags)
+	}
+
+	listed, err := repo.List(ctx, dmarkets.ListFilters{Limit: 10})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(listed) != 1 || len(listed[0].Tags) != 1 || listed[0].Tags[0].Slug != "sports" {
+		t.Fatalf("expected hydrated tag on List, got %+v", listed)
+	}
+}
+
+func TestGormRepositorySetMarketTagsRejectsInactiveTags(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("inactive_tag_creator", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+	market := modelstesting.GenerateMarket(802, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+	if _, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "inactive", DisplayName: "Inactive", IsActive: false}); err != nil {
+		t.Fatalf("CreateMarketTag returned error: %v", err)
+	}
+
+	if _, err := repo.SetMarketTags(ctx, market.ID, []string{"inactive"}, creator.Username, dmarkets.MarketTagAssignmentSourceCreate, time.Now().UTC()); !errors.Is(err, dmarkets.ErrInvalidInput) {
+		t.Fatalf("SetMarketTags error = %v, want ErrInvalidInput", err)
+	}
+}

--- a/backend/internal/repository/markets/repository_test.go
+++ b/backend/internal/repository/markets/repository_test.go
@@ -585,12 +585,15 @@ func TestGormRepositoryMarketTagsCreateListUpdateAssignAndHydrate(t *testing.T) 
 	if _, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "sports", DisplayName: "Sports", IsActive: true, SortOrder: 1, CreatedBy: "admin"}); err != nil {
 		t.Fatalf("CreateMarketTag sports: %v", err)
 	}
+	if _, err := repo.CreateMarketTag(ctx, dmarkets.MarketTag{Slug: "economy", DisplayName: "Economy", IsActive: true, SortOrder: 3, CreatedBy: "admin"}); err != nil {
+		t.Fatalf("CreateMarketTag economy: %v", err)
+	}
 
 	activeTags, err := repo.ListMarketTags(ctx, false)
 	if err != nil {
 		t.Fatalf("ListMarketTags returned error: %v", err)
 	}
-	if len(activeTags) != 2 || activeTags[0].Slug != "sports" || activeTags[1].Slug != "politics" {
+	if len(activeTags) != 3 || activeTags[0].Slug != "sports" || activeTags[1].Slug != "politics" || activeTags[2].Slug != "economy" {
 		t.Fatalf("expected sorted active tags, got %+v", activeTags)
 	}
 
@@ -625,6 +628,28 @@ func TestGormRepositoryMarketTagsCreateListUpdateAssignAndHydrate(t *testing.T) 
 	}
 	if len(listed) != 1 || len(listed[0].Tags) != 1 || listed[0].Tags[0].Slug != "sports" {
 		t.Fatalf("expected hydrated tag on List, got %+v", listed)
+	}
+
+	assigned, err = repo.SetMarketTags(ctx, market.ID, []string{"sports", "economy"}, creator.Username, dmarkets.MarketTagAssignmentSourceAdmin, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SetMarketTags with two tags returned error: %v", err)
+	}
+	if len(assigned) != 2 {
+		t.Fatalf("expected two assigned tags, got %+v", assigned)
+	}
+	assigned, err = repo.SetMarketTags(ctx, market.ID, []string{"sports"}, creator.Username, dmarkets.MarketTagAssignmentSourceAdmin, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("SetMarketTags removing one retained tag returned error: %v", err)
+	}
+	if len(assigned) != 1 || assigned[0].Slug != "sports" {
+		t.Fatalf("expected only retained sports tag, got %+v", assigned)
+	}
+	got, err = repo.GetByID(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("GetByID after replacing tags returned error: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0].Slug != "sports" {
+		t.Fatalf("expected hydrated retained tag after replacement, got %+v", got.Tags)
 	}
 }
 

--- a/backend/internal/repository/users/repository.go
+++ b/backend/internal/repository/users/repository.go
@@ -3,6 +3,7 @@ package users
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"socialpredict/internal/domain/boundary"
@@ -152,6 +153,16 @@ func (r *GormRepository) List(ctx context.Context, filters dusers.ListFilters) (
 
 	if filters.UserType != "" {
 		query = query.Where("user_type = ?", filters.UserType)
+	}
+
+	if term := strings.ToLower(strings.TrimSpace(filters.Query)); term != "" {
+		like := "%" + term + "%"
+		query = query.Where(
+			"LOWER(username) LIKE ? OR LOWER(display_name) LIKE ? OR LOWER(email) LIKE ?",
+			like,
+			like,
+			like,
+		)
 	}
 
 	if filters.Limit > 0 {

--- a/backend/migration/migrations/20251215_090000_add_market_tags.go
+++ b/backend/migration/migrations/20251215_090000_add_market_tags.go
@@ -1,0 +1,20 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+// MigrateAddMarketTags adds admin-managed market taxonomy tags and the
+// market-to-tag assignment table used by moderator proposals and navigation.
+func MigrateAddMarketTags(db *gorm.DB) error {
+	return db.AutoMigrate(&models.MarketTag{}, &models.MarketTagAssignment{})
+}
+
+func init() {
+	migration.Register("20251215090000", func(db *gorm.DB) error {
+		return MigrateAddMarketTags(db)
+	})
+}

--- a/backend/migration/migrations/20251215_090000_add_market_tags_test.go
+++ b/backend/migration/migrations/20251215_090000_add_market_tags_test.go
@@ -1,0 +1,37 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateAddMarketTagsCreatesTagTables(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+
+	if err := migrations.MigrateAddMarketTags(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	if !db.Migrator().HasTable(&models.MarketTag{}) {
+		t.Fatalf("expected market tags table")
+	}
+	if !db.Migrator().HasTable(&models.MarketTagAssignment{}) {
+		t.Fatalf("expected market tag assignments table")
+	}
+	if !db.Migrator().HasIndex(&models.MarketTag{}, "idx_market_tags_slug") {
+		t.Fatalf("expected unique slug index")
+	}
+}
+
+func TestMigrateAddMarketTagsIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketTags(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateAddMarketTags(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20251222_090000_add_market_discovery_cms.go
+++ b/backend/migration/migrations/20251222_090000_add_market_discovery_cms.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+)
+
+// MigrateAddMarketDiscoveryCMS adds CMS-owned market discovery page,
+// section, and pin tables for FEATURE/09 taxonomy navigation.
+func MigrateAddMarketDiscoveryCMS(db *gorm.DB) error {
+	return db.AutoMigrate(
+		&models.MarketDiscoveryPage{},
+		&models.MarketDiscoverySection{},
+		&models.MarketDiscoveryPin{},
+	)
+}
+
+func init() {
+	migration.Register("20251222090000", func(db *gorm.DB) error {
+		return MigrateAddMarketDiscoveryCMS(db)
+	})
+}

--- a/backend/migration/migrations/20251222_090000_add_market_discovery_cms.go
+++ b/backend/migration/migrations/20251222_090000_add_market_discovery_cms.go
@@ -7,12 +7,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// MigrateAddMarketDiscoveryCMS adds CMS-owned market discovery page,
-// section, and pin tables for FEATURE/09 taxonomy navigation.
+// MigrateAddMarketDiscoveryCMS adds CMS-owned market discovery page and pin
+// tables for FEATURE/09 taxonomy navigation.
 func MigrateAddMarketDiscoveryCMS(db *gorm.DB) error {
 	return db.AutoMigrate(
 		&models.MarketDiscoveryPage{},
-		&models.MarketDiscoverySection{},
 		&models.MarketDiscoveryPin{},
 	)
 }

--- a/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
+++ b/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
@@ -27,6 +27,9 @@ func TestMigrateAddMarketDiscoveryCMSCreatesTables(t *testing.T) {
 	if !db.Migrator().HasIndex(&models.MarketDiscoveryPage{}, "idx_market_discovery_pages_slug") {
 		t.Fatalf("expected market discovery page slug index")
 	}
+	if !db.Migrator().HasColumn(&models.MarketDiscoveryPin{}, "target_page_slug") {
+		t.Fatalf("expected market discovery pin target_page_slug column")
+	}
 }
 
 func TestMigrateAddMarketDiscoveryCMSIsIdempotent(t *testing.T) {

--- a/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
+++ b/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
@@ -17,7 +17,6 @@ func TestMigrateAddMarketDiscoveryCMSCreatesTables(t *testing.T) {
 
 	for _, table := range []any{
 		&models.MarketDiscoveryPage{},
-		&models.MarketDiscoverySection{},
 		&models.MarketDiscoveryPin{},
 	} {
 		if !db.Migrator().HasTable(table) {

--- a/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
+++ b/backend/migration/migrations/20251222_090000_add_market_discovery_cms_test.go
@@ -1,0 +1,40 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateAddMarketDiscoveryCMSCreatesTables(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	for _, table := range []any{
+		&models.MarketDiscoveryPage{},
+		&models.MarketDiscoverySection{},
+		&models.MarketDiscoveryPin{},
+	} {
+		if !db.Migrator().HasTable(table) {
+			t.Fatalf("expected table for %T", table)
+		}
+	}
+	if !db.Migrator().HasIndex(&models.MarketDiscoveryPage{}, "idx_market_discovery_pages_slug") {
+		t.Fatalf("expected market discovery page slug index")
+	}
+}
+
+func TestMigrateAddMarketDiscoveryCMSIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published.go
+++ b/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+
+	"gorm.io/gorm"
+)
+
+// MigrateRemoveMarketDiscoveryIsPublished removes the unused CMS draft/publish
+// flag from market discovery pages. Market discovery CMS edits publish
+// immediately, so this column only added confusion.
+func MigrateRemoveMarketDiscoveryIsPublished(db *gorm.DB) error {
+	m := db.Migrator()
+	if !m.HasTable("market_discovery_pages") || !m.HasColumn("market_discovery_pages", "is_published") {
+		return nil
+	}
+	if db.Dialector.Name() == "postgres" {
+		return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN IF EXISTS is_published").Error
+	}
+	return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN is_published").Error
+}
+
+func init() {
+	migration.Register("20251229090000", func(db *gorm.DB) error {
+		return MigrateRemoveMarketDiscoveryIsPublished(db)
+	})
+}

--- a/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published_test.go
+++ b/backend/migration/migrations/20251229_090000_remove_market_discovery_is_published_test.go
@@ -1,0 +1,40 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateRemoveMarketDiscoveryIsPublishedDropsColumn(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := db.Exec("ALTER TABLE market_discovery_pages ADD COLUMN is_published boolean DEFAULT true").Error; err != nil {
+		t.Fatalf("add legacy is_published column: %v", err)
+	}
+	if !db.Migrator().HasColumn("market_discovery_pages", "is_published") {
+		t.Fatalf("expected setup schema to include is_published")
+	}
+	if err := migrations.MigrateRemoveMarketDiscoveryIsPublished(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	if db.Migrator().HasColumn("market_discovery_pages", "is_published") {
+		t.Fatalf("expected is_published to be removed")
+	}
+}
+
+func TestMigrateRemoveMarketDiscoveryIsPublishedIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoveryIsPublished(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoveryIsPublished(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20260105_090000_remove_market_discovery_sections.go
+++ b/backend/migration/migrations/20260105_090000_remove_market_discovery_sections.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+
+	"gorm.io/gorm"
+)
+
+// MigrateRemoveMarketDiscoverySections removes the unused FEATURE/09 section
+// scaffold. Market discovery now uses TOP topic pins plus page-level market
+// pins, so retaining sections would keep dead CMS functionality around.
+func MigrateRemoveMarketDiscoverySections(db *gorm.DB) error {
+	m := db.Migrator()
+	if m.HasTable("market_discovery_sections") {
+		if err := m.DropTable("market_discovery_sections"); err != nil {
+			return err
+		}
+	}
+	if !m.HasTable("market_discovery_pages") || !m.HasColumn("market_discovery_pages", "sections_enabled") {
+		return nil
+	}
+	if db.Dialector.Name() == "postgres" {
+		return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN IF EXISTS sections_enabled").Error
+	}
+	return db.Exec("ALTER TABLE market_discovery_pages DROP COLUMN sections_enabled").Error
+}
+
+func init() {
+	migration.Register("20260105090000", func(db *gorm.DB) error {
+		return MigrateRemoveMarketDiscoverySections(db)
+	})
+}

--- a/backend/migration/migrations/20260105_090000_remove_market_discovery_sections_test.go
+++ b/backend/migration/migrations/20260105_090000_remove_market_discovery_sections_test.go
@@ -1,0 +1,49 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateRemoveMarketDiscoverySectionsDropsTableAndColumn(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := db.Exec("ALTER TABLE market_discovery_pages ADD COLUMN sections_enabled boolean DEFAULT false").Error; err != nil {
+		t.Fatalf("add legacy sections_enabled column: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE market_discovery_sections (
+		id integer primary key,
+		page_id integer not null,
+		slug text not null,
+		title text not null
+	)`).Error; err != nil {
+		t.Fatalf("add legacy sections table: %v", err)
+	}
+
+	if err := migrations.MigrateRemoveMarketDiscoverySections(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	if db.Migrator().HasTable("market_discovery_sections") {
+		t.Fatalf("expected market_discovery_sections to be removed")
+	}
+	if db.Migrator().HasColumn("market_discovery_pages", "sections_enabled") {
+		t.Fatalf("expected sections_enabled to be removed")
+	}
+}
+
+func TestMigrateRemoveMarketDiscoverySectionsIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := migrations.MigrateAddMarketDiscoveryCMS(db); err != nil {
+		t.Fatalf("setup market discovery cms: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoverySections(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateRemoveMarketDiscoverySections(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/models/market.go
+++ b/backend/models/market.go
@@ -32,6 +32,27 @@ type Market struct {
 	StewardUsername         string     `json:"stewardUsername" gorm:"index"`
 }
 
+type MarketTag struct {
+	gorm.Model
+	ID          int64  `json:"id" gorm:"primary_key"`
+	Slug        string `json:"slug" gorm:"not null;uniqueIndex;size:64"`
+	DisplayName string `json:"displayName" gorm:"not null;size:120"`
+	Description string `json:"description,omitempty" gorm:"type:text"`
+	ColorKey    string `json:"colorKey,omitempty" gorm:"size:40"`
+	SortOrder   int    `json:"sortOrder" gorm:"not null;default:0;index"`
+	IsActive    bool   `json:"isActive" gorm:"not null;default:true;index"`
+	CreatedBy   string `json:"createdBy,omitempty" gorm:"index"`
+}
+
+type MarketTagAssignment struct {
+	gorm.Model
+	ID         int64  `json:"id" gorm:"primary_key"`
+	MarketID   int64  `json:"marketId" gorm:"not null;uniqueIndex:uniq_market_tag_assignment;index"`
+	TagID      int64  `json:"tagId" gorm:"not null;uniqueIndex:uniq_market_tag_assignment;index"`
+	AssignedBy string `json:"assignedBy,omitempty" gorm:"index"`
+	Source     string `json:"source,omitempty" gorm:"not null;default:moderator_create;index"`
+}
+
 type MarketStewardshipAudit struct {
 	gorm.Model
 	ID                  int64  `json:"id" gorm:"primary_key"`

--- a/backend/models/market_discovery.go
+++ b/backend/models/market_discovery.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type MarketDiscoveryPage struct {
+	gorm.Model
+	ID                         uint   `gorm:"primaryKey"`
+	Slug                       string `gorm:"not null;uniqueIndex;size:96"`
+	Title                      string `gorm:"not null;size:160"`
+	Description                string `gorm:"size:500"`
+	PageType                   string `gorm:"not null;index;size:32"`
+	PrimaryTagSlug             string `gorm:"index;size:64"`
+	SearchScope                string `gorm:"not null;default:all;size:32"`
+	FeaturedTopicsEnabled      bool   `gorm:"not null;default:false"`
+	FeaturedMarketsEnabled     bool   `gorm:"not null;default:false"`
+	SectionsEnabled            bool   `gorm:"not null;default:false"`
+	DefaultRecommendationLimit int    `gorm:"not null;default:20"`
+	CuratedRecommendationLimit int    `gorm:"not null;default:5"`
+	IsPublished                bool   `gorm:"not null;default:true;index"`
+	SortOrder                  int    `gorm:"not null;default:0;index"`
+	Version                    uint   `gorm:"not null;default:1"`
+	UpdatedBy                  string `gorm:"size:64"`
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
+}
+
+type MarketDiscoverySection struct {
+	gorm.Model
+	ID            uint   `gorm:"primaryKey"`
+	PageID        uint   `gorm:"not null;index"`
+	Slug          string `gorm:"not null;size:96"`
+	Title         string `gorm:"not null;size:160"`
+	Description   string `gorm:"size:500"`
+	TagFilterSlug string `gorm:"index;size:64"`
+	SortOrder     int    `gorm:"not null;default:0;index"`
+	IsActive      bool   `gorm:"not null;default:true;index"`
+}
+
+type MarketDiscoveryPin struct {
+	gorm.Model
+	ID           uint   `gorm:"primaryKey"`
+	ScopeType    string `gorm:"not null;index;size:32"`
+	ScopeID      uint   `gorm:"not null;index"`
+	PinType      string `gorm:"not null;index;size:32"`
+	MarketID     *int64 `gorm:"index"`
+	TargetPageID *uint  `gorm:"index"`
+	Label        string `gorm:"size:160"`
+	SortOrder    int    `gorm:"not null;default:0;index"`
+	CreatedBy    string `gorm:"size:64"`
+}

--- a/backend/models/market_discovery.go
+++ b/backend/models/market_discovery.go
@@ -42,13 +42,14 @@ type MarketDiscoverySection struct {
 
 type MarketDiscoveryPin struct {
 	gorm.Model
-	ID           uint   `gorm:"primaryKey"`
-	ScopeType    string `gorm:"not null;index;size:32"`
-	ScopeID      uint   `gorm:"not null;index"`
-	PinType      string `gorm:"not null;index;size:32"`
-	MarketID     *int64 `gorm:"index"`
-	TargetPageID *uint  `gorm:"index"`
-	Label        string `gorm:"size:160"`
-	SortOrder    int    `gorm:"not null;default:0;index"`
-	CreatedBy    string `gorm:"size:64"`
+	ID             uint   `gorm:"primaryKey"`
+	ScopeType      string `gorm:"not null;index;size:32"`
+	ScopeID        uint   `gorm:"not null;index"`
+	PinType        string `gorm:"not null;index;size:32"`
+	MarketID       *int64 `gorm:"index"`
+	TargetPageID   *uint  `gorm:"index"`
+	TargetPageSlug string `gorm:"index;size:96"`
+	Label          string `gorm:"size:160"`
+	SortOrder      int    `gorm:"not null;default:0;index"`
+	CreatedBy      string `gorm:"size:64"`
 }

--- a/backend/models/market_discovery.go
+++ b/backend/models/market_discovery.go
@@ -20,7 +20,6 @@ type MarketDiscoveryPage struct {
 	SectionsEnabled            bool   `gorm:"not null;default:false"`
 	DefaultRecommendationLimit int    `gorm:"not null;default:20"`
 	CuratedRecommendationLimit int    `gorm:"not null;default:5"`
-	IsPublished                bool   `gorm:"not null;default:true;index"`
 	SortOrder                  int    `gorm:"not null;default:0;index"`
 	Version                    uint   `gorm:"not null;default:1"`
 	UpdatedBy                  string `gorm:"size:64"`

--- a/backend/models/market_discovery.go
+++ b/backend/models/market_discovery.go
@@ -17,7 +17,6 @@ type MarketDiscoveryPage struct {
 	SearchScope                string `gorm:"not null;default:all;size:32"`
 	FeaturedTopicsEnabled      bool   `gorm:"not null;default:false"`
 	FeaturedMarketsEnabled     bool   `gorm:"not null;default:false"`
-	SectionsEnabled            bool   `gorm:"not null;default:false"`
 	DefaultRecommendationLimit int    `gorm:"not null;default:20"`
 	CuratedRecommendationLimit int    `gorm:"not null;default:5"`
 	SortOrder                  int    `gorm:"not null;default:0;index"`
@@ -25,18 +24,6 @@ type MarketDiscoveryPage struct {
 	UpdatedBy                  string `gorm:"size:64"`
 	CreatedAt                  time.Time
 	UpdatedAt                  time.Time
-}
-
-type MarketDiscoverySection struct {
-	gorm.Model
-	ID            uint   `gorm:"primaryKey"`
-	PageID        uint   `gorm:"not null;index"`
-	Slug          string `gorm:"not null;size:96"`
-	Title         string `gorm:"not null;size:160"`
-	Description   string `gorm:"size:500"`
-	TagFilterSlug string `gorm:"index;size:64"`
-	SortOrder     int    `gorm:"not null;default:0;index"`
-	IsActive      bool   `gorm:"not null;default:true;index"`
 }
 
 type MarketDiscoveryPin struct {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -441,6 +441,8 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	router.Handle("/v0/admin/content/home", securityMiddleware(http.HandlerFunc(homepageHandler.AdminUpdate))).Methods("PUT")
 	router.HandleFunc("/v0/content/market-discovery/{slug}", marketDiscoveryHandler.PublicGet).Methods("GET")
 	router.Handle("/v0/admin/content/market-discovery/{slug}", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminUpdate))).Methods("PUT")
+	router.Handle("/v0/admin/content/market-discovery/{slug}/sections", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminReplaceSections))).Methods("PUT")
+	router.Handle("/v0/admin/content/market-discovery/{slug}/pins", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminReplacePins))).Methods("PUT")
 	router.HandleFunc("/v0/content/social-share", socialShareHandler.PublicGet).Methods("GET")
 	router.HandleFunc("/v0/content/social-share/image", socialShareHandler.PublicImage).Methods("GET", "HEAD")
 	router.HandleFunc("/api/v0/content/social-share/image", socialShareHandler.PublicImage).Methods("GET", "HEAD")

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -18,6 +18,8 @@ import (
 	sellbetshandlers "socialpredict/handlers/bets/selling"
 	"socialpredict/handlers/cms/homepage"
 	cmshomehttp "socialpredict/handlers/cms/homepage/http"
+	"socialpredict/handlers/cms/marketdiscovery"
+	cmsdiscoveryhttp "socialpredict/handlers/cms/marketdiscovery/http"
 	"socialpredict/handlers/cms/socialshare"
 	cmssocialhttp "socialpredict/handlers/cms/socialshare/http"
 	marketshandlers "socialpredict/handlers/markets"
@@ -328,6 +330,10 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	homepageSvc := homepage.NewService(homepageRepo, homepageRenderer)
 	homepageHandler := cmshomehttp.NewHandler(homepageSvc, authService)
 
+	marketDiscoveryRepo := marketdiscovery.NewGormRepository(db)
+	marketDiscoverySvc := marketdiscovery.NewService(marketDiscoveryRepo)
+	marketDiscoveryHandler := cmsdiscoveryhttp.NewHandler(marketDiscoverySvc, authService)
+
 	socialShareRepo := socialshare.NewGormRepository(db)
 	socialShareSvc := socialshare.NewService(socialShareRepo)
 	socialShareHandler := cmssocialhttp.NewHandler(socialShareSvc, authService)
@@ -433,6 +439,8 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 
 	router.HandleFunc("/v0/content/home", homepageHandler.PublicGet).Methods("GET")
 	router.Handle("/v0/admin/content/home", securityMiddleware(http.HandlerFunc(homepageHandler.AdminUpdate))).Methods("PUT")
+	router.HandleFunc("/v0/content/market-discovery/{slug}", marketDiscoveryHandler.PublicGet).Methods("GET")
+	router.Handle("/v0/admin/content/market-discovery/{slug}", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminUpdate))).Methods("PUT")
 	router.HandleFunc("/v0/content/social-share", socialShareHandler.PublicGet).Methods("GET")
 	router.HandleFunc("/v0/content/social-share/image", socialShareHandler.PublicImage).Methods("GET", "HEAD")
 	router.HandleFunc("/api/v0/content/social-share/image", socialShareHandler.PublicImage).Methods("GET", "HEAD")

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -426,6 +426,7 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	router.Handle("/v0/admin/markets/{id}/approve", securityMiddleware(adminhandlers.ApproveMarketHandler(marketsService, authService))).Methods("PATCH")
 	router.Handle("/v0/admin/markets/{id}/reject", securityMiddleware(adminhandlers.RejectMarketHandler(marketsService, authService))).Methods("PATCH")
 	router.Handle("/v0/admin/markets/{id}/steward", securityMiddleware(adminhandlers.ReassignMarketStewardHandler(marketsService, authService))).Methods("PATCH")
+	router.Handle("/v0/admin/markets/{id}/tags", securityMiddleware(adminhandlers.UpdateMarketTagsHandler(marketsService, authService))).Methods("PATCH")
 	router.Handle("/v0/admin/market-tags", securityMiddleware(adminhandlers.ListAdminMarketTagsHandler(marketsService, authService))).Methods("GET")
 	router.Handle("/v0/admin/market-tags", securityMiddleware(adminhandlers.CreateAdminMarketTagHandler(marketsService, authService))).Methods("POST")
 	router.Handle("/v0/admin/market-tags/{slug}", securityMiddleware(adminhandlers.UpdateAdminMarketTagHandler(marketsService, authService))).Methods("PATCH")

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -441,7 +441,6 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	router.Handle("/v0/admin/content/home", securityMiddleware(http.HandlerFunc(homepageHandler.AdminUpdate))).Methods("PUT")
 	router.HandleFunc("/v0/content/market-discovery/{slug}", marketDiscoveryHandler.PublicGet).Methods("GET")
 	router.Handle("/v0/admin/content/market-discovery/{slug}", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminUpdate))).Methods("PUT")
-	router.Handle("/v0/admin/content/market-discovery/{slug}/sections", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminReplaceSections))).Methods("PUT")
 	router.Handle("/v0/admin/content/market-discovery/{slug}/pins", securityMiddleware(http.HandlerFunc(marketDiscoveryHandler.AdminReplacePins))).Methods("PUT")
 	router.HandleFunc("/v0/content/social-share", socialShareHandler.PublicGet).Methods("GET")
 	router.HandleFunc("/v0/content/social-share/image", socialShareHandler.PublicImage).Methods("GET", "HEAD")

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -386,6 +386,7 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	router.Handle("/v0/markets/{id}/resolve", securityMiddleware(http.HandlerFunc(marketsHandler.ResolveMarket))).Methods("POST")
 	router.Handle("/v0/markets/{id}/leaderboard", securityMiddleware(http.HandlerFunc(marketsHandler.MarketLeaderboard))).Methods("GET")
 	router.Handle("/v0/markets/{id}/projection", securityMiddleware(http.HandlerFunc(marketsHandler.ProjectProbability))).Methods("GET")
+	router.Handle("/v0/market-tags", securityMiddleware(marketshandlers.ListMarketTagsHandler(marketsService))).Methods("GET")
 	router.Handle("/v0/marketprojection/{marketId}/{amount}/{outcome}", securityMiddleware(marketshandlers.ProjectNewProbabilityHandler(marketsService))).Methods("GET")
 	router.Handle("/v0/marketprojection/{marketId}/{amount}/{outcome}/", securityMiddleware(marketshandlers.ProjectNewProbabilityHandler(marketsService))).Methods("GET")
 
@@ -425,6 +426,9 @@ func registerApplicationRoutes(router *mux.Router, db *gorm.DB, configService co
 	router.Handle("/v0/admin/markets/{id}/approve", securityMiddleware(adminhandlers.ApproveMarketHandler(marketsService, authService))).Methods("PATCH")
 	router.Handle("/v0/admin/markets/{id}/reject", securityMiddleware(adminhandlers.RejectMarketHandler(marketsService, authService))).Methods("PATCH")
 	router.Handle("/v0/admin/markets/{id}/steward", securityMiddleware(adminhandlers.ReassignMarketStewardHandler(marketsService, authService))).Methods("PATCH")
+	router.Handle("/v0/admin/market-tags", securityMiddleware(adminhandlers.ListAdminMarketTagsHandler(marketsService, authService))).Methods("GET")
+	router.Handle("/v0/admin/market-tags", securityMiddleware(adminhandlers.CreateAdminMarketTagHandler(marketsService, authService))).Methods("POST")
+	router.Handle("/v0/admin/market-tags/{slug}", securityMiddleware(adminhandlers.UpdateAdminMarketTagHandler(marketsService, authService))).Methods("PATCH")
 
 	router.HandleFunc("/v0/content/home", homepageHandler.PublicGet).Methods("GET")
 	router.Handle("/v0/admin/content/home", securityMiddleware(http.HandlerFunc(homepageHandler.AdminUpdate))).Methods("PUT")

--- a/frontend/src/api/adminUsersApi.js
+++ b/frontend/src/api/adminUsersApi.js
@@ -26,11 +26,23 @@ const adminRequest = async ({ path, token, method = 'GET', body }) => {
   });
 };
 
-export const listAdminUsers = ({ token, limit = 100, offset = 0 }) => {
+export const listAdminUsers = ({
+  token,
+  limit = 100,
+  offset = 0,
+  usertype = '',
+  query = '',
+}) => {
   const params = new URLSearchParams({
     limit: String(limit),
     offset: String(offset),
   });
+  if (usertype) {
+    params.set('usertype', usertype);
+  }
+  if (query) {
+    params.set('query', query);
+  }
   return adminRequest({
     path: `/v0/admin/users?${params.toString()}`,
     token,

--- a/frontend/src/api/marketTagsApi.js
+++ b/frontend/src/api/marketTagsApi.js
@@ -1,0 +1,42 @@
+import { apiRequest, authenticatedApiRequest } from './httpClient';
+
+const tagReasonMessages = {
+  AUTHORIZATION_DENIED: 'Only admins can manage market tags.',
+  INVALID_REQUEST: 'Check the tag fields and try again.',
+  VALIDATION_FAILED: 'Check the tag fields and try again.',
+};
+
+export const listMarketTags = () => apiRequest('/v0/market-tags', {
+  fallbackMessage: 'Unable to load market tags.',
+});
+
+export const listAdminMarketTags = ({ token, includeInactive = true }) => authenticatedApiRequest(
+  `/v0/admin/market-tags?includeInactive=${includeInactive ? 'true' : 'false'}`,
+  {
+    authToken: token,
+    fallbackMessage: 'Unable to load market tags.',
+    reasonMessages: tagReasonMessages,
+  },
+);
+
+export const createAdminMarketTag = ({ token, tag }) => authenticatedApiRequest('/v0/admin/market-tags', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(tag),
+  authToken: token,
+  fallbackMessage: 'Unable to create market tag.',
+  reasonMessages: tagReasonMessages,
+});
+
+export const updateAdminMarketTag = ({ token, slug, tag }) => authenticatedApiRequest(`/v0/admin/market-tags/${slug}`, {
+  method: 'PATCH',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(tag),
+  authToken: token,
+  fallbackMessage: 'Unable to update market tag.',
+  reasonMessages: tagReasonMessages,
+});

--- a/frontend/src/api/marketsApi.js
+++ b/frontend/src/api/marketsApi.js
@@ -7,7 +7,7 @@ import { API_URL } from '../config';
  * @param {number} limit - Maximum number of results (optional, defaults to 20)
  * @returns {Promise<Object>} Search results object
  */
-export const searchMarkets = async (query, status = 'all', limit = 20) => {
+export const searchMarkets = async (query, status = 'all', limit = 20, options = {}) => {
     if (!query?.trim()) {
         throw new Error('Search query is required');
     }
@@ -17,6 +17,9 @@ export const searchMarkets = async (query, status = 'all', limit = 20) => {
         status: status,
         limit: limit.toString()
     });
+    if (options.tagSlug) {
+        params.set('tagSlug', options.tagSlug);
+    }
 
     const response = await fetch(`${API_URL}/v0/markets/search?${params}`);
 

--- a/frontend/src/api/moderationApi.js
+++ b/frontend/src/api/moderationApi.js
@@ -71,3 +71,16 @@ export const reassignMarketSteward = ({ marketId, token, stewardUsername, reason
     },
   });
 };
+
+export const updateMarketTags = ({ marketId, token, tagSlugs }) => {
+  if (!Array.isArray(tagSlugs)) {
+    throw new Error('Market tags must be provided as a list.');
+  }
+
+  return reviewMarket({
+    marketId,
+    token,
+    action: 'tags',
+    body: { tagSlugs },
+  });
+};

--- a/frontend/src/components/charts/MarketChart.jsx
+++ b/frontend/src/components/charts/MarketChart.jsx
@@ -3,7 +3,18 @@ import CanvasJSReact from '@canvasjs/react-charts';
 
 const CanvasJSChart = CanvasJSReact.CanvasJSChart;
 
-const MarketChart = ({ data, currentProbability, title, className, closeDateTime, yesLabel, noLabel }) => {
+const MarketChart = ({
+  data,
+  currentProbability,
+  title,
+  className,
+  closeDateTime,
+  yesLabel,
+  noLabel,
+  showHeader = true,
+  compact = false,
+  height,
+}) => {
   const [showInverseProbability, setShowInverseProbability] = useState(false);
 
   const generateDataPoints = (data, isInverse = false) => {
@@ -61,28 +72,35 @@ const MarketChart = ({ data, currentProbability, title, className, closeDateTime
   };
 
   const options = {
-    animationEnabled: true,
+    animationEnabled: !compact,
     backgroundColor: 'transparent',
-    zoomEnabled: true,
+    zoomEnabled: !compact,
+    height,
     axisX: {
       valueFormatString: 'DD MMM YY HH:mm',
-      labelFontColor: '#708090',
+      labelFontColor: compact ? 'transparent' : '#708090',
+      tickLength: compact ? 0 : undefined,
+      lineThickness: compact ? 0 : undefined,
     },
     axisY: {
       includeZero: true,
       minimum: 0,
       maximum: 1,
-      labelFontColor: '#708090',
+      labelFontColor: compact ? 'transparent' : '#708090',
       suffix: '',
       valueFormatString: '0.00',
+      tickLength: compact ? 0 : undefined,
+      lineThickness: compact ? 0 : undefined,
+      gridThickness: compact ? 0 : undefined,
     },
     data: generateChartData(),
   };
 
   return (
-    <div className={`rounded-lg shadow p-4 ${className} overflow-hidden`}>
-      <div className="flex justify-between items-center mb-2">
-        <h3 className='text-lg font-medium'>{title}</h3>
+    <div className={`rounded-lg shadow ${compact ? 'p-0' : 'p-4'} ${className} overflow-hidden`}>
+      {showHeader && (
+        <div className="flex justify-between items-center mb-2">
+          <h3 className='text-lg font-medium'>{title}</h3>
           <button
             onClick={() => setShowInverseProbability(!showInverseProbability)}
             className={`px-3 py-1 text-sm rounded-lg transition-colors duration-200 ${showInverseProbability
@@ -93,7 +111,8 @@ const MarketChart = ({ data, currentProbability, title, className, closeDateTime
               ? `Show ${yesLabel} Probability`
               : `Show ${noLabel} Probability`}
           </button>
-      </div>
+        </div>
+      )}
       <CanvasJSChart options={options} />
     </div>
   );

--- a/frontend/src/components/charts/MarketChart.jsx
+++ b/frontend/src/components/charts/MarketChart.jsx
@@ -75,12 +75,9 @@ const MarketChart = ({
     animationEnabled: !compact,
     backgroundColor: 'transparent',
     zoomEnabled: !compact,
-    height,
     axisX: {
       valueFormatString: 'DD MMM YY HH:mm',
       labelFontColor: compact ? 'transparent' : '#708090',
-      tickLength: compact ? 0 : undefined,
-      lineThickness: compact ? 0 : undefined,
     },
     axisY: {
       includeZero: true,
@@ -89,12 +86,19 @@ const MarketChart = ({
       labelFontColor: compact ? 'transparent' : '#708090',
       suffix: '',
       valueFormatString: '0.00',
-      tickLength: compact ? 0 : undefined,
-      lineThickness: compact ? 0 : undefined,
-      gridThickness: compact ? 0 : undefined,
     },
     data: generateChartData(),
   };
+  if (height) {
+    options.height = height;
+  }
+  if (compact) {
+    options.axisX.tickLength = 0;
+    options.axisX.lineThickness = 0;
+    options.axisY.tickLength = 0;
+    options.axisY.lineThickness = 0;
+    options.axisY.gridThickness = 0;
+  }
 
   return (
     <div className={`rounded-lg shadow ${compact ? 'p-0' : 'p-4'} ${className} overflow-hidden`}>

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -15,7 +15,7 @@ import {
   listAdminMarketTags,
   updateAdminMarketTag,
 } from '../../../api/marketTagsApi';
-import MarketTagChips from '../../markets/MarketTagChips';
+import MarketTagChips, { MARKET_TAG_COLOR_OPTIONS } from '../../markets/MarketTagChips';
 
 const reviewTabs = [
   { label: 'Proposed Markets', status: 'proposed' },
@@ -533,11 +533,11 @@ const MarketTaxonomyAdmin = () => {
               onChange={(event) => updateForm({ colorKey: event.target.value })}
               className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
             >
-              <option value="slate">Slate</option>
-              <option value="sky">Sky</option>
-              <option value="emerald">Emerald</option>
-              <option value="amber">Amber</option>
-              <option value="rose">Rose</option>
+              {MARKET_TAG_COLOR_OPTIONS.map((option) => (
+                <option key={option.key} value={option.key}>
+                  {option.label}
+                </option>
+              ))}
             </select>
           </label>
           <label className="grid gap-1 text-sm text-gray-300">

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -659,6 +659,15 @@ const MarketTaxonomyAdmin = () => {
   };
 
   const setTagActive = async (tag, isActive) => {
+    if (!isActive) {
+      const confirmed = window.confirm(
+        `Deactivate "${tag.displayName}"?\n\nIt will stay visible on markets and existing layouts, but moderators/admins cannot newly assign it until reactivated.`,
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+
     setBusySlug(tag.slug);
     setError('');
     setSuccessMessage('');
@@ -694,6 +703,9 @@ const MarketTaxonomyAdmin = () => {
         <h2 className="text-lg font-semibold text-white">Market Tags</h2>
         <p className="mt-2 text-sm text-gray-300">
           Admins define the tag vocabulary. Moderators can attach active tags during market creation; admins can review those tags before publication.
+        </p>
+        <p className="mt-2 text-xs text-amber-200">
+          Deactivating a tag does not remove it from existing markets or topic pins. It only prevents new assignments until the tag is reactivated.
         </p>
       </div>
 
@@ -774,7 +786,7 @@ const MarketTaxonomyAdmin = () => {
               <MarketTagChips tags={[tag]} />
               <div className="mt-2 font-mono text-xs text-gray-500">{tag.slug}</div>
               {tag.description && <p className="mt-2 text-sm text-gray-300">{tag.description}</p>}
-              {!tag.isActive && <p className="mt-2 text-xs text-amber-300">Inactive tags stay visible on historical markets but cannot be newly assigned.</p>}
+              {!tag.isActive && <p className="mt-2 text-xs text-amber-300">Inactive tags stay visible on historical markets and layouts but cannot be newly assigned.</p>}
             </div>
             <button
               type="button"

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -392,6 +392,64 @@ const emptyTagForm = {
   sortOrder: 0,
 };
 
+const ColorKeyPicker = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const selectedOption = MARKET_TAG_COLOR_OPTIONS.find((option) => option.key === value)
+    || MARKET_TAG_COLOR_OPTIONS[0];
+  const previewTag = (option) => ({
+    slug: option.key,
+    displayName: option.label,
+    colorKey: option.key,
+    description: option.guidance,
+  });
+
+  const chooseColor = (colorKey) => {
+    onChange(colorKey);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="flex w-full items-center justify-between gap-3 rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-left text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+      >
+        <MarketTagChips tags={[previewTag(selectedOption)]} />
+        <span className="text-xs text-gray-400">▾</span>
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Market tag color key"
+          className="absolute z-30 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-gray-700 bg-gray-950 p-2 shadow-xl"
+        >
+          {MARKET_TAG_COLOR_OPTIONS.map((option) => {
+            const selected = option.key === selectedOption.key;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => chooseColor(option.key)}
+                className={`grid w-full gap-1 rounded-md px-3 py-2 text-left transition hover:bg-gray-800 ${
+                  selected ? 'bg-gray-800 ring-1 ring-primary-pink/60' : ''
+                }`}
+              >
+                <MarketTagChips tags={[previewTag(option)]} />
+                <span className="text-xs text-gray-500">{option.guidance}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const MarketTaxonomyAdmin = () => {
   const { token } = useAuth();
   const [tags, setTags] = useState([]);
@@ -528,17 +586,10 @@ const MarketTaxonomyAdmin = () => {
         <div className="grid gap-4 md:grid-cols-2">
           <label className="grid gap-1 text-sm text-gray-300">
             Color key
-            <select
+            <ColorKeyPicker
               value={form.colorKey}
-              onChange={(event) => updateForm({ colorKey: event.target.value })}
-              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
-            >
-              {MARKET_TAG_COLOR_OPTIONS.map((option) => (
-                <option key={option.key} value={option.key}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+              onChange={(colorKey) => updateForm({ colorKey })}
+            />
           </label>
           <label className="grid gap-1 text-sm text-gray-300">
             Sort order

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -400,7 +400,7 @@ const ColorKeyPicker = ({ value, onChange }) => {
     slug: option.key,
     displayName: option.label,
     colorKey: option.key,
-    description: option.guidance,
+    description: option.label,
   });
 
   const chooseColor = (colorKey) => {
@@ -440,7 +440,7 @@ const ColorKeyPicker = ({ value, onChange }) => {
                 }`}
               >
                 <MarketTagChips tags={[previewTag(option)]} />
-                <span className="text-xs text-gray-500">{option.guidance}</span>
+                <span className="font-mono text-xs text-gray-500">{option.key}</span>
               </button>
             );
           })}

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -49,14 +49,20 @@ const AdminMarketQueue = ({ status }) => {
   const [rejectionReasons, setRejectionReasons] = useState({});
   const [tagForms, setTagForms] = useState({});
   const [busyMarketId, setBusyMarketId] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const tagEditingEnabled = status === 'proposed' || status === 'published';
 
-  const loadMarkets = async () => {
+  const loadMarkets = async (query = searchQuery) => {
     setLoading(true);
     setError('');
     try {
-      const data = await listAdminLifecycleMarkets({ token, status });
+      const data = await listAdminLifecycleMarkets({
+        token,
+        status,
+        query,
+        limit: 100,
+      });
       setMarkets(data.markets || []);
     } catch (err) {
       setError(err.message || 'Unable to load market queue.');
@@ -66,9 +72,15 @@ const AdminMarketQueue = ({ status }) => {
   };
 
   useEffect(() => {
-    loadMarkets();
+    const timeoutId = window.setTimeout(() => {
+      loadMarkets(searchQuery);
+    }, 300);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status, token]);
+  }, [status, token, searchQuery]);
 
   useEffect(() => {
     if (!token || !tagEditingEnabled) {
@@ -287,6 +299,24 @@ const AdminMarketQueue = ({ status }) => {
           {successMessage}
         </div>
       )}
+      <div className="grid gap-2 rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <label htmlFor={`market-review-search-${status}`} className="text-xs font-mono uppercase tracking-[0.16em] text-gray-400">
+          Search markets
+        </label>
+        <div className="relative">
+          <input
+            id={`market-review-search-${status}`}
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={`Search ${status} markets by title or description`}
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 pr-10 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+          {loading && (
+            <div className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-b-2 border-primary-pink" />
+          )}
+        </div>
+      </div>
       <MarketLifecycleTable
         markets={markets}
         emptyMessage={`No ${status} markets found.`}
@@ -833,9 +863,6 @@ function ModeratorMarketReview() {
           Moderator mode
         </p>
         <h1 className="text-2xl font-bold mt-2">Market Review Queue</h1>
-        <p className="text-sm text-gray-300 mt-2 max-w-3xl">
-          Review proposed markets without manually entering IDs. Approved markets become published and tradable; rejected markets record the reason and refund the proposal cost. Stewardship controls which active moderator is responsible for operational market governance.
-        </p>
       </div>
 
       <SiteTabs tabs={tabsData} defaultTab="Proposed Markets" />

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -7,6 +7,7 @@ import {
   approveProposedMarket,
   rejectProposedMarket,
   reassignMarketSteward,
+  updateMarketTags,
 } from '../../../api/moderationApi';
 import { listAdminLifecycleMarkets } from '../../../api/lifecycleMarketsApi';
 import { listAdminUsers } from '../../../api/adminUsersApi';
@@ -23,17 +24,33 @@ const reviewTabs = [
   { label: 'Rejected Markets', status: 'rejected' },
 ];
 
+const maxMarketTagsPerMarket = 5;
+
 const isActiveModerator = (user) => (
   user?.usertype === 'MODERATOR' && (user.moderatorStatus || 'active') === 'active'
+);
+
+const marketTagSlugs = (market) => (market.tags || [])
+  .map((tag) => tag.slug)
+  .filter(Boolean)
+  .sort();
+
+const sameTagSlugs = (left, right) => (
+  JSON.stringify([...left].sort()) === JSON.stringify([...right].sort())
 );
 
 const AdminMarketQueue = ({ status }) => {
   const { token } = useAuth();
   const [markets, setMarkets] = useState([]);
+  const [activeTags, setActiveTags] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
   const [rejectionReasons, setRejectionReasons] = useState({});
+  const [tagForms, setTagForms] = useState({});
   const [busyMarketId, setBusyMarketId] = useState(null);
+
+  const tagEditingEnabled = status === 'proposed' || status === 'published';
 
   const loadMarkets = async () => {
     setLoading(true);
@@ -53,9 +70,36 @@ const AdminMarketQueue = ({ status }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, token]);
 
+  useEffect(() => {
+    if (!token || !tagEditingEnabled) {
+      return;
+    }
+
+    let ignore = false;
+    const loadActiveTags = async () => {
+      try {
+        const result = await listAdminMarketTags({ token, includeInactive: false });
+        if (!ignore) {
+          setActiveTags(result.tags || []);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load active market tags.');
+        }
+      }
+    };
+
+    loadActiveTags();
+
+    return () => {
+      ignore = true;
+    };
+  }, [token, tagEditingEnabled]);
+
   const approveMarket = async (marketId) => {
     setBusyMarketId(marketId);
     setError('');
+    setSuccessMessage('');
     try {
       await approveProposedMarket({ marketId, token });
       await loadMarkets();
@@ -70,6 +114,7 @@ const AdminMarketQueue = ({ status }) => {
     const reason = rejectionReasons[marketId];
     setBusyMarketId(marketId);
     setError('');
+    setSuccessMessage('');
     try {
       await rejectProposedMarket({ marketId, token, reason });
       setRejectionReasons((current) => ({ ...current, [marketId]: '' }));
@@ -81,39 +126,147 @@ const AdminMarketQueue = ({ status }) => {
     }
   };
 
+  const updateMarketInQueue = (updatedMarket) => {
+    setMarkets((current) => current.map((market) => (
+      market.id === updatedMarket.id ? { ...market, ...updatedMarket } : market
+    )));
+  };
+
+  const tagSlugsForForm = (market) => tagForms[market.id] || marketTagSlugs(market);
+
+  const toggleMarketTag = (market, slug) => {
+    setTagForms((current) => {
+      const selected = current[market.id] || marketTagSlugs(market);
+      const next = selected.includes(slug)
+        ? selected.filter((item) => item !== slug)
+        : [...selected, slug].sort();
+      return { ...current, [market.id]: next };
+    });
+  };
+
+  const saveMarketTags = async (market) => {
+    const tagSlugs = tagSlugsForForm(market);
+    setBusyMarketId(market.id);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const updatedMarket = await updateMarketTags({ marketId: market.id, token, tagSlugs });
+      updateMarketInQueue(updatedMarket);
+      setTagForms((current) => {
+        const next = { ...current };
+        delete next[market.id];
+        return next;
+      });
+      setSuccessMessage(`Updated tags for market ${updatedMarket.id}.`);
+    } catch (err) {
+      setError(err.message || 'Unable to update market tags.');
+    } finally {
+      setBusyMarketId(null);
+    }
+  };
+
+  const renderTagEditor = (market) => {
+    if (!tagEditingEnabled) {
+      return null;
+    }
+    const activeBySlug = new Map(activeTags.map((tag) => [tag.slug, tag]));
+    const tagChoices = [
+      ...activeTags,
+      ...(market.tags || []).filter((tag) => tag.slug && !activeBySlug.has(tag.slug)),
+    ];
+    const selectedSlugs = tagSlugsForForm(market);
+    const originalSlugs = marketTagSlugs(market);
+    const changed = !sameTagSlugs(selectedSlugs, originalSlugs);
+    const atLimit = selectedSlugs.length >= maxMarketTagsPerMarket;
+
+    return (
+      <div className="grid gap-2 rounded-lg border border-gray-700 bg-gray-900/80 p-3">
+        <div>
+          <div className="font-mono text-xs uppercase tracking-[0.14em] text-gray-400">
+            Admin tag adjustment
+          </div>
+          <p className="mt-1 text-xs text-gray-500">
+            Add or remove active tags before or after publication.
+          </p>
+        </div>
+        {tagChoices.length ? (
+          <div className="flex max-w-[280px] flex-wrap gap-2">
+            {tagChoices.map((tag) => {
+              const selected = selectedSlugs.includes(tag.slug);
+              const disabled = !selected && (atLimit || !tag.isActive);
+              return (
+                <button
+                  key={tag.slug}
+                  type="button"
+                  disabled={disabled || busyMarketId === market.id}
+                  onClick={() => toggleMarketTag(market, tag.slug)}
+                  className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                    selected
+                      ? 'border-primary-pink bg-primary-pink/20 text-white'
+                      : 'border-gray-600 bg-gray-800 text-gray-300 hover:border-gray-400'
+                  }`}
+                  title={disabled ? `A market can have up to ${maxMarketTagsPerMarket} active tags.` : tag.description || tag.displayName}
+                >
+                  {selected ? '✓ ' : ''}
+                  {tag.displayName || tag.slug}
+                  {!tag.isActive ? ' (inactive)' : ''}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-xs text-amber-200">Create active tags in the Tags tab before assigning them to markets.</p>
+        )}
+        <button
+          type="button"
+          disabled={busyMarketId === market.id || !changed}
+          onClick={() => saveMarketTags(market)}
+          className="justify-self-start rounded-md bg-sky-700 px-3 py-2 text-sm font-semibold text-white transition hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Save Tags
+        </button>
+      </div>
+    );
+  };
+
   const renderActions = (market) => {
-    if (status !== 'proposed') {
+    if (!tagEditingEnabled) {
       return null;
     }
 
     return (
       <div className="grid min-w-[220px] gap-3">
-        <button
-          type="button"
-          disabled={busyMarketId === market.id}
-          onClick={() => approveMarket(market.id)}
-          className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Approve
-        </button>
-        <textarea
-          value={rejectionReasons[market.id] || ''}
-          onChange={(event) => setRejectionReasons((current) => ({
-            ...current,
-            [market.id]: event.target.value,
-          }))}
-          rows={3}
-          placeholder="Reason for rejection"
-          className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
-        />
-        <button
-          type="button"
-          disabled={busyMarketId === market.id || !(rejectionReasons[market.id] || '').trim()}
-          onClick={() => rejectMarket(market.id)}
-          className="rounded-md bg-rose-700 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-600 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Reject and Refund
-        </button>
+        {renderTagEditor(market)}
+        {status === 'proposed' && (
+          <>
+            <button
+              type="button"
+              disabled={busyMarketId === market.id}
+              onClick={() => approveMarket(market.id)}
+              className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Approve
+            </button>
+            <textarea
+              value={rejectionReasons[market.id] || ''}
+              onChange={(event) => setRejectionReasons((current) => ({
+                ...current,
+                [market.id]: event.target.value,
+              }))}
+              rows={3}
+              placeholder="Reason for rejection"
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+            <button
+              type="button"
+              disabled={busyMarketId === market.id || !(rejectionReasons[market.id] || '').trim()}
+              onClick={() => rejectMarket(market.id)}
+              className="rounded-md bg-rose-700 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Reject and Refund
+            </button>
+          </>
+        )}
       </div>
     );
   };
@@ -129,12 +282,17 @@ const AdminMarketQueue = ({ status }) => {
           {error}
         </div>
       )}
+      {successMessage && (
+        <div className="rounded-md bg-emerald-700 p-3 text-sm text-white">
+          {successMessage}
+        </div>
+      )}
       <MarketLifecycleTable
         markets={markets}
         emptyMessage={`No ${status} markets found.`}
         showCreator
         showSteward
-        actions={status === 'proposed' ? renderActions : null}
+        actions={tagEditingEnabled ? renderActions : null}
       />
     </div>
   );

--- a/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
+++ b/frontend/src/components/layouts/admin/ModeratorMarketReview.jsx
@@ -10,6 +10,12 @@ import {
 } from '../../../api/moderationApi';
 import { listAdminLifecycleMarkets } from '../../../api/lifecycleMarketsApi';
 import { listAdminUsers } from '../../../api/adminUsersApi';
+import {
+  createAdminMarketTag,
+  listAdminMarketTags,
+  updateAdminMarketTag,
+} from '../../../api/marketTagsApi';
+import MarketTagChips from '../../markets/MarketTagChips';
 
 const reviewTabs = [
   { label: 'Proposed Markets', status: 'proposed' },
@@ -378,6 +384,211 @@ const MarketStewardshipQueue = () => {
   );
 };
 
+const emptyTagForm = {
+  slug: '',
+  displayName: '',
+  description: '',
+  colorKey: 'slate',
+  sortOrder: 0,
+};
+
+const MarketTaxonomyAdmin = () => {
+  const { token } = useAuth();
+  const [tags, setTags] = useState([]);
+  const [form, setForm] = useState(emptyTagForm);
+  const [loading, setLoading] = useState(true);
+  const [busySlug, setBusySlug] = useState('');
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const loadTags = async () => {
+    if (!token) {
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const result = await listAdminMarketTags({ token, includeInactive: true });
+      setTags(result.tags || []);
+    } catch (err) {
+      setError(err.message || 'Unable to load market tags.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadTags();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const updateForm = (updates) => {
+    setForm((current) => ({ ...current, ...updates }));
+  };
+
+  const createTag = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccessMessage('');
+    try {
+      const created = await createAdminMarketTag({ token, tag: form });
+      setTags((current) => [...current, created].sort((left, right) => (
+        (left.sortOrder - right.sortOrder) || String(left.displayName).localeCompare(String(right.displayName))
+      )));
+      setForm(emptyTagForm);
+      setSuccessMessage(`Created tag ${created.displayName}.`);
+    } catch (err) {
+      setError(err.message || 'Unable to create market tag.');
+    }
+  };
+
+  const setTagActive = async (tag, isActive) => {
+    setBusySlug(tag.slug);
+    setError('');
+    setSuccessMessage('');
+    try {
+      const updated = await updateAdminMarketTag({
+        token,
+        slug: tag.slug,
+        tag: {
+          displayName: tag.displayName,
+          description: tag.description || '',
+          colorKey: tag.colorKey || 'slate',
+          sortOrder: tag.sortOrder || 0,
+          isActive,
+          confirmDeactivate: !isActive,
+        },
+      });
+      setTags((current) => current.map((item) => (item.slug === updated.slug ? updated : item)));
+      setSuccessMessage(`${updated.displayName} is now ${updated.isActive ? 'active' : 'inactive'}.`);
+    } catch (err) {
+      setError(err.message || 'Unable to update market tag.');
+    } finally {
+      setBusySlug('');
+    }
+  };
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="grid gap-6">
+      <div className="rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <h2 className="text-lg font-semibold text-white">Market Tags</h2>
+        <p className="mt-2 text-sm text-gray-300">
+          Admins define the tag vocabulary. Moderators can attach active tags during market creation; admins can review those tags before publication.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-red-700 p-3 text-sm text-white">
+          {error}
+        </div>
+      )}
+      {successMessage && (
+        <div className="rounded-md bg-emerald-700 p-3 text-sm text-white">
+          {successMessage}
+        </div>
+      )}
+
+      <form onSubmit={createTag} className="grid gap-4 rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="grid gap-1 text-sm text-gray-300">
+            Display name
+            <input
+              value={form.displayName}
+              onChange={(event) => updateForm({ displayName: event.target.value })}
+              required
+              maxLength={120}
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            Slug (optional)
+            <input
+              value={form.slug}
+              onChange={(event) => updateForm({ slug: event.target.value })}
+              placeholder="auto-generated from display name"
+              maxLength={64}
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+          </label>
+        </div>
+        <label className="grid gap-1 text-sm text-gray-300">
+          Description
+          <textarea
+            value={form.description}
+            onChange={(event) => updateForm({ description: event.target.value })}
+            rows={3}
+            maxLength={500}
+            className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+        </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="grid gap-1 text-sm text-gray-300">
+            Color key
+            <select
+              value={form.colorKey}
+              onChange={(event) => updateForm({ colorKey: event.target.value })}
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            >
+              <option value="slate">Slate</option>
+              <option value="sky">Sky</option>
+              <option value="emerald">Emerald</option>
+              <option value="amber">Amber</option>
+              <option value="rose">Rose</option>
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            Sort order
+            <input
+              type="number"
+              value={form.sortOrder}
+              onChange={(event) => updateForm({ sortOrder: Number(event.target.value || 0) })}
+              className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+            />
+          </label>
+        </div>
+        <button
+          type="submit"
+          className="justify-self-start rounded-md bg-primary-pink px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-pink/80"
+        >
+          Create Tag
+        </button>
+      </form>
+
+      <div className="grid gap-3">
+        {tags.map((tag) => (
+          <div key={tag.slug} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-900/70 p-4 md:grid-cols-[1fr,auto] md:items-center">
+            <div>
+              <MarketTagChips tags={[tag]} />
+              <div className="mt-2 font-mono text-xs text-gray-500">{tag.slug}</div>
+              {tag.description && <p className="mt-2 text-sm text-gray-300">{tag.description}</p>}
+              {!tag.isActive && <p className="mt-2 text-xs text-amber-300">Inactive tags stay visible on historical markets but cannot be newly assigned.</p>}
+            </div>
+            <button
+              type="button"
+              disabled={busySlug === tag.slug}
+              onClick={() => setTagActive(tag, !tag.isActive)}
+              className={`rounded-md px-3 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                tag.isActive ? 'bg-amber-700 hover:bg-amber-600' : 'bg-emerald-700 hover:bg-emerald-600'
+              }`}
+            >
+              {tag.isActive ? 'Deactivate' : 'Reactivate'}
+            </button>
+          </div>
+        ))}
+        {!tags.length && (
+          <div className="rounded-lg border border-gray-700 bg-gray-900/70 p-6 text-center text-gray-300">
+            No tags have been created yet.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
 function ModeratorMarketReview() {
   const tabsData = [
     ...reviewTabs.map((tab) => ({
@@ -387,6 +598,10 @@ function ModeratorMarketReview() {
     {
       label: 'Stewardship',
       content: <MarketStewardshipQueue />,
+    },
+    {
+      label: 'Tags',
+      content: <MarketTaxonomyAdmin />,
     },
   ];
 

--- a/frontend/src/components/layouts/admin/UserQueue.jsx
+++ b/frontend/src/components/layouts/admin/UserQueue.jsx
@@ -5,6 +5,22 @@ import {
   promoteUserToModerator,
   updateModeratorSuspension,
 } from '../../../api/adminUsersApi';
+import SiteTabs from '../../tabs/SiteTabs';
+
+const userQueueTabs = [
+  {
+    label: 'Non-Moderators',
+    usertype: 'REGULAR',
+    emptyMessage: 'No non-moderator users found.',
+    searchPlaceholder: 'Search non-moderators by username, display name, or email',
+  },
+  {
+    label: 'Moderators',
+    usertype: 'MODERATOR',
+    emptyMessage: 'No moderators found.',
+    searchPlaceholder: 'Search moderators by username, display name, or email',
+  },
+];
 
 const roleBadgeClass = (user) => {
   if (user.usertype === 'ADMIN') return 'bg-sky-700 text-sky-50';
@@ -18,13 +34,16 @@ const moderatorLabel = (user) => {
   return user.moderatorStatus || 'active';
 };
 
-function UserQueue() {
+const userMatchesTab = (user, usertype) => user?.usertype === usertype;
+
+const UserQueueTab = ({ config }) => {
   const { token } = useAuth();
   const [users, setUsers] = useState([]);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [pendingUsername, setPendingUsername] = useState('');
   const [reasonByUsername, setReasonByUsername] = useState({});
+  const [searchQuery, setSearchQuery] = useState('');
 
   const counts = useMemo(() => users.reduce((acc, user) => {
     if (user.usertype === 'MODERATOR') {
@@ -38,11 +57,16 @@ function UserQueue() {
     return acc;
   }, { candidates: 0, moderators: 0, suspended: 0 }), [users]);
 
-  const loadUsers = async () => {
+  const loadUsers = async (query = searchQuery) => {
     setError('');
     setIsLoading(true);
     try {
-      const result = await listAdminUsers({ token });
+      const result = await listAdminUsers({
+        token,
+        usertype: config.usertype,
+        query,
+        limit: 250,
+      });
       setUsers(result.users || []);
     } catch (err) {
       setError(err.message || 'Failed to load user queue.');
@@ -52,9 +76,19 @@ function UserQueue() {
   };
 
   useEffect(() => {
-    loadUsers();
+    if (!token) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      loadUsers(searchQuery);
+    }, 300);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [token, config.usertype, searchQuery]);
 
   const reasonFor = (username) => reasonByUsername[username] || '';
 
@@ -66,9 +100,14 @@ function UserQueue() {
   };
 
   const updateUserInQueue = (updatedUser) => {
-    setUsers((current) => current.map((user) => (
-      user.username === updatedUser.username ? updatedUser : user
-    )));
+    setUsers((current) => {
+      if (!userMatchesTab(updatedUser, config.usertype)) {
+        return current.filter((user) => user.username !== updatedUser.username);
+      }
+      return current.map((user) => (
+        user.username === updatedUser.username ? updatedUser : user
+      ));
+    });
   };
 
   const runUserAction = async (username, action) => {
@@ -94,50 +133,52 @@ function UserQueue() {
   };
 
   return (
-    <section className="p-6 bg-primary-background shadow-md rounded-lg text-white">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <p className="text-xs uppercase tracking-[0.22em] text-primary-pink">
-            Moderator governance
-          </p>
-          <h1 className="mt-2 text-2xl font-bold">User Queue</h1>
-          <p className="mt-2 max-w-3xl text-sm text-gray-300">
-            Review all users, see who is approved as a moderator, and perform
-            baseline moderator promotion or suspension actions.
-          </p>
+    <div className="grid gap-5">
+      <div className="grid gap-2 rounded-lg border border-gray-700 bg-gray-900/70 p-4">
+        <label htmlFor={`user-queue-search-${config.usertype}`} className="text-xs font-mono uppercase tracking-[0.16em] text-gray-400">
+          Search users
+        </label>
+        <div className="relative">
+          <input
+            id={`user-queue-search-${config.usertype}`}
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={config.searchPlaceholder}
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 pr-10 text-sm text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+          />
+          {isLoading && (
+            <div className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-b-2 border-primary-pink" />
+          )}
         </div>
-        <button
-          type="button"
-          onClick={loadUsers}
-          disabled={isLoading}
-          className="rounded-md bg-primary-pink px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {isLoading ? 'Refreshing...' : 'Refresh Queue'}
-        </button>
       </div>
 
-      <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {config.usertype === 'REGULAR' && (
         <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
-          <p className="text-xs uppercase tracking-wide text-gray-400">Candidates</p>
+          <p className="text-xs uppercase tracking-wide text-gray-400">Non-moderator users</p>
           <p className="mt-1 text-2xl font-bold">{counts.candidates}</p>
         </div>
-        <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
-          <p className="text-xs uppercase tracking-wide text-gray-400">Moderators</p>
-          <p className="mt-1 text-2xl font-bold">{counts.moderators}</p>
+      )}
+      {config.usertype === 'MODERATOR' && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
+            <p className="text-xs uppercase tracking-wide text-gray-400">Moderators</p>
+            <p className="mt-1 text-2xl font-bold">{counts.moderators}</p>
+          </div>
+          <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
+            <p className="text-xs uppercase tracking-wide text-gray-400">Suspended</p>
+            <p className="mt-1 text-2xl font-bold">{counts.suspended}</p>
+          </div>
         </div>
-        <div className="rounded-md border border-gray-700 bg-gray-900 p-3">
-          <p className="text-xs uppercase tracking-wide text-gray-400">Suspended</p>
-          <p className="mt-1 text-2xl font-bold">{counts.suspended}</p>
-        </div>
-      </div>
+      )}
 
       {error && (
-        <div className="mt-5 rounded-md bg-red-700 p-3 text-sm text-white">
+        <div className="rounded-md bg-red-700 p-3 text-sm text-white">
           {error}
         </div>
       )}
 
-      <div className="mt-6 overflow-x-auto rounded-lg border border-gray-700">
+      <div className="overflow-x-auto rounded-lg border border-gray-700">
         <table className="min-w-full divide-y divide-gray-700 text-left text-sm">
           <thead className="bg-gray-900 text-xs uppercase tracking-wide text-gray-300">
             <tr>
@@ -228,12 +269,39 @@ function UserQueue() {
             {!isLoading && users.length === 0 && (
               <tr>
                 <td className="px-4 py-8 text-center text-gray-400" colSpan="5">
-                  No users found.
+                  {config.emptyMessage}
                 </td>
               </tr>
             )}
           </tbody>
         </table>
+      </div>
+    </div>
+  );
+};
+
+function UserQueue() {
+  const tabsData = userQueueTabs.map((tab) => ({
+    label: tab.label,
+    content: <UserQueueTab config={tab} />,
+  }));
+
+  return (
+    <section className="p-6 bg-primary-background shadow-md rounded-lg text-white">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.22em] text-primary-pink">
+            Moderator governance
+          </p>
+          <h1 className="mt-2 text-2xl font-bold">User Queue</h1>
+          <p className="mt-2 max-w-3xl text-sm text-gray-300">
+            Review users by moderator status and perform baseline moderator promotion or suspension actions.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <SiteTabs tabs={tabsData} defaultTab="Non-Moderators" />
       </div>
     </section>
   );

--- a/frontend/src/components/layouts/profile/MarketLifecycleTable.jsx
+++ b/frontend/src/components/layouts/profile/MarketLifecycleTable.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import MarketTagChips from '../../markets/MarketTagChips';
 
 const formatDate = (value) => {
   if (!value) return 'n/a';
@@ -101,6 +102,7 @@ const MarketLifecycleTable = ({ markets = [], emptyMessage, showCreator = false,
                     </button>
                   </div>
                 )}
+                <MarketTagChips tags={market.tags || []} className="mt-3" />
                 <MarketLabels market={market} />
                 {statusLabel(market) === 'published' && (
                   <Link className="mt-2 inline-block text-primary-pink hover:underline" to={`/markets/${market.id}`}>

--- a/frontend/src/components/marketDetails/MarketDetailsLayout.jsx
+++ b/frontend/src/components/marketDetails/MarketDetailsLayout.jsx
@@ -8,6 +8,7 @@ import TradeTabs from '../../components/tabs/TradeTabs';
 import { BetButton } from '../buttons/trade/BetButtons';
 import formatResolutionDate from '../../helpers/formatResolutionDate';
 import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const DEFAULT_CREATOR_EMOJI = '👤';
 
@@ -92,6 +93,7 @@ function MarketDetailsTable({
           <span>•</span>
           <span>🪙 {currentProbability.toFixed(2)}</span>
         </div>
+        <MarketTagChips tags={safeMarket.tags || []} className='mt-3' />
       </div>
 
       <div className='mb-4'>

--- a/frontend/src/components/markets/MarketTagChips.jsx
+++ b/frontend/src/components/markets/MarketTagChips.jsx
@@ -26,7 +26,7 @@ export const MARKET_TAG_COLOR_OPTIONS = [
   { key: 'violet', label: 'Violet' },
 ];
 
-const chipClassFor = (tag) => {
+export const marketTagChipClassFor = (tag) => {
   const key = String(tag?.colorKey || 'slate').toLowerCase();
   return colorClasses[key] || colorClasses.slate;
 };
@@ -42,7 +42,7 @@ const MarketTagChips = ({ tags = [], className = '' }) => {
       {visibleTags.map((tag) => (
         <span
           key={tag.slug || tag.displayName}
-          className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${chipClassFor(tag)}`}
+          className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${marketTagChipClassFor(tag)}`}
           title={tag.description || tag.displayName || tag.slug}
         >
           {tag.displayName || tag.slug}

--- a/frontend/src/components/markets/MarketTagChips.jsx
+++ b/frontend/src/components/markets/MarketTagChips.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const colorClasses = {
+  sky: 'border-sky-500/40 bg-sky-950/40 text-sky-100',
+  emerald: 'border-emerald-500/40 bg-emerald-950/40 text-emerald-100',
+  amber: 'border-amber-500/40 bg-amber-950/40 text-amber-100',
+  rose: 'border-rose-500/40 bg-rose-950/40 text-rose-100',
+  slate: 'border-gray-500/40 bg-gray-800/70 text-gray-200',
+};
+
+const chipClassFor = (tag) => {
+  const key = String(tag?.colorKey || 'slate').toLowerCase();
+  return colorClasses[key] || colorClasses.slate;
+};
+
+const MarketTagChips = ({ tags = [], className = '' }) => {
+  const visibleTags = (tags || []).filter((tag) => tag?.slug || tag?.displayName);
+  if (!visibleTags.length) {
+    return null;
+  }
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`.trim()} aria-label="Market tags">
+      {visibleTags.map((tag) => (
+        <span
+          key={tag.slug || tag.displayName}
+          className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${chipClassFor(tag)}`}
+          title={tag.description || tag.displayName || tag.slug}
+        >
+          {tag.displayName || tag.slug}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default MarketTagChips;

--- a/frontend/src/components/markets/MarketTagChips.jsx
+++ b/frontend/src/components/markets/MarketTagChips.jsx
@@ -2,11 +2,29 @@ import React from 'react';
 
 const colorClasses = {
   sky: 'border-sky-500/40 bg-sky-950/40 text-sky-100',
+  cyan: 'border-cyan-500/40 bg-cyan-950/40 text-cyan-100',
+  teal: 'border-teal-500/40 bg-teal-950/40 text-teal-100',
   emerald: 'border-emerald-500/40 bg-emerald-950/40 text-emerald-100',
+  lime: 'border-lime-500/40 bg-lime-950/40 text-lime-100',
   amber: 'border-amber-500/40 bg-amber-950/40 text-amber-100',
+  orange: 'border-orange-500/40 bg-orange-950/40 text-orange-100',
   rose: 'border-rose-500/40 bg-rose-950/40 text-rose-100',
+  violet: 'border-violet-500/40 bg-violet-950/40 text-violet-100',
   slate: 'border-gray-500/40 bg-gray-800/70 text-gray-200',
 };
+
+export const MARKET_TAG_COLOR_OPTIONS = [
+  { key: 'slate', label: 'Slate', guidance: 'Default / general' },
+  { key: 'sky', label: 'Sky', guidance: 'Open questions / civic' },
+  { key: 'cyan', label: 'Cyan', guidance: 'Science / technology' },
+  { key: 'teal', label: 'Teal', guidance: 'Health / environment' },
+  { key: 'emerald', label: 'Emerald', guidance: 'Finance / growth' },
+  { key: 'lime', label: 'Lime', guidance: 'Sports / active events' },
+  { key: 'amber', label: 'Amber', guidance: 'Warnings / high attention' },
+  { key: 'orange', label: 'Orange', guidance: 'Culture / media' },
+  { key: 'rose', label: 'Rose', guidance: 'Politics / conflict' },
+  { key: 'violet', label: 'Violet', guidance: 'Meta / platform' },
+];
 
 const chipClassFor = (tag) => {
   const key = String(tag?.colorKey || 'slate').toLowerCase();

--- a/frontend/src/components/markets/MarketTagChips.jsx
+++ b/frontend/src/components/markets/MarketTagChips.jsx
@@ -14,16 +14,16 @@ const colorClasses = {
 };
 
 export const MARKET_TAG_COLOR_OPTIONS = [
-  { key: 'slate', label: 'Slate', guidance: 'Default / general' },
-  { key: 'sky', label: 'Sky', guidance: 'Open questions / civic' },
-  { key: 'cyan', label: 'Cyan', guidance: 'Science / technology' },
-  { key: 'teal', label: 'Teal', guidance: 'Health / environment' },
-  { key: 'emerald', label: 'Emerald', guidance: 'Finance / growth' },
-  { key: 'lime', label: 'Lime', guidance: 'Sports / active events' },
-  { key: 'amber', label: 'Amber', guidance: 'Warnings / high attention' },
-  { key: 'orange', label: 'Orange', guidance: 'Culture / media' },
-  { key: 'rose', label: 'Rose', guidance: 'Politics / conflict' },
-  { key: 'violet', label: 'Violet', guidance: 'Meta / platform' },
+  { key: 'slate', label: 'Slate' },
+  { key: 'sky', label: 'Sky' },
+  { key: 'cyan', label: 'Cyan' },
+  { key: 'teal', label: 'Teal' },
+  { key: 'emerald', label: 'Emerald' },
+  { key: 'lime', label: 'Lime' },
+  { key: 'amber', label: 'Amber' },
+  { key: 'orange', label: 'Orange' },
+  { key: 'rose', label: 'Rose' },
+  { key: 'violet', label: 'Violet' },
 ];
 
 const chipClassFor = (tag) => {

--- a/frontend/src/components/search/GlobalSearchBar.jsx
+++ b/frontend/src/components/search/GlobalSearchBar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { searchMarkets } from '../../api/marketsApi';
 import { RegularInput } from '../inputs/InputBar';
 
-const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSearching }) => {
+const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSearching, tagSlug = '' }) => {
     const [query, setQuery] = useState('');
     const [loading, setLoading] = useState(false);
 
@@ -19,14 +19,14 @@ const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSea
         }, 300); // 300ms debounce
 
         return () => clearTimeout(timeoutId);
-    }, [query, currentStatus]);
+    }, [query, currentStatus, tagSlug]);
 
     const performSearch = async (searchQuery) => {
         setLoading(true);
         setIsSearching(true);
         
         try {
-            const results = await searchMarkets(searchQuery, currentStatus, 20);
+            const results = await searchMarkets(searchQuery, currentStatus, 20, { tagSlug });
             onSearchResults(results);
         } catch (error) {
             console.error('Search error:', error);
@@ -73,7 +73,9 @@ const GlobalSearchBar = ({ onSearchResults, currentStatus, isSearching, setIsSea
             </div>
             {isSearching && query && (
                 <div className="mt-2 text-sm text-gray-400">
-                    Searching in <span className="text-primary-pink font-medium">{currentStatus}</span> markets for: 
+                    Searching in <span className="text-primary-pink font-medium">{currentStatus}</span> markets{tagSlug ? (
+                        <> tagged <span className="text-primary-pink font-medium">{tagSlug}</span></>
+                    ) : null} for:
                     <span className="text-white font-medium"> "{query}"</span>
                 </div>
             )}

--- a/frontend/src/components/tables/MarketTable.jsx
+++ b/frontend/src/components/tables/MarketTable.jsx
@@ -5,6 +5,7 @@ import MobileMarketCard from './MobileMarketCard';
 import ExpandableText from '../utils/ExpandableText';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
 import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const TableHeader = () => (
   <thead className='bg-gray-900'>
@@ -60,6 +61,7 @@ const MarketRow = ({ marketData }) => (
           expandIcon="📐"
         />
       </Link>
+      <MarketTagChips tags={marketData.market.tags || []} className="mt-2" />
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
       {formatResolutionDate(marketData.market.resolutionDateTime)}

--- a/frontend/src/components/tables/MarketTables.jsx
+++ b/frontend/src/components/tables/MarketTables.jsx
@@ -6,6 +6,7 @@ import MobileMarketCard from '../../components/tables/MobileMarketCard';
 import LoadingSpinner from '../../components/loaders/LoadingSpinner';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
 import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const TableHeader = () => (
   <thead className='bg-gray-900'>
@@ -45,7 +46,7 @@ const MarketRow = ({ marketData }) => (
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-300'>
       {marketData.lastProbability.toFixed(2)}
     </td>
-    <td className='px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-300'>
+    <td className='px-6 py-4 whitespace-normal text-sm font-medium text-gray-300'>
       <Link
         to={`/markets/${marketData.market.id}`}
         className='hover:text-blue-400 transition-colors duration-200 block max-w-xs overflow-hidden overflow-ellipsis'
@@ -53,6 +54,7 @@ const MarketRow = ({ marketData }) => (
       >
         {marketData.market.questionTitle}
       </Link>
+      <MarketTagChips tags={marketData.market.tags || []} className="mt-2" />
     </td>
     <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
       {formatResolutionDate(marketData.market.resolutionDateTime)}

--- a/frontend/src/components/tables/MarketsByStatusTable.jsx
+++ b/frontend/src/components/tables/MarketsByStatusTable.jsx
@@ -181,7 +181,7 @@ function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT, tagSlug = '' }) {
         const params = new URLSearchParams();
 
         if (status && status.toLowerCase() !== 'all') {
-          params.set('status', status.toUpperCase());
+          params.set('status', status.toLowerCase());
         }
 
         params.set('limit', String(limit || DEFAULT_LIMIT));

--- a/frontend/src/components/tables/MarketsByStatusTable.jsx
+++ b/frontend/src/components/tables/MarketsByStatusTable.jsx
@@ -164,7 +164,7 @@ const MarketRow = ({ marketData }) => {
   );
 };
 
-function MarketsByStatusTable({ status }) {
+function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT }) {
   const [marketsData, setMarketsData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -184,7 +184,7 @@ function MarketsByStatusTable({ status }) {
           params.set('status', status.toUpperCase());
         }
 
-        params.set('limit', String(DEFAULT_LIMIT));
+        params.set('limit', String(limit || DEFAULT_LIMIT));
         url.search = params.toString();
 
         const response = await fetch(url.toString(), { signal: controller.signal });
@@ -214,7 +214,7 @@ function MarketsByStatusTable({ status }) {
     fetchMarkets();
 
     return () => controller.abort();
-  }, [status]);
+  }, [status, limit]);
 
   if (loading)
     return (

--- a/frontend/src/components/tables/MarketsByStatusTable.jsx
+++ b/frontend/src/components/tables/MarketsByStatusTable.jsx
@@ -7,6 +7,7 @@ import LoadingSpinner from '../loaders/LoadingSpinner';
 import ExpandableLink from '../utils/ExpandableLink';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
 import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_CREATOR_EMOJI = '👤';
@@ -113,15 +114,18 @@ const MarketRow = ({ marketData }) => {
         {probabilityDisplay}
       </td>
       <td className='px-6 py-4 text-sm font-medium text-gray-300'>
-        <ExpandableLink
-          text={questionTitle}
-          to={marketId ? `/markets/${marketId}` : '#'}
-          maxLength={45}
-          className=''
-          linkClassName='hover:text-blue-400 transition-colors duration-200'
-          buttonClassName='text-xs text-blue-400 hover:text-blue-300 transition-colors ml-1'
-          expandIcon='📐'
-        />
+        <div className='flex max-w-md flex-wrap items-center gap-2'>
+          <ExpandableLink
+            text={questionTitle}
+            to={marketId ? `/markets/${marketId}` : '#'}
+            maxLength={45}
+            className=''
+            linkClassName='hover:text-blue-400 transition-colors duration-200'
+            buttonClassName='text-xs text-blue-400 hover:text-blue-300 transition-colors ml-1'
+            expandIcon='📐'
+          />
+          <MarketTagChips tags={market.tags || []} />
+        </div>
       </td>
       <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-400'>
         {formatResolutionDate(resolutionDate)}

--- a/frontend/src/components/tables/MarketsByStatusTable.jsx
+++ b/frontend/src/components/tables/MarketsByStatusTable.jsx
@@ -164,7 +164,7 @@ const MarketRow = ({ marketData }) => {
   );
 };
 
-function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT }) {
+function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT, tagSlug = '' }) {
   const [marketsData, setMarketsData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -185,6 +185,9 @@ function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT }) {
         }
 
         params.set('limit', String(limit || DEFAULT_LIMIT));
+        if (tagSlug) {
+          params.set('tagSlug', tagSlug);
+        }
         url.search = params.toString();
 
         const response = await fetch(url.toString(), { signal: controller.signal });
@@ -214,7 +217,7 @@ function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT }) {
     fetchMarkets();
 
     return () => controller.abort();
-  }, [status, limit]);
+  }, [status, limit, tagSlug]);
 
   if (loading)
     return (

--- a/frontend/src/components/tables/MobileMarketCard.jsx
+++ b/frontend/src/components/tables/MobileMarketCard.jsx
@@ -4,6 +4,7 @@ import formatResolutionDate from '../../helpers/formatResolutionDate';
 import ExpandableText from '../utils/ExpandableText';
 import { getResolvedText, getResultCssClass } from '../../utils/labelMapping';
 import StewardTag, { stewardUsernameFor } from '../markets/StewardTag';
+import MarketTagChips from '../markets/MarketTagChips';
 
 const MobileMarketCard = ({ marketData }) => {
   const isMarketOpen =
@@ -56,6 +57,7 @@ const MobileMarketCard = ({ marketData }) => {
           expandIcon="📐"
         />
       </Link>
+      <MarketTagChips tags={marketData.market.tags || []} className='mb-3' />
       <div className='grid grid-cols-3 text-sm text-gray-400'>
         <span className='truncate'>👤 {marketData.numUsers}</span>
         <span className='text-center'>

--- a/frontend/src/helpers/AppRoutes.jsx
+++ b/frontend/src/helpers/AppRoutes.jsx
@@ -40,6 +40,13 @@ const AppRoutes = () => {
           <About />
         )}
       </Route>
+      <Route exact path='/markets/topic/:slug'>
+        {isLoggedIn && mustChangePassword ? (
+          <Redirect to='/changepassword' />
+        ) : (
+          <Markets />
+        )}
+      </Route>
       <Route exact path='/markets/:marketId'>
         {isLoggedIn && mustChangePassword ? (
           <Redirect to='/changepassword' />

--- a/frontend/src/hooks/useMarketDetails.jsx
+++ b/frontend/src/hooks/useMarketDetails.jsx
@@ -39,6 +39,32 @@ const normalizeProbabilityChanges = (raw) => {
     .filter((item) => item !== null);
 };
 
+const normalizeMarketTag = (tag) => {
+  if (!tag || typeof tag !== 'object') {
+    return null;
+  }
+
+  return {
+    id: tag.id ?? tag.ID ?? null,
+    slug: tag.slug ?? tag.Slug ?? '',
+    displayName: tag.displayName ?? tag.DisplayName ?? '',
+    description: tag.description ?? tag.Description ?? '',
+    colorKey: tag.colorKey ?? tag.ColorKey ?? 'slate',
+    sortOrder: toNumber(tag.sortOrder ?? tag.SortOrder),
+    isActive: tag.isActive ?? tag.IsActive ?? true,
+  };
+};
+
+const normalizeMarketTags = (raw) => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .map(normalizeMarketTag)
+    .filter((tag) => tag !== null);
+};
+
 const normalizeMarket = (market) => {
   if (!market || typeof market !== 'object') {
     return {
@@ -57,6 +83,7 @@ const normalizeMarket = (market) => {
       initialProbability: 0,
       isResolved: false,
       resolutionResult: null,
+      tags: [],
     };
   }
 
@@ -76,6 +103,7 @@ const normalizeMarket = (market) => {
     initialProbability: toNumber(market.initialProbability ?? market.InitialProbability),
     isResolved: market.isResolved ?? market.IsResolved ?? false,
     resolutionResult: market.resolutionResult ?? market.ResolutionResult ?? null,
+    tags: normalizeMarketTags(market.tags ?? market.Tags),
   };
 };
 

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import AdminAddUser from '../../components/layouts/admin/AddUser';
 import ModeratorMarketReview from '../../components/layouts/admin/ModeratorMarketReview';
 import UserQueue from '../../components/layouts/admin/UserQueue';
-import HomeEditor from './HomeEditor';
-import SocialShareEditor from './SocialShareEditor';
+import CmsDashboard from './CmsDashboard';
 import SiteTabs from '../../components/tabs/SiteTabs';
 
 function AdminDashboard() {
@@ -16,13 +15,9 @@ function AdminDashboard() {
             label: 'User Queue',
             content: <UserQueue />
         },
-        { 
-            label: 'Homepage Editor', 
-            content: <HomeEditor /> 
-        },
         {
-            label: 'Social Share',
-            content: <SocialShareEditor />
+            label: 'CMS',
+            content: <CmsDashboard />
         },
         {
             label: 'Market Review',

--- a/frontend/src/pages/admin/CmsDashboard.jsx
+++ b/frontend/src/pages/admin/CmsDashboard.jsx
@@ -22,7 +22,7 @@ function CmsDashboard() {
 
   return (
     <section className="bg-primary-background text-white">
-      <div className="p-6 pb-0">
+      <div className="p-6 pb-5">
         <p className="text-xs uppercase tracking-[0.22em] text-primary-pink">Admin CMS</p>
         <h1 className="mt-2 text-2xl font-bold">Content And Discovery Management</h1>
         <p className="mt-2 max-w-3xl text-sm text-gray-300">

--- a/frontend/src/pages/admin/CmsDashboard.jsx
+++ b/frontend/src/pages/admin/CmsDashboard.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import SiteTabs from '../../components/tabs/SiteTabs';
+import HomeEditor from './HomeEditor';
+import MarketDiscoveryLayoutEditor from './MarketDiscoveryLayoutEditor';
+import SocialShareEditor from './SocialShareEditor';
+
+function CmsDashboard() {
+  const tabsData = [
+    {
+      label: 'Home Page',
+      content: <HomeEditor />,
+    },
+    {
+      label: 'Market Discovery Layout',
+      content: <MarketDiscoveryLayoutEditor />,
+    },
+    {
+      label: 'Social Share',
+      content: <SocialShareEditor />,
+    },
+  ];
+
+  return (
+    <section className="bg-primary-background text-white">
+      <div className="p-6 pb-0">
+        <p className="text-xs uppercase tracking-[0.22em] text-primary-pink">Admin CMS</p>
+        <h1 className="mt-2 text-2xl font-bold">Content And Discovery Management</h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-300">
+          Manage public homepage content, market discovery layout planning, and social share defaults.
+        </p>
+      </div>
+      <SiteTabs tabs={tabsData} defaultTab="Home Page" />
+    </section>
+  );
+}
+
+export default CmsDashboard;

--- a/frontend/src/pages/admin/CmsDashboard.jsx
+++ b/frontend/src/pages/admin/CmsDashboard.jsx
@@ -7,12 +7,12 @@ import SocialShareEditor from './SocialShareEditor';
 function CmsDashboard() {
   const tabsData = [
     {
-      label: 'Home Page',
-      content: <HomeEditor />,
-    },
-    {
       label: 'Market Discovery Layout',
       content: <MarketDiscoveryLayoutEditor />,
+    },
+    {
+      label: 'Home Page',
+      content: <HomeEditor />,
     },
     {
       label: 'Social Share',
@@ -29,7 +29,7 @@ function CmsDashboard() {
           Manage public homepage content, market discovery layout planning, and social share defaults.
         </p>
       </div>
-      <SiteTabs tabs={tabsData} defaultTab="Home Page" />
+      <SiteTabs tabs={tabsData} defaultTab="Market Discovery Layout" />
     </section>
   );
 }

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
-import { searchMarkets } from '../../api/marketsApi';
+import { getMarketDetails, searchMarkets } from '../../api/marketsApi';
 import { listAdminMarketTags } from '../../api/marketTagsApi';
 
 const layoutModes = {
@@ -151,6 +151,40 @@ const MarketPinSearch = ({ pin, onSelect }) => {
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
   const [searchError, setSearchError] = useState('');
+  const [selectedTitle, setSelectedTitle] = useState('');
+  const [loadingSelectedTitle, setLoadingSelectedTitle] = useState(false);
+
+  useEffect(() => {
+    const marketId = Number(pin.marketId);
+    if (!marketId) {
+      setSelectedTitle('');
+      setLoadingSelectedTitle(false);
+      return undefined;
+    }
+
+    let ignore = false;
+    setLoadingSelectedTitle(true);
+    getMarketDetails(marketId)
+      .then((details) => {
+        if (!ignore) {
+          setSelectedTitle(details?.market?.questionTitle || `Market #${marketId}`);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setSelectedTitle(`Market #${marketId}`);
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setLoadingSelectedTitle(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [pin.marketId]);
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -191,9 +225,16 @@ const MarketPinSearch = ({ pin, onSelect }) => {
     <div className="grid gap-3">
       <div className="rounded-lg border border-gray-700 bg-gray-900/70 p-3">
         <div className="font-mono text-xs uppercase tracking-[0.14em] text-gray-400">Selected Market</div>
-        <div className="mt-1 text-sm text-white">
-          {Number(pin.marketId) > 0 ? `Market #${pin.marketId}` : 'No market selected yet.'}
-        </div>
+        {Number(pin.marketId) > 0 ? (
+          <>
+            <div className="mt-1 text-sm font-semibold text-white">
+              {loadingSelectedTitle ? 'Loading selected market...' : selectedTitle || `Market #${pin.marketId}`}
+            </div>
+            <div className="mt-1 text-xs text-gray-400">Market #{pin.marketId}</div>
+          </>
+        ) : (
+          <div className="mt-1 text-sm text-white">No market selected yet.</div>
+        )}
       </div>
       <Field label="Search Active Markets">
         <input
@@ -214,6 +255,7 @@ const MarketPinSearch = ({ pin, onSelect }) => {
                 key={id}
                 type="button"
                 onClick={() => {
+                  setSelectedTitle(marketOverviewTitle(overview));
                   onSelect(id);
                   setQuery('');
                   setResults([]);

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
+import { listAdminMarketTags } from '../../api/marketTagsApi';
 
 const layoutModes = {
   top: {
@@ -118,6 +119,24 @@ const Field = ({ label, children, className = '' }) => (
 
 const textInputClass = 'rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40';
 
+const tagOptionLabel = (tag) => `${tag.displayName || tag.slug} (${tag.slug})`;
+
+const tagOptionsWithCurrent = (tags, currentSlug) => {
+  const normalizedCurrent = String(currentSlug || '').trim();
+  if (!normalizedCurrent || tags.some((tag) => tag.slug === normalizedCurrent)) {
+    return tags;
+  }
+
+  return [
+    ...tags,
+    {
+      slug: normalizedCurrent,
+      displayName: `Saved slug: ${normalizedCurrent}`,
+      isActive: false,
+    },
+  ];
+};
+
 const LayoutPreview = ({ mode, state }) => {
   const hasCuratedBlocks = state.featuredTopicsEnabled || state.featuredMarketsEnabled || state.sectionsEnabled;
   const recommendationLimit = hasCuratedBlocks
@@ -181,6 +200,7 @@ function MarketDiscoveryLayoutEditor() {
   const [saving, setSaving] = useState(false);
   const [savingSections, setSavingSections] = useState(false);
   const [savingPins, setSavingPins] = useState(false);
+  const [activeTags, setActiveTags] = useState([]);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
@@ -219,10 +239,39 @@ function MarketDiscoveryLayoutEditor() {
     };
   }, []);
 
+  useEffect(() => {
+    let ignore = false;
+
+    const loadActiveTags = async () => {
+      try {
+        const result = await listAdminMarketTags({ includeInactive: false });
+        if (!ignore) {
+          setActiveTags(result.tags || []);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load active market tags.');
+        }
+      }
+    };
+
+    loadActiveTags();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
   const mode = layoutModes[selectedMode];
   const state = layoutState[selectedMode];
   const topicPins = state.pins.filter((pin) => pin.pinType === 'discovery_page');
   const marketPins = state.pins.filter((pin) => pin.pinType === 'market');
+  const activeTagOptions = useMemo(() => (
+    [...activeTags].sort((left, right) => (
+      (left.displayName || left.slug).localeCompare(right.displayName || right.slug)
+    ))
+  ), [activeTags]);
+  const firstActiveTagSlug = activeTagOptions[0]?.slug || '';
 
   const replaceSelectedState = (saved) => {
     setLayoutState((current) => ({
@@ -350,7 +399,7 @@ function MarketDiscoveryLayoutEditor() {
         {
           pinType,
           marketId: pinType === 'market' ? '' : 0,
-          targetPageSlug: pinType === 'discovery_page' ? 'topic-template' : '',
+          targetPageSlug: pinType === 'discovery_page' ? firstActiveTagSlug : '',
           label: pinType === 'market' ? 'Featured Market' : 'Featured Topic',
           sortOrder: nextSortOrder(state.pins),
         },
@@ -522,7 +571,7 @@ function MarketDiscoveryLayoutEditor() {
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h3 className="text-xl font-bold text-white">Sections</h3>
-                  <p className="mt-1 text-sm text-gray-400">Named section cards can optionally point at a tag slug. Empty pages still use the implicit All section.</p>
+                  <p className="mt-1 text-sm text-gray-400">Named section cards can optionally point at an active tag. Empty pages still use the implicit All section.</p>
                 </div>
                 <div className="flex gap-2">
                   <button type="button" onClick={addSection} className="rounded-md border border-sky-500/50 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-950/50">Add Section</button>
@@ -548,8 +597,19 @@ function MarketDiscoveryLayoutEditor() {
                       <input type="checkbox" checked={section.isActive !== false} onChange={(event) => updateSection(index, { isActive: event.target.checked })} className="h-4 w-4 accent-primary-pink" />
                       Active
                     </label>
-                    <Field label="Tag Filter Slug" className="md:col-span-2">
-                      <input value={section.tagFilterSlug || ''} onChange={(event) => updateSection(index, { tagFilterSlug: event.target.value })} placeholder="politics" className={textInputClass} />
+                    <Field label="Tag Filter" className="md:col-span-2">
+                      <select
+                        value={section.tagFilterSlug || ''}
+                        onChange={(event) => updateSection(index, { tagFilterSlug: event.target.value })}
+                        className={textInputClass}
+                      >
+                        <option value="">No tag filter</option>
+                        {tagOptionsWithCurrent(activeTagOptions, section.tagFilterSlug).map((tag) => (
+                          <option key={tag.slug} value={tag.slug}>
+                            {tagOptionLabel(tag)}{tag.isActive === false ? ' - inactive or missing' : ''}
+                          </option>
+                        ))}
+                      </select>
                     </Field>
                     <Field label="Description" className="md:col-span-2">
                       <input value={section.description || ''} onChange={(event) => updateSection(index, { description: event.target.value })} className={textInputClass} />
@@ -568,10 +628,18 @@ function MarketDiscoveryLayoutEditor() {
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h3 className="text-xl font-bold text-white">Pins</h3>
-                  <p className="mt-1 text-sm text-gray-400">Page-level pins render as featured topic cards or featured market cards on /markets when their block is enabled.</p>
+                  <p className="mt-1 text-sm text-gray-400">Topic pins point at active tag slugs. The selected tag drives /markets/topic/:slug filtering.</p>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  <button type="button" onClick={() => addPin('discovery_page')} className="rounded-md border border-sky-500/50 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-950/50">Add Topic Pin</button>
+                  <button
+                    type="button"
+                    onClick={() => addPin('discovery_page')}
+                    disabled={activeTagOptions.length === 0}
+                    className="rounded-md border border-sky-500/50 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-950/50 disabled:cursor-not-allowed disabled:opacity-50"
+                    title={activeTagOptions.length === 0 ? 'Create an active tag before adding topic pins.' : 'Add a pinned topic from active tags.'}
+                  >
+                    Add Topic Pin
+                  </button>
                   <button type="button" onClick={() => addPin('market')} className="rounded-md border border-emerald-500/50 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-950/50">Add Market Pin</button>
                   <button type="button" disabled={savingPins} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
                     {savingPins ? 'Saving...' : 'Save Pins'}
@@ -587,7 +655,18 @@ function MarketDiscoveryLayoutEditor() {
                 {state.pins.map((pin, index) => (
                   <div key={`${pin.pinType}-${index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[170px_1fr_120px]">
                     <Field label="Pin Type">
-                      <select value={pin.pinType || 'market'} onChange={(event) => updatePin(index, { pinType: event.target.value })} className={textInputClass}>
+                      <select
+                        value={pin.pinType || 'market'}
+                        onChange={(event) => {
+                          const pinType = event.target.value;
+                          updatePin(index, {
+                            pinType,
+                            marketId: pinType === 'market' ? (pin.marketId || '') : 0,
+                            targetPageSlug: pinType === 'discovery_page' ? (pin.targetPageSlug || firstActiveTagSlug) : '',
+                          });
+                        }}
+                        className={textInputClass}
+                      >
                         <option value="market">Featured market</option>
                         <option value="discovery_page">Featured topic page</option>
                       </select>
@@ -599,8 +678,21 @@ function MarketDiscoveryLayoutEditor() {
                       <input type="number" value={pin.sortOrder || index + 1} onChange={(event) => updatePin(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
                     </Field>
                     {pin.pinType === 'discovery_page' ? (
-                      <Field label="Target Page Slug" className="md:col-span-2">
-                        <input value={pin.targetPageSlug || ''} onChange={(event) => updatePin(index, { targetPageSlug: event.target.value })} placeholder="topic-template" className={textInputClass} />
+                      <Field label="Target Topic Tag" className="md:col-span-2">
+                        <select
+                          value={pin.targetPageSlug || ''}
+                          onChange={(event) => updatePin(index, { targetPageSlug: event.target.value })}
+                          className={textInputClass}
+                        >
+                          {activeTagOptions.length === 0 && !pin.targetPageSlug && (
+                            <option value="">Create an active tag first</option>
+                          )}
+                          {tagOptionsWithCurrent(activeTagOptions, pin.targetPageSlug).map((tag) => (
+                            <option key={tag.slug} value={tag.slug}>
+                              {tagOptionLabel(tag)}{tag.isActive === false ? ' - inactive or missing' : ''}
+                            </option>
+                          ))}
+                        </select>
                       </Field>
                     ) : (
                       <Field label="Market ID" className="md:col-span-2">

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -66,7 +66,7 @@ const normalizePage = (page = {}, modeKey = 'top') => {
     description: page.description || (modeKey === 'secondary' ? 'Browse and search markets in this topic.' : 'Browse and search prediction markets.'),
     pageType: page.pageType || mode.pageType,
     primaryTagSlug: page.primaryTagSlug || '',
-    searchScope: page.searchScope || (modeKey === 'secondary' ? 'tag' : 'all'),
+    searchScope: modeKey === 'secondary' ? 'tag' : 'all',
     featuredTopicsEnabled: !!page.featuredTopicsEnabled,
     featuredMarketsEnabled: !!page.featuredMarketsEnabled,
     defaultRecommendationLimit,
@@ -536,7 +536,7 @@ function MarketDiscoveryLayoutEditor() {
           ...state,
           pageType: mode.pageType,
           primaryTagSlug: selectedMode === 'secondary' ? selectedSecondarySlug : state.primaryTagSlug,
-          searchScope: selectedMode === 'secondary' ? 'tag' : state.searchScope,
+          searchScope: selectedMode === 'secondary' ? 'tag' : 'all',
           featuredTopicsEnabled: selectedMode === 'secondary' ? false : state.featuredTopicsEnabled,
           featuredMarketsEnabled: selectedMode === 'secondary' ? true : state.featuredMarketsEnabled,
         }),
@@ -703,24 +703,13 @@ function MarketDiscoveryLayoutEditor() {
               )}
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
-                <Field label="Page Title">
+                <Field label="Page Title" className="md:col-span-2">
                   <input
                     value={state.title}
                     maxLength={160}
                     onChange={(event) => updateState({ title: event.target.value })}
                     className={textInputClass}
                   />
-                </Field>
-                <Field label="Search Scope">
-                  <select
-                    value={state.searchScope}
-                    onChange={(event) => updateState({ searchScope: event.target.value })}
-                    disabled={selectedMode === 'secondary'}
-                    className={textInputClass}
-                  >
-                    <option value="all">All public markets</option>
-                    <option value="tag">Current topic/tag by default</option>
-                  </select>
                 </Field>
                 <Field label="Page Description" className="md:col-span-2">
                   <textarea

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -49,7 +49,11 @@ const defaultPageState = {
   recommendationLimit: 20,
   isPublished: true,
   version: 0,
+  sections: [],
+  pins: [],
 };
+
+const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortOrder || 0) - Number(b.sortOrder || 0));
 
 const normalizePage = (page = {}, modeKey = 'top') => {
   const mode = layoutModes[modeKey];
@@ -73,8 +77,12 @@ const normalizePage = (page = {}, modeKey = 'top') => {
     recommendationLimit: hasCuratedBlocks ? curatedRecommendationLimit : defaultRecommendationLimit,
     isPublished: page.isPublished !== false,
     version: Number(page.version || 0),
+    sections: sortBySortOrder(page.sections || []),
+    pins: sortBySortOrder(page.pins || []),
   };
 };
+
+const nextSortOrder = (items = []) => items.reduce((max, item) => Math.max(max, Number(item.sortOrder || 0)), 0) + 1;
 
 const ToggleCard = ({ title, description, checked, onChange }) => (
   <label className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition ${
@@ -100,6 +108,15 @@ const Pill = ({ children }) => (
     {children}
   </span>
 );
+
+const Field = ({ label, children, className = '' }) => (
+  <label className={`grid gap-2 text-sm text-gray-300 ${className}`}>
+    {label}
+    {children}
+  </label>
+);
+
+const textInputClass = 'rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40';
 
 const LayoutPreview = ({ mode, state }) => {
   const hasCuratedBlocks = state.featuredTopicsEnabled || state.featuredMarketsEnabled || state.sectionsEnabled;
@@ -134,19 +151,19 @@ const LayoutPreview = ({ mode, state }) => {
         {state.featuredTopicsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
             <div className="text-sm font-semibold text-white">Featured topic/category cards</div>
-            <div className="mt-1 text-xs text-gray-400">Pinned secondary pages appear after compact recommendations.</div>
+            <div className="mt-1 text-xs text-gray-400">{state.pins.filter((pin) => pin.pinType === 'discovery_page').length} page pins configured.</div>
           </div>
         )}
         {state.featuredMarketsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
             <div className="text-sm font-semibold text-white">Featured market cards</div>
-            <div className="mt-1 text-xs text-gray-400">Admin-pinned markets appear in configured order.</div>
+            <div className="mt-1 text-xs text-gray-400">{state.pins.filter((pin) => pin.pinType === 'market').length} market pins configured.</div>
           </div>
         )}
         {state.sectionsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
             <div className="text-sm font-semibold text-white">Sections</div>
-            <div className="mt-1 text-xs text-gray-400">Explicit sections render after pins; otherwise the page has an implicit All section.</div>
+            <div className="mt-1 text-xs text-gray-400">{state.sections.length} named sections configured; otherwise the page has an implicit All section.</div>
           </div>
         )}
       </div>
@@ -162,6 +179,8 @@ function MarketDiscoveryLayoutEditor() {
   });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [savingSections, setSavingSections] = useState(false);
+  const [savingPins, setSavingPins] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
@@ -202,6 +221,16 @@ function MarketDiscoveryLayoutEditor() {
 
   const mode = layoutModes[selectedMode];
   const state = layoutState[selectedMode];
+  const topicPins = state.pins.filter((pin) => pin.pinType === 'discovery_page');
+  const marketPins = state.pins.filter((pin) => pin.pinType === 'market');
+
+  const replaceSelectedState = (saved) => {
+    setLayoutState((current) => ({
+      ...current,
+      [selectedMode]: normalizePage(saved, selectedMode),
+    }));
+  };
+
   const updateState = (updates) => {
     setLayoutState((current) => ({
       ...current,
@@ -210,6 +239,22 @@ function MarketDiscoveryLayoutEditor() {
         ...updates,
       },
     }));
+  };
+
+  const updateSection = (index, updates) => {
+    updateState({
+      sections: state.sections.map((section, currentIndex) => (
+        currentIndex === index ? { ...section, ...updates } : section
+      )),
+    });
+  };
+
+  const updatePin = (index, updates) => {
+    updateState({
+      pins: state.pins.map((pin, currentIndex) => (
+        currentIndex === index ? { ...pin, ...updates } : pin
+      )),
+    });
   };
 
   const selectedBlocks = useMemo(() => [
@@ -233,16 +278,84 @@ function MarketDiscoveryLayoutEditor() {
         }),
         fallbackMessage: 'Failed to save market discovery layout.',
       });
-      setLayoutState((current) => ({
-        ...current,
-        [selectedMode]: normalizePage(saved, selectedMode),
-      }));
+      replaceSelectedState(saved);
       setMessage(`${mode.label} saved. /markets will use the TOP layout immediately after refresh.`);
     } catch (err) {
       setError(err.message || 'Unable to save market discovery layout.');
     } finally {
       setSaving(false);
     }
+  };
+
+  const saveSections = async () => {
+    setSavingSections(true);
+    setMessage('');
+    setError('');
+    try {
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${mode.slug}/sections`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sections: state.sections }),
+        fallbackMessage: 'Failed to save discovery sections.',
+      });
+      replaceSelectedState(saved);
+      setMessage(`${mode.label} sections saved.`);
+    } catch (err) {
+      setError(err.message || 'Unable to save discovery sections.');
+    } finally {
+      setSavingSections(false);
+    }
+  };
+
+  const savePins = async () => {
+    setSavingPins(true);
+    setMessage('');
+    setError('');
+    try {
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${mode.slug}/pins`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pins: state.pins }),
+        fallbackMessage: 'Failed to save discovery pins.',
+      });
+      replaceSelectedState(saved);
+      setMessage(`${mode.label} pins saved.`);
+    } catch (err) {
+      setError(err.message || 'Unable to save discovery pins.');
+    } finally {
+      setSavingPins(false);
+    }
+  };
+
+  const addSection = () => {
+    updateState({
+      sections: [
+        ...state.sections,
+        {
+          slug: '',
+          title: 'New Section',
+          description: '',
+          tagFilterSlug: '',
+          sortOrder: nextSortOrder(state.sections),
+          isActive: true,
+        },
+      ],
+    });
+  };
+
+  const addPin = (pinType) => {
+    updateState({
+      pins: [
+        ...state.pins,
+        {
+          pinType,
+          marketId: pinType === 'market' ? '' : 0,
+          targetPageSlug: pinType === 'discovery_page' ? 'topic-template' : '',
+          label: pinType === 'market' ? 'Featured Market' : 'Featured Topic',
+          sortOrder: nextSortOrder(state.pins),
+        },
+      ],
+    });
   };
 
   if (loading) {
@@ -261,7 +374,7 @@ function MarketDiscoveryLayoutEditor() {
           <h1 className="mt-2 text-3xl font-bold text-white">Market Discovery Layout</h1>
           <p className="mt-2 max-w-3xl text-gray-300">
             Configure persisted TOP market page and SECONDARY topic page layout options from FEATURE/09.
-            The TOP record now controls the public /markets page title, description, fallback list size, and CMS block visibility.
+            The TOP record controls the public /markets page title, description, fallback list size, section cards, and featured pins.
           </p>
         </div>
 
@@ -319,58 +432,53 @@ function MarketDiscoveryLayoutEditor() {
               </div>
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
-                <label className="grid gap-2 text-sm text-gray-300">
-                  Page Title
+                <Field label="Page Title">
                   <input
                     value={state.title}
                     maxLength={160}
                     onChange={(event) => updateState({ title: event.target.value })}
-                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                    className={textInputClass}
                   />
-                </label>
-                <label className="grid gap-2 text-sm text-gray-300">
-                  Search Scope
+                </Field>
+                <Field label="Search Scope">
                   <select
                     value={state.searchScope}
                     onChange={(event) => updateState({ searchScope: event.target.value })}
-                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                    className={textInputClass}
                   >
                     <option value="all">All public markets</option>
                     <option value="tag">Current topic/tag by default</option>
                   </select>
-                </label>
-                <label className="grid gap-2 text-sm text-gray-300 md:col-span-2">
-                  Page Description
+                </Field>
+                <Field label="Page Description" className="md:col-span-2">
                   <textarea
                     value={state.description}
                     maxLength={500}
                     rows={3}
                     onChange={(event) => updateState({ description: event.target.value })}
-                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                    className={textInputClass}
                   />
-                </label>
-                <label className="grid gap-2 text-sm text-gray-300">
-                  Empty CMS Recommendation Limit
+                </Field>
+                <Field label="Empty CMS Recommendation Limit">
                   <input
                     type="number"
                     min="1"
                     max="50"
                     value={state.defaultRecommendationLimit}
                     onChange={(event) => updateState({ defaultRecommendationLimit: Number(event.target.value || 1) })}
-                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                    className={textInputClass}
                   />
-                </label>
-                <label className="grid gap-2 text-sm text-gray-300">
-                  Curated CMS Recommendation Limit
+                </Field>
+                <Field label="Curated CMS Recommendation Limit">
                   <input
                     type="number"
                     min="1"
                     max="50"
                     value={state.curatedRecommendationLimit}
                     onChange={(event) => updateState({ curatedRecommendationLimit: Number(event.target.value || 1) })}
-                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                    className={textInputClass}
                   />
-                </label>
+                </Field>
               </div>
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
@@ -407,6 +515,105 @@ function MarketDiscoveryLayoutEditor() {
                     <li key={block}>{block}</li>
                   ))}
                 </ol>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-xl font-bold text-white">Sections</h3>
+                  <p className="mt-1 text-sm text-gray-400">Named section cards can optionally point at a tag slug. Empty pages still use the implicit All section.</p>
+                </div>
+                <div className="flex gap-2">
+                  <button type="button" onClick={addSection} className="rounded-md border border-sky-500/50 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-950/50">Add Section</button>
+                  <button type="button" disabled={savingSections} onClick={saveSections} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
+                    {savingSections ? 'Saving...' : 'Save Sections'}
+                  </button>
+                </div>
+              </div>
+              <div className="mt-4 space-y-3">
+                {state.sections.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No explicit sections yet.</p>}
+                {state.sections.map((section, index) => (
+                  <div key={`${section.slug}-${index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[1fr_1fr_110px_auto]">
+                    <Field label="Title">
+                      <input value={section.title || ''} onChange={(event) => updateSection(index, { title: event.target.value })} className={textInputClass} />
+                    </Field>
+                    <Field label="Slug">
+                      <input value={section.slug || ''} onChange={(event) => updateSection(index, { slug: event.target.value })} placeholder="auto-from-title" className={textInputClass} />
+                    </Field>
+                    <Field label="Order">
+                      <input type="number" value={section.sortOrder || index + 1} onChange={(event) => updateSection(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
+                    </Field>
+                    <label className="flex items-end gap-2 pb-2 text-sm text-gray-300">
+                      <input type="checkbox" checked={section.isActive !== false} onChange={(event) => updateSection(index, { isActive: event.target.checked })} className="h-4 w-4 accent-primary-pink" />
+                      Active
+                    </label>
+                    <Field label="Tag Filter Slug" className="md:col-span-2">
+                      <input value={section.tagFilterSlug || ''} onChange={(event) => updateSection(index, { tagFilterSlug: event.target.value })} placeholder="politics" className={textInputClass} />
+                    </Field>
+                    <Field label="Description" className="md:col-span-2">
+                      <input value={section.description || ''} onChange={(event) => updateSection(index, { description: event.target.value })} className={textInputClass} />
+                    </Field>
+                    <div className="md:col-span-4">
+                      <button type="button" onClick={() => updateState({ sections: state.sections.filter((_, currentIndex) => currentIndex !== index) })} className="text-sm font-semibold text-red-300 hover:text-red-200">
+                        Remove section
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-xl font-bold text-white">Pins</h3>
+                  <p className="mt-1 text-sm text-gray-400">Page-level pins render as featured topic cards or featured market cards on /markets when their block is enabled.</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" onClick={() => addPin('discovery_page')} className="rounded-md border border-sky-500/50 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-950/50">Add Topic Pin</button>
+                  <button type="button" onClick={() => addPin('market')} className="rounded-md border border-emerald-500/50 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-950/50">Add Market Pin</button>
+                  <button type="button" disabled={savingPins} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
+                    {savingPins ? 'Saving...' : 'Save Pins'}
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-400">
+                <Pill>{topicPins.length} topic pins</Pill>
+                <Pill>{marketPins.length} market pins</Pill>
+              </div>
+              <div className="mt-4 space-y-3">
+                {state.pins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No page-level pins yet.</p>}
+                {state.pins.map((pin, index) => (
+                  <div key={`${pin.pinType}-${index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[170px_1fr_120px]">
+                    <Field label="Pin Type">
+                      <select value={pin.pinType || 'market'} onChange={(event) => updatePin(index, { pinType: event.target.value })} className={textInputClass}>
+                        <option value="market">Featured market</option>
+                        <option value="discovery_page">Featured topic page</option>
+                      </select>
+                    </Field>
+                    <Field label="Label">
+                      <input value={pin.label || ''} onChange={(event) => updatePin(index, { label: event.target.value })} className={textInputClass} />
+                    </Field>
+                    <Field label="Order">
+                      <input type="number" value={pin.sortOrder || index + 1} onChange={(event) => updatePin(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
+                    </Field>
+                    {pin.pinType === 'discovery_page' ? (
+                      <Field label="Target Page Slug" className="md:col-span-2">
+                        <input value={pin.targetPageSlug || ''} onChange={(event) => updatePin(index, { targetPageSlug: event.target.value })} placeholder="topic-template" className={textInputClass} />
+                      </Field>
+                    ) : (
+                      <Field label="Market ID" className="md:col-span-2">
+                        <input type="number" min="1" value={pin.marketId || ''} onChange={(event) => updatePin(index, { marketId: Number(event.target.value || 0) })} className={textInputClass} />
+                      </Field>
+                    )}
+                    <div className="flex items-end">
+                      <button type="button" onClick={() => updateState({ pins: state.pins.filter((_, currentIndex) => currentIndex !== index) })} className="pb-2 text-sm font-semibold text-red-300 hover:text-red-200">
+                        Remove pin
+                      </button>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
 

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -32,7 +32,6 @@ const layoutModes = {
 
 const persistedTables = [
   'market_discovery_pages',
-  'market_discovery_sections',
   'market_discovery_pins',
 ];
 
@@ -45,12 +44,10 @@ const defaultPageState = {
   searchScope: 'all',
   featuredTopicsEnabled: false,
   featuredMarketsEnabled: false,
-  sectionsEnabled: false,
   defaultRecommendationLimit: 20,
   curatedRecommendationLimit: 5,
   recommendationLimit: 20,
   version: 0,
-  sections: [],
   pins: [],
 };
 
@@ -58,7 +55,7 @@ const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortO
 
 const normalizePage = (page = {}, modeKey = 'top') => {
   const mode = layoutModes[modeKey];
-  const hasCuratedBlocks = !!(page.featuredTopicsEnabled || page.featuredMarketsEnabled || page.sectionsEnabled);
+  const hasCuratedBlocks = !!(page.featuredTopicsEnabled || page.featuredMarketsEnabled);
   const defaultRecommendationLimit = Number(page.defaultRecommendationLimit || 20);
   const curatedRecommendationLimit = Number(page.curatedRecommendationLimit || 5);
 
@@ -72,12 +69,10 @@ const normalizePage = (page = {}, modeKey = 'top') => {
     searchScope: page.searchScope || (modeKey === 'secondary' ? 'tag' : 'all'),
     featuredTopicsEnabled: !!page.featuredTopicsEnabled,
     featuredMarketsEnabled: !!page.featuredMarketsEnabled,
-    sectionsEnabled: !!page.sectionsEnabled,
     defaultRecommendationLimit,
     curatedRecommendationLimit,
     recommendationLimit: hasCuratedBlocks ? curatedRecommendationLimit : defaultRecommendationLimit,
     version: Number(page.version || 0),
-    sections: sortBySortOrder(page.sections || []),
     pins: sortBySortOrder(page.pins || []),
   };
 };
@@ -276,7 +271,7 @@ const MarketPinSearch = ({ pin, onSelect, tagSlug = '' }) => {
 };
 
 const LayoutPreview = ({ mode, state }) => {
-  const hasCuratedBlocks = state.featuredTopicsEnabled || state.featuredMarketsEnabled || state.sectionsEnabled;
+  const hasCuratedBlocks = state.featuredTopicsEnabled || state.featuredMarketsEnabled;
   const recommendationLimit = hasCuratedBlocks
     ? state.curatedRecommendationLimit
     : state.defaultRecommendationLimit;
@@ -317,12 +312,6 @@ const LayoutPreview = ({ mode, state }) => {
             <div className="mt-1 text-xs text-gray-400">{state.pins.filter((pin) => pin.pinType === 'market').length} market pins configured.</div>
           </div>
         )}
-        {state.sectionsEnabled && (
-          <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
-            <div className="text-sm font-semibold text-white">Sections</div>
-            <div className="mt-1 text-xs text-gray-400">{state.sections.length} named sections configured; otherwise the page has an implicit All section.</div>
-          </div>
-        )}
       </div>
     </div>
   );
@@ -339,7 +328,6 @@ function MarketDiscoveryLayoutEditor() {
   const [loading, setLoading] = useState(true);
   const [loadingSecondary, setLoadingSecondary] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [savingSections, setSavingSections] = useState(false);
   const [savingPins, setSavingPins] = useState(false);
   const [activeTags, setActiveTags] = useState([]);
   const [message, setMessage] = useState('');
@@ -426,7 +414,6 @@ function MarketDiscoveryLayoutEditor() {
               searchScope: 'tag',
               featuredTopicsEnabled: false,
               featuredMarketsEnabled: true,
-              sectionsEnabled: false,
             },
           }));
         }
@@ -485,7 +472,6 @@ function MarketDiscoveryLayoutEditor() {
     }
     return [
       layoutTab,
-      { key: 'sections', label: 'Sections' },
       { key: 'topicPins', label: 'Topic Pins' },
       { key: 'marketPins', label: 'Market Pins' },
       { key: 'preview', label: 'Preview' },
@@ -509,7 +495,6 @@ function MarketDiscoveryLayoutEditor() {
           searchScope: 'tag',
           featuredTopicsEnabled: false,
           featuredMarketsEnabled: true,
-          sectionsEnabled: false,
         }
         : normalizePage(saved, selectedMode),
     }));
@@ -525,14 +510,6 @@ function MarketDiscoveryLayoutEditor() {
     }));
   };
 
-  const updateSection = (index, updates) => {
-    updateState({
-      sections: state.sections.map((section, currentIndex) => (
-        currentIndex === index ? { ...section, ...updates } : section
-      )),
-    });
-  };
-
   const updatePin = (index, updates) => {
     updateState({
       pins: state.pins.map((pin, currentIndex) => (
@@ -545,7 +522,6 @@ function MarketDiscoveryLayoutEditor() {
     ...mode.fixedBlocks,
     ...(state.featuredTopicsEnabled ? ['Topic Pins'] : []),
     ...(state.featuredMarketsEnabled ? ['Market Pins'] : []),
-    ...(state.sectionsEnabled ? ['CMS sections'] : []),
   ], [mode, state]);
 
   const saveLayout = async () => {
@@ -563,7 +539,6 @@ function MarketDiscoveryLayoutEditor() {
           searchScope: selectedMode === 'secondary' ? 'tag' : state.searchScope,
           featuredTopicsEnabled: selectedMode === 'secondary' ? false : state.featuredTopicsEnabled,
           featuredMarketsEnabled: selectedMode === 'secondary' ? true : state.featuredMarketsEnabled,
-          sectionsEnabled: selectedMode === 'secondary' ? false : state.sectionsEnabled,
         }),
         fallbackMessage: 'Failed to save market discovery layout.',
       });
@@ -573,26 +548,6 @@ function MarketDiscoveryLayoutEditor() {
       setError(err.message || 'Unable to save market discovery layout.');
     } finally {
       setSaving(false);
-    }
-  };
-
-  const saveSections = async () => {
-    setSavingSections(true);
-    setMessage('');
-    setError('');
-    try {
-      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${selectedPageSlug}/sections`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sections: state.sections }),
-        fallbackMessage: 'Failed to save discovery sections.',
-      });
-      replaceSelectedState(saved);
-      setMessage(`${selectedPageLabel} sections saved.`);
-    } catch (err) {
-      setError(err.message || 'Unable to save discovery sections.');
-    } finally {
-      setSavingSections(false);
     }
   };
 
@@ -617,22 +572,6 @@ function MarketDiscoveryLayoutEditor() {
     } finally {
       setSavingPins(false);
     }
-  };
-
-  const addSection = () => {
-    updateState({
-      sections: [
-        ...state.sections,
-        {
-          slug: '',
-          title: 'New Section',
-          description: '',
-          tagFilterSlug: '',
-          sortOrder: nextSortOrder(state.sections),
-          isActive: true,
-        },
-      ],
-    });
   };
 
   const addPin = (pinType) => {
@@ -829,14 +768,6 @@ function MarketDiscoveryLayoutEditor() {
                   checked={selectedMode === 'secondary' ? true : state.featuredMarketsEnabled}
                   onChange={(checked) => updateState({ featuredMarketsEnabled: checked })}
                 />
-                {selectedMode === 'top' && (
-                  <ToggleCard
-                    title="CMS sections"
-                    description="Allow named sections beyond the implicit All section."
-                    checked={state.sectionsEnabled}
-                    onChange={(checked) => updateState({ sectionsEnabled: checked })}
-                  />
-                )}
               </div>
 
               <div className="mt-6 rounded-lg border border-gray-700 bg-gray-950 p-4">
@@ -846,65 +777,6 @@ function MarketDiscoveryLayoutEditor() {
                     <li key={block}>{block}</li>
                   ))}
                 </ol>
-              </div>
-            </div>
-            )}
-
-            {selectedMode === 'top' && activeEditorTab === 'sections' && (
-              <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <h3 className="text-xl font-bold text-white">Sections</h3>
-                  <p className="mt-1 text-sm text-gray-400">Named section cards can optionally point at an active tag. Empty pages still use the implicit All section.</p>
-                </div>
-                <div className="flex gap-2">
-                  <button type="button" onClick={addSection} className="rounded-md border border-sky-500/50 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-950/50">Add Section</button>
-                  <button type="button" disabled={savingSections} onClick={saveSections} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
-                    {savingSections ? 'Saving...' : 'Save Sections'}
-                  </button>
-                </div>
-              </div>
-              <div className="mt-4 space-y-3">
-                {state.sections.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No explicit sections yet.</p>}
-                {state.sections.map((section, index) => (
-                  <div key={`${section.slug}-${index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[1fr_1fr_110px_auto]">
-                    <Field label="Title">
-                      <input value={section.title || ''} onChange={(event) => updateSection(index, { title: event.target.value })} className={textInputClass} />
-                    </Field>
-                    <Field label="Slug">
-                      <input value={section.slug || ''} onChange={(event) => updateSection(index, { slug: event.target.value })} placeholder="auto-from-title" className={textInputClass} />
-                    </Field>
-                    <Field label="Order">
-                      <input type="number" value={section.sortOrder || index + 1} onChange={(event) => updateSection(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
-                    </Field>
-                    <label className="flex items-end gap-2 pb-2 text-sm text-gray-300">
-                      <input type="checkbox" checked={section.isActive !== false} onChange={(event) => updateSection(index, { isActive: event.target.checked })} className="h-4 w-4 accent-primary-pink" />
-                      Active
-                    </label>
-                    <Field label="Tag Filter" className="md:col-span-2">
-                      <select
-                        value={section.tagFilterSlug || ''}
-                        onChange={(event) => updateSection(index, { tagFilterSlug: event.target.value })}
-                        className={textInputClass}
-                      >
-                        <option value="">No tag filter</option>
-                        {tagOptionsWithCurrent(activeTagOptions, section.tagFilterSlug).map((tag) => (
-                          <option key={tag.slug} value={tag.slug}>
-                            {tagOptionLabel(tag)}{tag.isActive === false ? ' - inactive or missing' : ''}
-                          </option>
-                        ))}
-                      </select>
-                    </Field>
-                    <Field label="Description" className="md:col-span-2">
-                      <input value={section.description || ''} onChange={(event) => updateSection(index, { description: event.target.value })} className={textInputClass} />
-                    </Field>
-                    <div className="md:col-span-4">
-                      <button type="button" onClick={() => updateState({ sections: state.sections.filter((_, currentIndex) => currentIndex !== index) })} className="text-sm font-semibold text-red-300 hover:text-red-200">
-                        Remove section
-                      </button>
-                    </div>
-                  </div>
-                ))}
               </div>
             </div>
             )}

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -18,9 +18,9 @@ const layoutModes = {
   },
   secondary: {
     slug: 'topic-template',
-    label: 'Topic page layout (SECONDARY)',
+    label: 'Topic page pins (SECONDARY)',
     route: '/markets/topic/:slug',
-    purpose: 'Tag-scoped market discovery page for a CMS-managed topic.',
+    purpose: 'Tag-scoped market discovery page with independent per-topic market pins.',
     pageType: 'secondary',
     fixedBlocks: [
       'Topic title and description',
@@ -146,7 +146,7 @@ const marketOverviewTitle = (overview) => (
 
 const marketOverviewId = (overview) => overview?.market?.id || overview?.id || overview?.marketId || 0;
 
-const MarketPinSearch = ({ pin, onSelect }) => {
+const MarketPinSearch = ({ pin, onSelect, tagSlug = '' }) => {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
@@ -199,7 +199,7 @@ const MarketPinSearch = ({ pin, onSelect }) => {
       setSearching(true);
       setSearchError('');
       try {
-        const response = await searchMarkets(trimmed, 'active', 8);
+        const response = await searchMarkets(trimmed, 'active', 8, tagSlug ? { tagSlug } : {});
         if (!ignore) {
           setResults(response.primaryResults || []);
         }
@@ -219,7 +219,7 @@ const MarketPinSearch = ({ pin, onSelect }) => {
       ignore = true;
       clearTimeout(timeoutId);
     };
-  }, [query]);
+  }, [query, tagSlug]);
 
   return (
     <div className="grid gap-3">
@@ -240,7 +240,7 @@ const MarketPinSearch = ({ pin, onSelect }) => {
         <input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder="Type at least 2 characters..."
+          placeholder={tagSlug ? `Search active ${tagSlug} markets...` : 'Type at least 2 characters...'}
           className={textInputClass}
         />
       </Field>
@@ -332,11 +332,13 @@ const LayoutPreview = ({ mode, state }) => {
 
 function MarketDiscoveryLayoutEditor() {
   const [selectedMode, setSelectedMode] = useState('top');
+  const [selectedSecondarySlug, setSelectedSecondarySlug] = useState('');
   const [layoutState, setLayoutState] = useState({
     top: normalizePage({}, 'top'),
     secondary: normalizePage({}, 'secondary'),
   });
   const [loading, setLoading] = useState(true);
+  const [loadingSecondary, setLoadingSecondary] = useState(false);
   const [saving, setSaving] = useState(false);
   const [savingSections, setSavingSections] = useState(false);
   const [savingPins, setSavingPins] = useState(false);
@@ -351,14 +353,11 @@ function MarketDiscoveryLayoutEditor() {
       setLoading(true);
       setError('');
       try {
-        const [topPage, secondaryPage] = await Promise.all([
-          apiRequest('/v0/content/market-discovery/markets', { fallbackMessage: 'Failed to load TOP layout.' }),
-          apiRequest('/v0/content/market-discovery/topic-template', { fallbackMessage: 'Failed to load SECONDARY layout.' }),
-        ]);
+        const topPage = await apiRequest('/v0/content/market-discovery/markets', { fallbackMessage: 'Failed to load TOP layout.' });
         if (!ignore) {
           setLayoutState({
             top: normalizePage(topPage, 'top'),
-            secondary: normalizePage(secondaryPage, 'secondary'),
+            secondary: normalizePage({}, 'secondary'),
           });
         }
       } catch (err) {
@@ -386,7 +385,9 @@ function MarketDiscoveryLayoutEditor() {
       try {
         const result = await listAdminMarketTags({ includeInactive: false });
         if (!ignore) {
-          setActiveTags(result.tags || []);
+          const tags = result.tags || [];
+          setActiveTags(tags);
+          setSelectedSecondarySlug((current) => current || tags[0]?.slug || '');
         }
       } catch (err) {
         if (!ignore) {
@@ -402,8 +403,63 @@ function MarketDiscoveryLayoutEditor() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!selectedSecondarySlug) {
+      return undefined;
+    }
+
+    let ignore = false;
+
+    const loadSecondaryPage = async () => {
+      setLoadingSecondary(true);
+      setError('');
+      try {
+        const page = await apiRequest(`/v0/content/market-discovery/${selectedSecondarySlug}`, {
+          fallbackMessage: 'Failed to load topic page layout.',
+        });
+        if (!ignore) {
+          setLayoutState((current) => ({
+            ...current,
+            secondary: {
+              ...normalizePage(page, 'secondary'),
+              slug: selectedSecondarySlug,
+              primaryTagSlug: selectedSecondarySlug,
+              searchScope: 'tag',
+              featuredTopicsEnabled: false,
+              featuredMarketsEnabled: true,
+              sectionsEnabled: false,
+            },
+          }));
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load topic page layout.');
+        }
+      } finally {
+        if (!ignore) {
+          setLoadingSecondary(false);
+        }
+      }
+    };
+
+    loadSecondaryPage();
+
+    return () => {
+      ignore = true;
+    };
+  }, [selectedSecondarySlug]);
+
   const mode = layoutModes[selectedMode];
   const state = layoutState[selectedMode];
+  const selectedSecondaryTag = activeTags.find((tag) => tag.slug === selectedSecondarySlug);
+  const selectedPageSlug = selectedMode === 'secondary' ? selectedSecondarySlug : mode.slug;
+  const selectedPageLabel = selectedMode === 'secondary' && selectedSecondarySlug
+    ? `${mode.label}: ${tagOptionLabel(selectedSecondaryTag || { slug: selectedSecondarySlug })}`
+    : mode.label;
+  const selectedRoute = selectedMode === 'secondary' && selectedSecondarySlug
+    ? `/markets/topic/${selectedSecondarySlug}`
+    : mode.route;
+  const canEditSelectedPage = selectedMode !== 'secondary' || !!selectedSecondarySlug;
   const topicPins = state.pins
     .map((pin, index) => ({ pin, index }))
     .filter(({ pin }) => pin.pinType === 'discovery_page');
@@ -420,7 +476,17 @@ function MarketDiscoveryLayoutEditor() {
   const replaceSelectedState = (saved) => {
     setLayoutState((current) => ({
       ...current,
-      [selectedMode]: normalizePage(saved, selectedMode),
+      [selectedMode]: selectedMode === 'secondary'
+        ? {
+          ...normalizePage(saved, selectedMode),
+          slug: selectedSecondarySlug,
+          primaryTagSlug: selectedSecondarySlug,
+          searchScope: 'tag',
+          featuredTopicsEnabled: false,
+          featuredMarketsEnabled: true,
+          sectionsEnabled: false,
+        }
+        : normalizePage(saved, selectedMode),
     }));
   };
 
@@ -462,17 +528,22 @@ function MarketDiscoveryLayoutEditor() {
     setMessage('');
     setError('');
     try {
-      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${mode.slug}`, {
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${selectedPageSlug}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...state,
           pageType: mode.pageType,
+          primaryTagSlug: selectedMode === 'secondary' ? selectedSecondarySlug : state.primaryTagSlug,
+          searchScope: selectedMode === 'secondary' ? 'tag' : state.searchScope,
+          featuredTopicsEnabled: selectedMode === 'secondary' ? false : state.featuredTopicsEnabled,
+          featuredMarketsEnabled: selectedMode === 'secondary' ? true : state.featuredMarketsEnabled,
+          sectionsEnabled: selectedMode === 'secondary' ? false : state.sectionsEnabled,
         }),
         fallbackMessage: 'Failed to save market discovery layout.',
       });
       replaceSelectedState(saved);
-      setMessage(`${mode.label} saved. /markets will use the TOP layout immediately after refresh.`);
+      setMessage(`${selectedPageLabel} saved.`);
     } catch (err) {
       setError(err.message || 'Unable to save market discovery layout.');
     } finally {
@@ -485,14 +556,14 @@ function MarketDiscoveryLayoutEditor() {
     setMessage('');
     setError('');
     try {
-      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${mode.slug}/sections`, {
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${selectedPageSlug}/sections`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sections: state.sections }),
         fallbackMessage: 'Failed to save discovery sections.',
       });
       replaceSelectedState(saved);
-      setMessage(`${mode.label} sections saved.`);
+      setMessage(`${selectedPageLabel} sections saved.`);
     } catch (err) {
       setError(err.message || 'Unable to save discovery sections.');
     } finally {
@@ -505,14 +576,17 @@ function MarketDiscoveryLayoutEditor() {
     setMessage('');
     setError('');
     try {
-      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${mode.slug}/pins`, {
+      const pins = selectedMode === 'secondary'
+        ? state.pins.filter((pin) => pin.pinType === 'market')
+        : state.pins;
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${selectedPageSlug}/pins`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pins: state.pins }),
+        body: JSON.stringify({ pins }),
         fallbackMessage: 'Failed to save discovery pins.',
       });
       replaceSelectedState(saved);
-      setMessage(`${mode.label} pins saved.`);
+      setMessage(`${selectedPageLabel} pins saved.`);
     } catch (err) {
       setError(err.message || 'Unable to save discovery pins.');
     } finally {
@@ -615,18 +689,40 @@ function MarketDiscoveryLayoutEditor() {
             <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <h2 className="text-2xl font-bold text-white">{mode.label}</h2>
+                  <h2 className="text-2xl font-bold text-white">{selectedPageLabel}</h2>
                   <p className="mt-2 max-w-2xl text-sm text-gray-300">{mode.purpose}</p>
+                  <p className="mt-1 text-xs font-semibold text-sky-200">{selectedRoute}</p>
                 </div>
                 <button
                   type="button"
-                  disabled={saving}
+                  disabled={saving || loadingSecondary || !canEditSelectedPage}
                   onClick={saveLayout}
                   className="rounded-md bg-primary-pink px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-pink/80 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {saving ? 'Saving...' : 'Save Layout'}
                 </button>
               </div>
+
+              {selectedMode === 'secondary' && (
+                <div className="mt-5 rounded-lg border border-sky-500/30 bg-sky-950/20 p-4">
+                  <Field label="Secondary Topic Page">
+                    <select
+                      value={selectedSecondarySlug}
+                      onChange={(event) => setSelectedSecondarySlug(event.target.value)}
+                      className={textInputClass}
+                    >
+                      {activeTagOptions.length === 0 && <option value="">Create an active tag first</option>}
+                      {activeTagOptions.map((tag) => (
+                        <option key={tag.slug} value={tag.slug}>{tagOptionLabel(tag)}</option>
+                      ))}
+                    </select>
+                  </Field>
+                  <p className="mt-3 text-xs text-sky-100/80">
+                    Secondary pages are stored per active tag. Market pins here are independent from the TOP /markets page pins and are searched within this topic.
+                  </p>
+                  {loadingSecondary && <p className="mt-2 text-xs text-gray-300">Loading selected topic page...</p>}
+                </div>
+              )}
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
                 <Field label="Page Title">
@@ -641,6 +737,7 @@ function MarketDiscoveryLayoutEditor() {
                   <select
                     value={state.searchScope}
                     onChange={(event) => updateState({ searchScope: event.target.value })}
+                    disabled={selectedMode === 'secondary'}
                     className={textInputClass}
                   >
                     <option value="all">All public markets</option>
@@ -679,24 +776,28 @@ function MarketDiscoveryLayoutEditor() {
               </div>
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
-                <ToggleCard
-                  title="Topic Pins"
-                  description="Create the topic navigation bar by pinning active topic tags. Usually enabled on the TOP markets page and disabled inside individual topic pages."
-                  checked={state.featuredTopicsEnabled}
-                  onChange={(checked) => updateState({ featuredTopicsEnabled: checked })}
-                />
+                {selectedMode === 'top' && (
+                  <ToggleCard
+                    title="Topic Pins"
+                    description="Create the topic navigation bar by pinning active topic tags. Usually enabled on the TOP markets page and disabled inside individual topic pages."
+                    checked={state.featuredTopicsEnabled}
+                    onChange={(checked) => updateState({ featuredTopicsEnabled: checked })}
+                  />
+                )}
                 <ToggleCard
                   title="Market Pins"
-                  description="Pin active markets as large chart cards before long fallback lists."
-                  checked={state.featuredMarketsEnabled}
+                  description={selectedMode === 'secondary' ? 'Pin active markets for this topic page only.' : 'Pin active markets as large chart cards before long fallback lists.'}
+                  checked={selectedMode === 'secondary' ? true : state.featuredMarketsEnabled}
                   onChange={(checked) => updateState({ featuredMarketsEnabled: checked })}
                 />
-                <ToggleCard
-                  title="CMS sections"
-                  description="Allow named sections beyond the implicit All section."
-                  checked={state.sectionsEnabled}
-                  onChange={(checked) => updateState({ sectionsEnabled: checked })}
-                />
+                {selectedMode === 'top' && (
+                  <ToggleCard
+                    title="CMS sections"
+                    description="Allow named sections beyond the implicit All section."
+                    checked={state.sectionsEnabled}
+                    onChange={(checked) => updateState({ sectionsEnabled: checked })}
+                  />
+                )}
                 <ToggleCard
                   title="Published"
                   description="Unpublished secondary layouts stay editable but should not appear publicly once topic routes are added."
@@ -715,7 +816,8 @@ function MarketDiscoveryLayoutEditor() {
               </div>
             </div>
 
-            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+            {selectedMode === 'top' && (
+              <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h3 className="text-xl font-bold text-white">Sections</h3>
@@ -771,8 +873,10 @@ function MarketDiscoveryLayoutEditor() {
                 ))}
               </div>
             </div>
+            )}
 
-            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+            {selectedMode === 'top' && (
+              <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h3 className="text-xl font-bold text-white">Topic Pins</h3>
@@ -833,18 +937,21 @@ function MarketDiscoveryLayoutEditor() {
                 ))}
               </div>
             </div>
+            )}
 
             <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h3 className="text-xl font-bold text-white">Market Pins</h3>
                   <p className="mt-1 text-sm text-gray-400">
-                    Market pins render selected active markets as featured chart cards. Search active markets, select one, then save.
+                    {selectedMode === 'secondary'
+                      ? `Market pins render selected active ${selectedSecondarySlug || 'topic'} markets on this topic page only.`
+                      : 'Market pins render selected active markets as featured chart cards. Search active markets, select one, then save.'}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  <button type="button" onClick={() => addPin('market')} className="rounded-md border border-emerald-500/50 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-950/50">Add Market Pin</button>
-                  <button type="button" disabled={savingPins} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
+                  <button type="button" onClick={() => addPin('market')} disabled={!canEditSelectedPage || loadingSecondary} className="rounded-md border border-emerald-500/50 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-950/50 disabled:cursor-not-allowed disabled:opacity-50">Add Market Pin</button>
+                  <button type="button" disabled={savingPins || !canEditSelectedPage || loadingSecondary} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
                     {savingPins ? 'Saving...' : 'Save Pins'}
                   </button>
                 </div>
@@ -856,7 +963,7 @@ function MarketDiscoveryLayoutEditor() {
                 {marketPins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No market pins yet.</p>}
                 {marketPins.map(({ pin, index }) => (
                   <div key={`market-${pin.id || pin.marketId || index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,90px)]">
-                    <MarketPinSearch pin={pin} onSelect={(marketId) => updatePin(index, { marketId: Number(marketId), label: '' })} />
+                    <MarketPinSearch pin={pin} tagSlug={selectedMode === 'secondary' ? selectedSecondarySlug : ''} onSelect={(marketId) => updatePin(index, { marketId: Number(marketId), label: '' })} />
                     <Field label="Order">
                       <input type="number" value={pin.sortOrder || index + 1} onChange={(event) => updatePin(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
                     </Field>
@@ -870,7 +977,7 @@ function MarketDiscoveryLayoutEditor() {
               </div>
             </div>
 
-            <LayoutPreview mode={mode} state={state} />
+            <LayoutPreview mode={{ ...mode, route: selectedRoute }} state={state} />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -1,47 +1,80 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
 
 const layoutModes = {
   top: {
+    slug: 'markets',
     label: 'Market page layout (TOP)',
     route: '/markets',
     purpose: 'Search-first discovery page for all public markets.',
-    defaultRecommendationLimit: 20,
-    curatedRecommendationLimit: 5,
+    pageType: 'top',
     fixedBlocks: [
       'Search bar',
       'Status tabs: Active, Closed, Resolved, All',
       'Recommendation fallback',
     ],
-    optionalBlocks: [
-      'Featured topic/category cards',
-      'Featured market cards',
-      'CMS sections',
-    ],
   },
   secondary: {
+    slug: 'topic-template',
     label: 'Topic page layout (SECONDARY)',
     route: '/markets/topic/:slug',
     purpose: 'Tag-scoped market discovery page for a CMS-managed topic.',
-    defaultRecommendationLimit: 20,
-    curatedRecommendationLimit: 5,
+    pageType: 'secondary',
     fixedBlocks: [
       'Topic title and description',
       'Search bar filtered by topic tag',
       'Status tabs: Active, Closed, Resolved, All',
     ],
-    optionalBlocks: [
-      'Pinned markets for this topic',
-      'Topic sections',
-      'Section-specific featured markets',
-    ],
   },
 };
 
-const plannedPersistence = [
+const persistedTables = [
   'market_discovery_pages',
   'market_discovery_sections',
   'market_discovery_pins',
 ];
+
+const defaultPageState = {
+  slug: 'markets',
+  title: 'Markets',
+  description: 'Browse and search prediction markets.',
+  pageType: 'top',
+  primaryTagSlug: '',
+  searchScope: 'all',
+  featuredTopicsEnabled: false,
+  featuredMarketsEnabled: false,
+  sectionsEnabled: false,
+  defaultRecommendationLimit: 20,
+  curatedRecommendationLimit: 5,
+  recommendationLimit: 20,
+  isPublished: true,
+  version: 0,
+};
+
+const normalizePage = (page = {}, modeKey = 'top') => {
+  const mode = layoutModes[modeKey];
+  const hasCuratedBlocks = !!(page.featuredTopicsEnabled || page.featuredMarketsEnabled || page.sectionsEnabled);
+  const defaultRecommendationLimit = Number(page.defaultRecommendationLimit || 20);
+  const curatedRecommendationLimit = Number(page.curatedRecommendationLimit || 5);
+
+  return {
+    ...defaultPageState,
+    slug: page.slug || mode.slug,
+    title: page.title || (modeKey === 'secondary' ? 'Topic Markets' : 'Markets'),
+    description: page.description || (modeKey === 'secondary' ? 'Browse and search markets in this topic.' : 'Browse and search prediction markets.'),
+    pageType: page.pageType || mode.pageType,
+    primaryTagSlug: page.primaryTagSlug || '',
+    searchScope: page.searchScope || (modeKey === 'secondary' ? 'tag' : 'all'),
+    featuredTopicsEnabled: !!page.featuredTopicsEnabled,
+    featuredMarketsEnabled: !!page.featuredMarketsEnabled,
+    sectionsEnabled: !!page.sectionsEnabled,
+    defaultRecommendationLimit,
+    curatedRecommendationLimit,
+    recommendationLimit: hasCuratedBlocks ? curatedRecommendationLimit : defaultRecommendationLimit,
+    isPublished: page.isPublished !== false,
+    version: Number(page.version || 0),
+  };
+};
 
 const ToggleCard = ({ title, description, checked, onChange }) => (
   <label className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition ${
@@ -69,17 +102,18 @@ const Pill = ({ children }) => (
 );
 
 const LayoutPreview = ({ mode, state }) => {
-  const hasCuratedBlocks = state.featuredTopics || state.featuredMarkets || state.sections;
+  const hasCuratedBlocks = state.featuredTopicsEnabled || state.featuredMarketsEnabled || state.sectionsEnabled;
   const recommendationLimit = hasCuratedBlocks
-    ? mode.curatedRecommendationLimit
-    : mode.defaultRecommendationLimit;
+    ? state.curatedRecommendationLimit
+    : state.defaultRecommendationLimit;
 
   return (
     <div className="rounded-xl border border-gray-700 bg-gray-950 p-5 shadow-lg">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <p className="font-mono text-xs uppercase tracking-[0.18em] text-sky-300">Preview Contract</p>
-          <h3 className="mt-2 text-xl font-bold text-white">{mode.label}</h3>
+          <h3 className="mt-2 text-xl font-bold text-white">{state.title}</h3>
+          {state.description && <p className="mt-1 text-sm text-gray-400">{state.description}</p>}
         </div>
         <Pill>{mode.route}</Pill>
       </div>
@@ -97,19 +131,19 @@ const LayoutPreview = ({ mode, state }) => {
             Show {recommendationLimit} fallback markets when CMS content is {hasCuratedBlocks ? 'present' : 'empty'}.
           </div>
         </div>
-        {state.featuredTopics && (
+        {state.featuredTopicsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
             <div className="text-sm font-semibold text-white">Featured topic/category cards</div>
             <div className="mt-1 text-xs text-gray-400">Pinned secondary pages appear after compact recommendations.</div>
           </div>
         )}
-        {state.featuredMarkets && (
+        {state.featuredMarketsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
             <div className="text-sm font-semibold text-white">Featured market cards</div>
             <div className="mt-1 text-xs text-gray-400">Admin-pinned markets appear in configured order.</div>
           </div>
         )}
-        {state.sections && (
+        {state.sectionsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
             <div className="text-sm font-semibold text-white">Sections</div>
             <div className="mt-1 text-xs text-gray-400">Explicit sections render after pins; otherwise the page has an implicit All section.</div>
@@ -123,19 +157,48 @@ const LayoutPreview = ({ mode, state }) => {
 function MarketDiscoveryLayoutEditor() {
   const [selectedMode, setSelectedMode] = useState('top');
   const [layoutState, setLayoutState] = useState({
-    top: {
-      searchScope: 'all',
-      featuredTopics: true,
-      featuredMarkets: true,
-      sections: false,
-    },
-    secondary: {
-      searchScope: 'tag',
-      featuredTopics: false,
-      featuredMarkets: true,
-      sections: true,
-    },
+    top: normalizePage({}, 'top'),
+    secondary: normalizePage({}, 'secondary'),
   });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let ignore = false;
+
+    const loadPages = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const [topPage, secondaryPage] = await Promise.all([
+          apiRequest('/v0/content/market-discovery/markets', { fallbackMessage: 'Failed to load TOP layout.' }),
+          apiRequest('/v0/content/market-discovery/topic-template', { fallbackMessage: 'Failed to load SECONDARY layout.' }),
+        ]);
+        if (!ignore) {
+          setLayoutState({
+            top: normalizePage(topPage, 'top'),
+            secondary: normalizePage(secondaryPage, 'secondary'),
+          });
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err.message || 'Unable to load market discovery layouts.');
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadPages();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
 
   const mode = layoutModes[selectedMode];
   const state = layoutState[selectedMode];
@@ -151,10 +214,44 @@ function MarketDiscoveryLayoutEditor() {
 
   const selectedBlocks = useMemo(() => [
     ...mode.fixedBlocks,
-    ...(state.featuredTopics ? ['Featured topic/category cards'] : []),
-    ...(state.featuredMarkets ? ['Featured market cards'] : []),
-    ...(state.sections ? ['CMS sections'] : []),
+    ...(state.featuredTopicsEnabled ? ['Featured topic/category cards'] : []),
+    ...(state.featuredMarketsEnabled ? ['Featured market cards'] : []),
+    ...(state.sectionsEnabled ? ['CMS sections'] : []),
   ], [mode, state]);
+
+  const saveLayout = async () => {
+    setSaving(true);
+    setMessage('');
+    setError('');
+    try {
+      const saved = await authenticatedApiRequest(`/v0/admin/content/market-discovery/${mode.slug}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...state,
+          pageType: mode.pageType,
+        }),
+        fallbackMessage: 'Failed to save market discovery layout.',
+      });
+      setLayoutState((current) => ({
+        ...current,
+        [selectedMode]: normalizePage(saved, selectedMode),
+      }));
+      setMessage(`${mode.label} saved. /markets will use the TOP layout immediately after refresh.`);
+    } catch (err) {
+      setError(err.message || 'Unable to save market discovery layout.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-primary-background p-8 text-white">
+        Loading market discovery layouts...
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-primary-background p-8">
@@ -163,15 +260,13 @@ function MarketDiscoveryLayoutEditor() {
           <p className="text-sm font-semibold uppercase tracking-[0.22em] text-sky-300">CMS</p>
           <h1 className="mt-2 text-3xl font-bold text-white">Market Discovery Layout</h1>
           <p className="mt-2 max-w-3xl text-gray-300">
-            Scaffold the TOP market page and SECONDARY topic page layout options from FEATURE/09.
-            This panel defines the admin-facing CMS shape before page/section/pin persistence is added.
+            Configure persisted TOP market page and SECONDARY topic page layout options from FEATURE/09.
+            The TOP record now controls the public /markets page title, description, fallback list size, and CMS block visibility.
           </p>
         </div>
 
-        <div className="rounded-lg border border-amber-500/40 bg-amber-950/40 p-4 text-sm text-amber-100">
-          These controls are a planning scaffold only. Saving will be enabled after backend CMS tables
-          and APIs are added for discovery pages, sections, and pins.
-        </div>
+        {message && <div className="rounded-lg bg-emerald-700 p-4 text-sm text-white">{message}</div>}
+        {error && <div className="rounded-lg bg-red-700 p-4 text-sm text-white">{error}</div>}
 
         <div className="grid gap-6 lg:grid-cols-[320px,minmax(0,1fr)]">
           <div className="space-y-4">
@@ -197,9 +292,9 @@ function MarketDiscoveryLayoutEditor() {
             </div>
 
             <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-4">
-              <h2 className="font-semibold text-white">Planned Backend Tables</h2>
+              <h2 className="font-semibold text-white">Persisted Backend Tables</h2>
               <div className="mt-3 flex flex-wrap gap-2">
-                {plannedPersistence.map((table) => (
+                {persistedTables.map((table) => (
                   <Pill key={table}>{table}</Pill>
                 ))}
               </div>
@@ -215,50 +310,94 @@ function MarketDiscoveryLayoutEditor() {
                 </div>
                 <button
                   type="button"
-                  disabled
-                  className="rounded-md bg-gray-700 px-4 py-2 text-sm font-semibold text-gray-400 disabled:cursor-not-allowed"
-                  title="Backend persistence is planned in FEATURE/09 sections 06 and 07."
+                  disabled={saving}
+                  onClick={saveLayout}
+                  className="rounded-md bg-primary-pink px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-pink/80 disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                  Save Layout Later
+                  {saving ? 'Saving...' : 'Save Layout'}
                 </button>
+              </div>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                <label className="grid gap-2 text-sm text-gray-300">
+                  Page Title
+                  <input
+                    value={state.title}
+                    maxLength={160}
+                    onChange={(event) => updateState({ title: event.target.value })}
+                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                  />
+                </label>
+                <label className="grid gap-2 text-sm text-gray-300">
+                  Search Scope
+                  <select
+                    value={state.searchScope}
+                    onChange={(event) => updateState({ searchScope: event.target.value })}
+                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                  >
+                    <option value="all">All public markets</option>
+                    <option value="tag">Current topic/tag by default</option>
+                  </select>
+                </label>
+                <label className="grid gap-2 text-sm text-gray-300 md:col-span-2">
+                  Page Description
+                  <textarea
+                    value={state.description}
+                    maxLength={500}
+                    rows={3}
+                    onChange={(event) => updateState({ description: event.target.value })}
+                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                  />
+                </label>
+                <label className="grid gap-2 text-sm text-gray-300">
+                  Empty CMS Recommendation Limit
+                  <input
+                    type="number"
+                    min="1"
+                    max="50"
+                    value={state.defaultRecommendationLimit}
+                    onChange={(event) => updateState({ defaultRecommendationLimit: Number(event.target.value || 1) })}
+                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                  />
+                </label>
+                <label className="grid gap-2 text-sm text-gray-300">
+                  Curated CMS Recommendation Limit
+                  <input
+                    type="number"
+                    min="1"
+                    max="50"
+                    value={state.curatedRecommendationLimit}
+                    onChange={(event) => updateState({ curatedRecommendationLimit: Number(event.target.value || 1) })}
+                    className="rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                  />
+                </label>
               </div>
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
                 <ToggleCard
                   title="Featured topic/category cards"
                   description="Show pinned SECONDARY pages on the TOP page. Usually disabled inside SECONDARY topic pages."
-                  checked={state.featuredTopics}
-                  onChange={(checked) => updateState({ featuredTopics: checked })}
+                  checked={state.featuredTopicsEnabled}
+                  onChange={(checked) => updateState({ featuredTopicsEnabled: checked })}
                 />
                 <ToggleCard
                   title="Featured market cards"
                   description="Show manually pinned markets before long fallback lists."
-                  checked={state.featuredMarkets}
-                  onChange={(checked) => updateState({ featuredMarkets: checked })}
+                  checked={state.featuredMarketsEnabled}
+                  onChange={(checked) => updateState({ featuredMarketsEnabled: checked })}
                 />
                 <ToggleCard
                   title="CMS sections"
                   description="Allow named sections beyond the implicit All section."
-                  checked={state.sections}
-                  onChange={(checked) => updateState({ sections: checked })}
+                  checked={state.sectionsEnabled}
+                  onChange={(checked) => updateState({ sectionsEnabled: checked })}
                 />
-                <div className="rounded-lg border border-gray-700 bg-gray-950 p-4">
-                  <label className="block font-semibold text-white" htmlFor="search-scope">
-                    Search Scope
-                  </label>
-                  <select
-                    id="search-scope"
-                    value={state.searchScope}
-                    onChange={(event) => updateState({ searchScope: event.target.value })}
-                    className="mt-3 w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
-                  >
-                    <option value="all">All public markets</option>
-                    <option value="tag">Current topic/tag by default</option>
-                  </select>
-                  <p className="mt-2 text-sm text-gray-400">
-                    TOP should usually use all markets; SECONDARY should usually use topic/tag scope.
-                  </p>
-                </div>
+                <ToggleCard
+                  title="Published"
+                  description="Unpublished secondary layouts stay editable but should not appear publicly once topic routes are added."
+                  checked={state.isPublished}
+                  onChange={(checked) => updateState({ isPublished: checked })}
+                />
               </div>
 
               <div className="mt-6 rounded-lg border border-gray-700 bg-gray-950 p-4">

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -49,7 +49,6 @@ const defaultPageState = {
   defaultRecommendationLimit: 20,
   curatedRecommendationLimit: 5,
   recommendationLimit: 20,
-  isPublished: true,
   version: 0,
   sections: [],
   pins: [],
@@ -77,7 +76,6 @@ const normalizePage = (page = {}, modeKey = 'top') => {
     defaultRecommendationLimit,
     curatedRecommendationLimit,
     recommendationLimit: hasCuratedBlocks ? curatedRecommendationLimit : defaultRecommendationLimit,
-    isPublished: page.isPublished !== false,
     version: Number(page.version || 0),
     sections: sortBySortOrder(page.sections || []),
     pins: sortBySortOrder(page.pins || []),
@@ -333,6 +331,7 @@ const LayoutPreview = ({ mode, state }) => {
 function MarketDiscoveryLayoutEditor() {
   const [selectedMode, setSelectedMode] = useState('top');
   const [selectedSecondarySlug, setSelectedSecondarySlug] = useState('');
+  const [activeEditorTab, setActiveEditorTab] = useState('layout');
   const [layoutState, setLayoutState] = useState({
     top: normalizePage({}, 'top'),
     secondary: normalizePage({}, 'secondary'),
@@ -472,6 +471,32 @@ function MarketDiscoveryLayoutEditor() {
     ))
   ), [activeTags]);
   const firstActiveTagSlug = activeTagOptions[0]?.slug || '';
+  const editorTabs = useMemo(() => {
+    const layoutTab = {
+      key: 'layout',
+      label: selectedMode === 'secondary' ? 'Topic page pins (SECONDARY)' : 'Market page layout (TOP)',
+    };
+    if (selectedMode === 'secondary') {
+      return [
+        layoutTab,
+        { key: 'marketPins', label: 'Market Pins' },
+        { key: 'preview', label: 'Preview' },
+      ];
+    }
+    return [
+      layoutTab,
+      { key: 'sections', label: 'Sections' },
+      { key: 'topicPins', label: 'Topic Pins' },
+      { key: 'marketPins', label: 'Market Pins' },
+      { key: 'preview', label: 'Preview' },
+    ];
+  }, [selectedMode]);
+
+  useEffect(() => {
+    if (!editorTabs.some((tab) => tab.key === activeEditorTab)) {
+      setActiveEditorTab(editorTabs[0]?.key || 'layout');
+    }
+  }, [activeEditorTab, editorTabs]);
 
   const replaceSelectedState = (saved) => {
     setLayoutState((current) => ({
@@ -682,7 +707,25 @@ function MarketDiscoveryLayoutEditor() {
           </div>
 
           <div className="space-y-6">
-            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+            <div className="flex flex-wrap gap-2 rounded-xl border border-gray-700 bg-gray-900/80 p-3">
+              {editorTabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => setActiveEditorTab(tab.key)}
+                  className={`rounded-lg px-3 py-2 text-sm font-semibold transition ${
+                    activeEditorTab === tab.key
+                      ? 'bg-primary-pink text-white'
+                      : 'border border-gray-700 bg-gray-950 text-gray-300 hover:border-gray-500 hover:text-white'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            {activeEditorTab === 'layout' && (
+              <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
                   <h2 className="text-2xl font-bold text-white">{selectedPageLabel}</h2>
@@ -794,12 +837,6 @@ function MarketDiscoveryLayoutEditor() {
                     onChange={(checked) => updateState({ sectionsEnabled: checked })}
                   />
                 )}
-                <ToggleCard
-                  title="Published"
-                  description="Unpublished secondary layouts stay editable but should not appear publicly once topic routes are added."
-                  checked={state.isPublished}
-                  onChange={(checked) => updateState({ isPublished: checked })}
-                />
               </div>
 
               <div className="mt-6 rounded-lg border border-gray-700 bg-gray-950 p-4">
@@ -811,8 +848,9 @@ function MarketDiscoveryLayoutEditor() {
                 </ol>
               </div>
             </div>
+            )}
 
-            {selectedMode === 'top' && (
+            {selectedMode === 'top' && activeEditorTab === 'sections' && (
               <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
@@ -871,7 +909,7 @@ function MarketDiscoveryLayoutEditor() {
             </div>
             )}
 
-            {selectedMode === 'top' && (
+            {selectedMode === 'top' && activeEditorTab === 'topicPins' && (
               <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
@@ -935,6 +973,7 @@ function MarketDiscoveryLayoutEditor() {
             </div>
             )}
 
+            {activeEditorTab === 'marketPins' && (
             <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
@@ -972,8 +1011,9 @@ function MarketDiscoveryLayoutEditor() {
                 ))}
               </div>
             </div>
+            )}
 
-            <LayoutPreview mode={{ ...mode, route: selectedRoute }} state={state} />
+            {activeEditorTab === 'preview' && <LayoutPreview mode={{ ...mode, route: selectedRoute }} state={state} />}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
+import { searchMarkets } from '../../api/marketsApi';
 import { listAdminMarketTags } from '../../api/marketTagsApi';
 
 const layoutModes = {
@@ -137,6 +138,103 @@ const tagOptionsWithCurrent = (tags, currentSlug) => {
   ];
 };
 
+const marketOverviewTitle = (overview) => (
+  overview?.market?.questionTitle
+  || overview?.questionTitle
+  || `Market #${overview?.market?.id || overview?.id || 'unknown'}`
+);
+
+const marketOverviewId = (overview) => overview?.market?.id || overview?.id || overview?.marketId || 0;
+
+const MarketPinSearch = ({ pin, onSelect }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState('');
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setSearchError('');
+      return undefined;
+    }
+
+    let ignore = false;
+    const timeoutId = setTimeout(async () => {
+      setSearching(true);
+      setSearchError('');
+      try {
+        const response = await searchMarkets(trimmed, 'active', 8);
+        if (!ignore) {
+          setResults(response.primaryResults || []);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setSearchError(err.message || 'Unable to search active markets.');
+          setResults([]);
+        }
+      } finally {
+        if (!ignore) {
+          setSearching(false);
+        }
+      }
+    }, 250);
+
+    return () => {
+      ignore = true;
+      clearTimeout(timeoutId);
+    };
+  }, [query]);
+
+  return (
+    <div className="grid gap-3">
+      <div className="rounded-lg border border-gray-700 bg-gray-900/70 p-3">
+        <div className="font-mono text-xs uppercase tracking-[0.14em] text-gray-400">Selected Market</div>
+        <div className="mt-1 text-sm text-white">
+          {Number(pin.marketId) > 0 ? `Market #${pin.marketId}` : 'No market selected yet.'}
+        </div>
+      </div>
+      <Field label="Search Active Markets">
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Type at least 2 characters..."
+          className={textInputClass}
+        />
+      </Field>
+      {searching && <p className="text-xs text-gray-400">Searching active markets...</p>}
+      {searchError && <p className="text-xs text-red-300">{searchError}</p>}
+      {results.length > 0 && (
+        <div className="grid gap-2">
+          {results.map((overview) => {
+            const id = marketOverviewId(overview);
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => {
+                  onSelect(id);
+                  setQuery('');
+                  setResults([]);
+                }}
+                className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                  Number(pin.marketId) === Number(id)
+                    ? 'border-primary-pink bg-primary-pink/15 text-white'
+                    : 'border-gray-700 bg-gray-800 text-gray-200 hover:border-sky-400/60'
+                }`}
+              >
+                <span className="block font-semibold">{marketOverviewTitle(overview)}</span>
+                <span className="mt-1 block text-xs text-gray-400">Active market #{id}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const LayoutPreview = ({ mode, state }) => {
   const hasCuratedBlocks = state.featuredTopicsEnabled || state.featuredMarketsEnabled || state.sectionsEnabled;
   const recommendationLimit = hasCuratedBlocks
@@ -169,13 +267,13 @@ const LayoutPreview = ({ mode, state }) => {
         </div>
         {state.featuredTopicsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
-            <div className="text-sm font-semibold text-white">Featured topic/category cards</div>
+            <div className="text-sm font-semibold text-white">Topic Pins</div>
             <div className="mt-1 text-xs text-gray-400">{state.pins.filter((pin) => pin.pinType === 'discovery_page').length} page pins configured.</div>
           </div>
         )}
         {state.featuredMarketsEnabled && (
           <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
-            <div className="text-sm font-semibold text-white">Featured market cards</div>
+            <div className="text-sm font-semibold text-white">Market Pins</div>
             <div className="mt-1 text-xs text-gray-400">{state.pins.filter((pin) => pin.pinType === 'market').length} market pins configured.</div>
           </div>
         )}
@@ -264,8 +362,12 @@ function MarketDiscoveryLayoutEditor() {
 
   const mode = layoutModes[selectedMode];
   const state = layoutState[selectedMode];
-  const topicPins = state.pins.filter((pin) => pin.pinType === 'discovery_page');
-  const marketPins = state.pins.filter((pin) => pin.pinType === 'market');
+  const topicPins = state.pins
+    .map((pin, index) => ({ pin, index }))
+    .filter(({ pin }) => pin.pinType === 'discovery_page');
+  const marketPins = state.pins
+    .map((pin, index) => ({ pin, index }))
+    .filter(({ pin }) => pin.pinType === 'market');
   const activeTagOptions = useMemo(() => (
     [...activeTags].sort((left, right) => (
       (left.displayName || left.slug).localeCompare(right.displayName || right.slug)
@@ -308,8 +410,8 @@ function MarketDiscoveryLayoutEditor() {
 
   const selectedBlocks = useMemo(() => [
     ...mode.fixedBlocks,
-    ...(state.featuredTopicsEnabled ? ['Featured topic/category cards'] : []),
-    ...(state.featuredMarketsEnabled ? ['Featured market cards'] : []),
+    ...(state.featuredTopicsEnabled ? ['Topic Pins'] : []),
+    ...(state.featuredMarketsEnabled ? ['Market Pins'] : []),
     ...(state.sectionsEnabled ? ['CMS sections'] : []),
   ], [mode, state]);
 
@@ -400,11 +502,15 @@ function MarketDiscoveryLayoutEditor() {
           pinType,
           marketId: pinType === 'market' ? '' : 0,
           targetPageSlug: pinType === 'discovery_page' ? firstActiveTagSlug : '',
-          label: pinType === 'market' ? 'Featured Market' : 'Featured Topic',
+          label: pinType === 'market' ? '' : 'Featured Topic',
           sortOrder: nextSortOrder(state.pins),
         },
       ],
     });
+  };
+
+  const removePin = (index) => {
+    updateState({ pins: state.pins.filter((_, currentIndex) => currentIndex !== index) });
   };
 
   if (loading) {
@@ -532,14 +638,14 @@ function MarketDiscoveryLayoutEditor() {
 
               <div className="mt-6 grid gap-4 md:grid-cols-2">
                 <ToggleCard
-                  title="Featured topic/category cards"
-                  description="Show pinned SECONDARY pages on the TOP page. Usually disabled inside SECONDARY topic pages."
+                  title="Topic Pins"
+                  description="Create the topic navigation bar by pinning active topic tags. Usually enabled on the TOP markets page and disabled inside individual topic pages."
                   checked={state.featuredTopicsEnabled}
                   onChange={(checked) => updateState({ featuredTopicsEnabled: checked })}
                 />
                 <ToggleCard
-                  title="Featured market cards"
-                  description="Show manually pinned markets before long fallback lists."
+                  title="Market Pins"
+                  description="Pin active markets as large chart cards before long fallback lists."
                   checked={state.featuredMarketsEnabled}
                   onChange={(checked) => updateState({ featuredMarketsEnabled: checked })}
                 />
@@ -627,8 +733,10 @@ function MarketDiscoveryLayoutEditor() {
             <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <h3 className="text-xl font-bold text-white">Pins</h3>
-                  <p className="mt-1 text-sm text-gray-400">Topic pins point at active tag slugs. The selected tag drives /markets/topic/:slug filtering.</p>
+                  <h3 className="text-xl font-bold text-white">Topic Pins</h3>
+                  <p className="mt-1 text-sm text-gray-400">
+                    Topic pins build the /markets topic nav bar. Each entry points to an active tag and filters /markets/topic/:slug.
+                  </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <button
@@ -640,7 +748,6 @@ function MarketDiscoveryLayoutEditor() {
                   >
                     Add Topic Pin
                   </button>
-                  <button type="button" onClick={() => addPin('market')} className="rounded-md border border-emerald-500/50 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-950/50">Add Market Pin</button>
                   <button type="button" disabled={savingPins} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
                     {savingPins ? 'Saving...' : 'Save Pins'}
                   </button>
@@ -648,60 +755,72 @@ function MarketDiscoveryLayoutEditor() {
               </div>
               <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-400">
                 <Pill>{topicPins.length} topic pins</Pill>
-                <Pill>{marketPins.length} market pins</Pill>
               </div>
               <div className="mt-4 space-y-3">
-                {state.pins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No page-level pins yet.</p>}
-                {state.pins.map((pin, index) => (
-                  <div key={`${pin.pinType}-${index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[minmax(0,150px)_minmax(0,1fr)_minmax(0,90px)]">
-                    <Field label="Pin Type">
+                {topicPins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No topic pins yet.</p>}
+                {topicPins.map(({ pin, index }) => (
+                  <div key={`topic-${pin.id || pin.targetPageSlug || index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,90px)]">
+                    <Field label="Nav Label">
+                      <input value={pin.label || ''} onChange={(event) => updatePin(index, { label: event.target.value })} className={textInputClass} />
+                    </Field>
+                    <Field label="Target Topic Tag">
                       <select
-                        value={pin.pinType || 'market'}
-                        onChange={(event) => {
-                          const pinType = event.target.value;
-                          updatePin(index, {
-                            pinType,
-                            marketId: pinType === 'market' ? (pin.marketId || '') : 0,
-                            targetPageSlug: pinType === 'discovery_page' ? (pin.targetPageSlug || firstActiveTagSlug) : '',
-                          });
-                        }}
+                        value={pin.targetPageSlug || ''}
+                        onChange={(event) => updatePin(index, { targetPageSlug: event.target.value })}
                         className={textInputClass}
                       >
-                        <option value="market">Featured market</option>
-                        <option value="discovery_page">Featured topic page</option>
+                        {activeTagOptions.length === 0 && !pin.targetPageSlug && (
+                          <option value="">Create an active tag first</option>
+                        )}
+                        {tagOptionsWithCurrent(activeTagOptions, pin.targetPageSlug).map((tag) => (
+                          <option key={tag.slug} value={tag.slug}>
+                            {tagOptionLabel(tag)}{tag.isActive === false ? ' - inactive or missing' : ''}
+                          </option>
+                        ))}
                       </select>
-                    </Field>
-                    <Field label="Label">
-                      <input value={pin.label || ''} onChange={(event) => updatePin(index, { label: event.target.value })} className={textInputClass} />
                     </Field>
                     <Field label="Order">
                       <input type="number" value={pin.sortOrder || index + 1} onChange={(event) => updatePin(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
                     </Field>
-                    {pin.pinType === 'discovery_page' ? (
-                      <Field label="Target Topic Tag" className="md:col-span-2">
-                        <select
-                          value={pin.targetPageSlug || ''}
-                          onChange={(event) => updatePin(index, { targetPageSlug: event.target.value })}
-                          className={textInputClass}
-                        >
-                          {activeTagOptions.length === 0 && !pin.targetPageSlug && (
-                            <option value="">Create an active tag first</option>
-                          )}
-                          {tagOptionsWithCurrent(activeTagOptions, pin.targetPageSlug).map((tag) => (
-                            <option key={tag.slug} value={tag.slug}>
-                              {tagOptionLabel(tag)}{tag.isActive === false ? ' - inactive or missing' : ''}
-                            </option>
-                          ))}
-                        </select>
-                      </Field>
-                    ) : (
-                      <Field label="Market ID" className="md:col-span-2">
-                        <input type="number" min="1" value={pin.marketId || ''} onChange={(event) => updatePin(index, { marketId: Number(event.target.value || 0) })} className={textInputClass} />
-                      </Field>
-                    )}
-                    <div className="flex items-end">
-                      <button type="button" onClick={() => updateState({ pins: state.pins.filter((_, currentIndex) => currentIndex !== index) })} className="pb-2 text-sm font-semibold text-red-300 hover:text-red-200">
-                        Remove pin
+                    <div className="md:col-span-3">
+                      <button type="button" onClick={() => removePin(index)} className="text-sm font-semibold text-red-300 hover:text-red-200">
+                        Remove topic pin
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-xl font-bold text-white">Market Pins</h3>
+                  <p className="mt-1 text-sm text-gray-400">
+                    Market pins render selected active markets as featured chart cards. Search active markets, select one, then save.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" onClick={() => addPin('market')} className="rounded-md border border-emerald-500/50 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-950/50">Add Market Pin</button>
+                  <button type="button" disabled={savingPins} onClick={savePins} className="rounded-md bg-primary-pink px-3 py-2 text-sm font-semibold text-white hover:bg-primary-pink/80 disabled:opacity-50">
+                    {savingPins ? 'Saving...' : 'Save Pins'}
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-400">
+                <Pill>{marketPins.length} market pins</Pill>
+              </div>
+              <div className="mt-4 space-y-3">
+                {marketPins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No market pins yet.</p>}
+                {marketPins.map(({ pin, index }) => (
+                  <div key={`market-${pin.id || pin.marketId || index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,90px)]">
+                    <MarketPinSearch pin={pin} onSelect={(marketId) => updatePin(index, { marketId: Number(marketId), label: '' })} />
+                    <Field label="Order">
+                      <input type="number" value={pin.sortOrder || index + 1} onChange={(event) => updatePin(index, { sortOrder: Number(event.target.value || 0) })} className={textInputClass} />
+                    </Field>
+                    <div className="md:col-span-2">
+                      <button type="button" onClick={() => removePin(index)} className="text-sm font-semibold text-red-300 hover:text-red-200">
+                        Remove market pin
                       </button>
                     </div>
                   </div>

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -643,10 +643,6 @@ function MarketDiscoveryLayoutEditor() {
         <div>
           <p className="text-sm font-semibold uppercase tracking-[0.22em] text-sky-300">CMS</p>
           <h1 className="mt-2 text-3xl font-bold text-white">Market Discovery Layout</h1>
-          <p className="mt-2 max-w-3xl text-gray-300">
-            Configure persisted TOP market page and SECONDARY topic page layout options from FEATURE/09.
-            The TOP record controls the public /markets page title, description, fallback list size, section cards, and featured pins.
-          </p>
         </div>
 
         {message && <div className="rounded-lg bg-emerald-700 p-4 text-sm text-white">{message}</div>}

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -1,0 +1,282 @@
+import React, { useMemo, useState } from 'react';
+
+const layoutModes = {
+  top: {
+    label: 'Market page layout (TOP)',
+    route: '/markets',
+    purpose: 'Search-first discovery page for all public markets.',
+    defaultRecommendationLimit: 20,
+    curatedRecommendationLimit: 5,
+    fixedBlocks: [
+      'Search bar',
+      'Status tabs: Active, Closed, Resolved, All',
+      'Recommendation fallback',
+    ],
+    optionalBlocks: [
+      'Featured topic/category cards',
+      'Featured market cards',
+      'CMS sections',
+    ],
+  },
+  secondary: {
+    label: 'Topic page layout (SECONDARY)',
+    route: '/markets/topic/:slug',
+    purpose: 'Tag-scoped market discovery page for a CMS-managed topic.',
+    defaultRecommendationLimit: 20,
+    curatedRecommendationLimit: 5,
+    fixedBlocks: [
+      'Topic title and description',
+      'Search bar filtered by topic tag',
+      'Status tabs: Active, Closed, Resolved, All',
+    ],
+    optionalBlocks: [
+      'Pinned markets for this topic',
+      'Topic sections',
+      'Section-specific featured markets',
+    ],
+  },
+};
+
+const plannedPersistence = [
+  'market_discovery_pages',
+  'market_discovery_sections',
+  'market_discovery_pins',
+];
+
+const ToggleCard = ({ title, description, checked, onChange }) => (
+  <label className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition ${
+    checked
+      ? 'border-primary-pink bg-primary-pink/10'
+      : 'border-gray-700 bg-gray-900/70 hover:border-gray-500'
+  }`}>
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+      className="mt-1 h-4 w-4 accent-primary-pink"
+    />
+    <span>
+      <span className="block font-semibold text-white">{title}</span>
+      <span className="mt-1 block text-sm text-gray-400">{description}</span>
+    </span>
+  </label>
+);
+
+const Pill = ({ children }) => (
+  <span className="rounded-full border border-sky-500/40 bg-sky-950/40 px-3 py-1 text-xs font-semibold text-sky-100">
+    {children}
+  </span>
+);
+
+const LayoutPreview = ({ mode, state }) => {
+  const hasCuratedBlocks = state.featuredTopics || state.featuredMarkets || state.sections;
+  const recommendationLimit = hasCuratedBlocks
+    ? mode.curatedRecommendationLimit
+    : mode.defaultRecommendationLimit;
+
+  return (
+    <div className="rounded-xl border border-gray-700 bg-gray-950 p-5 shadow-lg">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-sky-300">Preview Contract</p>
+          <h3 className="mt-2 text-xl font-bold text-white">{mode.label}</h3>
+        </div>
+        <Pill>{mode.route}</Pill>
+      </div>
+
+      <div className="mt-5 space-y-3">
+        <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+          <div className="text-sm font-semibold text-white">1. Search first</div>
+          <div className="mt-1 text-xs text-gray-400">
+            {state.searchScope === 'tag' ? 'Search defaults to the page tag.' : 'Search defaults to all public markets.'}
+          </div>
+        </div>
+        <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+          <div className="text-sm font-semibold text-white">2. Recommendations</div>
+          <div className="mt-1 text-xs text-gray-400">
+            Show {recommendationLimit} fallback markets when CMS content is {hasCuratedBlocks ? 'present' : 'empty'}.
+          </div>
+        </div>
+        {state.featuredTopics && (
+          <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+            <div className="text-sm font-semibold text-white">Featured topic/category cards</div>
+            <div className="mt-1 text-xs text-gray-400">Pinned secondary pages appear after compact recommendations.</div>
+          </div>
+        )}
+        {state.featuredMarkets && (
+          <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+            <div className="text-sm font-semibold text-white">Featured market cards</div>
+            <div className="mt-1 text-xs text-gray-400">Admin-pinned markets appear in configured order.</div>
+          </div>
+        )}
+        {state.sections && (
+          <div className="rounded-lg border border-gray-700 bg-gray-900 p-4">
+            <div className="text-sm font-semibold text-white">Sections</div>
+            <div className="mt-1 text-xs text-gray-400">Explicit sections render after pins; otherwise the page has an implicit All section.</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+function MarketDiscoveryLayoutEditor() {
+  const [selectedMode, setSelectedMode] = useState('top');
+  const [layoutState, setLayoutState] = useState({
+    top: {
+      searchScope: 'all',
+      featuredTopics: true,
+      featuredMarkets: true,
+      sections: false,
+    },
+    secondary: {
+      searchScope: 'tag',
+      featuredTopics: false,
+      featuredMarkets: true,
+      sections: true,
+    },
+  });
+
+  const mode = layoutModes[selectedMode];
+  const state = layoutState[selectedMode];
+  const updateState = (updates) => {
+    setLayoutState((current) => ({
+      ...current,
+      [selectedMode]: {
+        ...current[selectedMode],
+        ...updates,
+      },
+    }));
+  };
+
+  const selectedBlocks = useMemo(() => [
+    ...mode.fixedBlocks,
+    ...(state.featuredTopics ? ['Featured topic/category cards'] : []),
+    ...(state.featuredMarkets ? ['Featured market cards'] : []),
+    ...(state.sections ? ['CMS sections'] : []),
+  ], [mode, state]);
+
+  return (
+    <div className="min-h-screen bg-primary-background p-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-sky-300">CMS</p>
+          <h1 className="mt-2 text-3xl font-bold text-white">Market Discovery Layout</h1>
+          <p className="mt-2 max-w-3xl text-gray-300">
+            Scaffold the TOP market page and SECONDARY topic page layout options from FEATURE/09.
+            This panel defines the admin-facing CMS shape before page/section/pin persistence is added.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-amber-500/40 bg-amber-950/40 p-4 text-sm text-amber-100">
+          These controls are a planning scaffold only. Saving will be enabled after backend CMS tables
+          and APIs are added for discovery pages, sections, and pins.
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[320px,minmax(0,1fr)]">
+          <div className="space-y-4">
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-4">
+              <h2 className="font-semibold text-white">Layout Type</h2>
+              <div className="mt-4 grid gap-3">
+                {Object.entries(layoutModes).map(([key, item]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSelectedMode(key)}
+                    className={`rounded-lg border p-4 text-left transition ${
+                      selectedMode === key
+                        ? 'border-primary-pink bg-primary-pink/15 text-white'
+                        : 'border-gray-700 bg-gray-950 text-gray-300 hover:border-gray-500'
+                    }`}
+                  >
+                    <span className="block font-semibold">{item.label}</span>
+                    <span className="mt-1 block text-xs text-gray-400">{item.route}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-4">
+              <h2 className="font-semibold text-white">Planned Backend Tables</h2>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {plannedPersistence.map((table) => (
+                  <Pill key={table}>{table}</Pill>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-xl border border-gray-700 bg-gray-900/80 p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-2xl font-bold text-white">{mode.label}</h2>
+                  <p className="mt-2 max-w-2xl text-sm text-gray-300">{mode.purpose}</p>
+                </div>
+                <button
+                  type="button"
+                  disabled
+                  className="rounded-md bg-gray-700 px-4 py-2 text-sm font-semibold text-gray-400 disabled:cursor-not-allowed"
+                  title="Backend persistence is planned in FEATURE/09 sections 06 and 07."
+                >
+                  Save Layout Later
+                </button>
+              </div>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                <ToggleCard
+                  title="Featured topic/category cards"
+                  description="Show pinned SECONDARY pages on the TOP page. Usually disabled inside SECONDARY topic pages."
+                  checked={state.featuredTopics}
+                  onChange={(checked) => updateState({ featuredTopics: checked })}
+                />
+                <ToggleCard
+                  title="Featured market cards"
+                  description="Show manually pinned markets before long fallback lists."
+                  checked={state.featuredMarkets}
+                  onChange={(checked) => updateState({ featuredMarkets: checked })}
+                />
+                <ToggleCard
+                  title="CMS sections"
+                  description="Allow named sections beyond the implicit All section."
+                  checked={state.sections}
+                  onChange={(checked) => updateState({ sections: checked })}
+                />
+                <div className="rounded-lg border border-gray-700 bg-gray-950 p-4">
+                  <label className="block font-semibold text-white" htmlFor="search-scope">
+                    Search Scope
+                  </label>
+                  <select
+                    id="search-scope"
+                    value={state.searchScope}
+                    onChange={(event) => updateState({ searchScope: event.target.value })}
+                    className="mt-3 w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40"
+                  >
+                    <option value="all">All public markets</option>
+                    <option value="tag">Current topic/tag by default</option>
+                  </select>
+                  <p className="mt-2 text-sm text-gray-400">
+                    TOP should usually use all markets; SECONDARY should usually use topic/tag scope.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-6 rounded-lg border border-gray-700 bg-gray-950 p-4">
+                <h3 className="font-semibold text-white">Selected Render Blocks</h3>
+                <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-gray-300">
+                  {selectedBlocks.map((block) => (
+                    <li key={block}>{block}</li>
+                  ))}
+                </ol>
+              </div>
+            </div>
+
+            <LayoutPreview mode={mode} state={state} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MarketDiscoveryLayoutEditor;

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -117,7 +117,7 @@ const Field = ({ label, children, className = '' }) => (
   </label>
 );
 
-const textInputClass = 'rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40';
+const textInputClass = 'w-full min-w-0 rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:border-primary-pink focus:outline-none focus:ring-2 focus:ring-primary-pink/40';
 
 const tagOptionLabel = (tag) => `${tag.displayName || tag.slug} (${tag.slug})`;
 
@@ -653,7 +653,7 @@ function MarketDiscoveryLayoutEditor() {
               <div className="mt-4 space-y-3">
                 {state.pins.length === 0 && <p className="rounded-lg border border-dashed border-gray-700 p-4 text-sm text-gray-400">No page-level pins yet.</p>}
                 {state.pins.map((pin, index) => (
-                  <div key={`${pin.pinType}-${index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[170px_1fr_120px]">
+                  <div key={`${pin.pinType}-${index}`} className="grid gap-3 rounded-lg border border-gray-700 bg-gray-950 p-4 md:grid-cols-[minmax(0,150px)_minmax(0,1fr)_minmax(0,90px)]">
                     <Field label="Pin Type">
                       <select
                         value={pin.pinType || 'market'}

--- a/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
+++ b/frontend/src/pages/admin/MarketDiscoveryLayoutEditor.jsx
@@ -718,7 +718,7 @@ function MarketDiscoveryLayoutEditor() {
                     </select>
                   </Field>
                   <p className="mt-3 text-xs text-sky-100/80">
-                    Secondary pages are stored per active tag. Market pins here are independent from the TOP /markets page pins and are searched within this topic.
+                    Secondary pages are stored per active tag. The topic nav is inherited from the TOP /markets page; market pins here are independent and searched within this topic.
                   </p>
                   {loadingSecondary && <p className="mt-2 text-xs text-gray-300">Loading selected topic page...</p>}
                 </div>
@@ -779,7 +779,7 @@ function MarketDiscoveryLayoutEditor() {
                 {selectedMode === 'top' && (
                   <ToggleCard
                     title="Topic Pins"
-                    description="Create the topic navigation bar by pinning active topic tags. Usually enabled on the TOP markets page and disabled inside individual topic pages."
+                    description="Create the persistent topic navigation bar. TOP Topic Pins appear on /markets and every secondary topic page."
                     checked={state.featuredTopicsEnabled}
                     onChange={(checked) => updateState({ featuredTopicsEnabled: checked })}
                   />
@@ -881,7 +881,7 @@ function MarketDiscoveryLayoutEditor() {
                 <div>
                   <h3 className="text-xl font-bold text-white">Topic Pins</h3>
                   <p className="mt-1 text-sm text-gray-400">
-                    Topic pins build the /markets topic nav bar. Each entry points to an active tag and filters /markets/topic/:slug.
+                    Topic pins build the persistent market topic nav bar. Each entry points to an active tag and appears on /markets and every /markets/topic/:slug page.
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">

--- a/frontend/src/pages/create/Create.jsx
+++ b/frontend/src/pages/create/Create.jsx
@@ -9,6 +9,8 @@ import EmojiPickerInput from '../../components/inputs/EmojiPicker';
 import SiteButton from '../../components/buttons/SiteButtons';
 import { USER_CREDIT_REFRESH_EVENT } from '../../components/utils/userFinanceTools/FetchUserCredit';
 import { apiRequest, authenticatedApiRequest } from '../../api/httpClient';
+import { listMarketTags } from '../../api/marketTagsApi';
+import MarketTagChips from '../../components/markets/MarketTagChips';
 
 function Create() {
   const [questionTitle, setQuestionTitle] = useState('');
@@ -21,6 +23,8 @@ function Create() {
   const [error, setError] = useState('');
   const [createdMarket, setCreatedMarket] = useState(null);
   const [marketCreationCost, setMarketCreationCost] = useState(null);
+  const [marketTags, setMarketTags] = useState([]);
+  const [selectedTagSlugs, setSelectedTagSlugs] = useState([]);
   const { username } = useAuth();
   const history = useHistory();
 
@@ -52,6 +56,42 @@ function Create() {
       ignore = true;
     };
   }, []);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const loadTags = async () => {
+      try {
+        const data = await listMarketTags();
+        if (!ignore) {
+          setMarketTags(data.tags || []);
+        }
+      } catch {
+        if (!ignore) {
+          setMarketTags([]);
+        }
+      }
+    };
+
+    loadTags();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const toggleTagSlug = (slug) => {
+    setSelectedTagSlugs((current) => {
+      if (current.includes(slug)) {
+        return current.filter((value) => value !== slug);
+      }
+      if (current.length >= 5) {
+        setError('You can select up to five market tags.');
+        return current;
+      }
+      setError('');
+      return [...current, slug];
+    });
+  };
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -97,6 +137,7 @@ function Create() {
         utcOffset: new Date().getTimezoneOffset(),
         yesLabel: trimmedYesLabel || 'YES',
         noLabel: trimmedNoLabel || 'NO',
+        tagSlugs: selectedTagSlugs,
       };
 
       const responseData = await authenticatedApiRequest('/v0/markets', {
@@ -172,6 +213,45 @@ function Create() {
             className='w-full h-32 resize-y bg-gray-700 border border-gray-600 text-white px-3 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500'
           />
         </div>
+
+        {marketTags.length > 0 && (
+          <div className='rounded-lg border border-gray-700 bg-gray-900/60 p-4'>
+            <div className='mb-3 flex flex-wrap items-center justify-between gap-2'>
+              <div>
+                <p className='text-sm font-medium text-gray-200'>Market Tags</p>
+                <p className='mt-1 text-xs text-gray-400'>
+                  Pick up to five categories so admins can review routing and users can find this market.
+                </p>
+              </div>
+              <span className='rounded-full bg-gray-800 px-3 py-1 text-xs text-gray-300'>
+                {selectedTagSlugs.length}/5 selected
+              </span>
+            </div>
+            <div className='flex flex-wrap gap-2'>
+              {marketTags.map((tag) => {
+                const selected = selectedTagSlugs.includes(tag.slug);
+                return (
+                  <button
+                    key={tag.slug}
+                    type='button'
+                    onClick={() => toggleTagSlug(tag.slug)}
+                    className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                      selected
+                        ? 'border-primary-pink bg-primary-pink/20 text-white'
+                        : 'border-gray-600 bg-gray-800 text-gray-300 hover:border-primary-pink/70 hover:text-white'
+                    }`}
+                  >
+                    {tag.displayName || tag.slug}
+                  </button>
+                );
+              })}
+            </div>
+            <MarketTagChips
+              tags={marketTags.filter((tag) => selectedTagSlugs.includes(tag.slug))}
+              className='mt-3'
+            />
+          </div>
+        )}
 
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
           <div>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -4,11 +4,71 @@ import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
 import GlobalSearchBar from '../../components/search/GlobalSearchBar';
 import SearchResultsTable from '../../components/tables/SearchResultsTable';
 import { TAB_TO_STATUS } from '../../utils/statusMap';
+import { apiRequest } from '../../api/httpClient';
+
+const defaultDiscoveryLayout = {
+    title: 'Markets',
+    description: '',
+    featuredTopicsEnabled: false,
+    featuredMarketsEnabled: false,
+    sectionsEnabled: false,
+    recommendationLimit: 20,
+};
+
+const hasCuratedBlocks = (layout) => (
+    layout?.featuredTopicsEnabled || layout?.featuredMarketsEnabled || layout?.sectionsEnabled
+);
+
+const DiscoveryPlaceholderPanel = ({ layout }) => {
+    if (!hasCuratedBlocks(layout)) return null;
+
+    return (
+        <div className="mb-6 grid gap-4 rounded-xl border border-gray-700 bg-gray-900/70 p-4 text-gray-200">
+            <div>
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-sky-300">
+                    CMS Market Discovery
+                </p>
+                <h2 className="mt-2 text-lg font-semibold text-white">Curated discovery blocks enabled</h2>
+                <p className="mt-1 text-sm text-gray-400">
+                    Pins and sections are persisted next; recommendations below are compacted to {layout.recommendationLimit} markets while curation is enabled.
+                </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+                {layout.featuredTopicsEnabled && <span className="rounded-full border border-sky-500/40 bg-sky-950/40 px-3 py-1 text-xs font-semibold text-sky-100">Featured topics</span>}
+                {layout.featuredMarketsEnabled && <span className="rounded-full border border-emerald-500/40 bg-emerald-950/40 px-3 py-1 text-xs font-semibold text-emerald-100">Featured markets</span>}
+                {layout.sectionsEnabled && <span className="rounded-full border border-violet-500/40 bg-violet-950/40 px-3 py-1 text-xs font-semibold text-violet-100">Sections</span>}
+            </div>
+        </div>
+    );
+};
 
 function Markets() {
     const [searchResults, setSearchResults] = useState(null);
     const [isSearching, setIsSearching] = useState(false);
     const [activeTab, setActiveTab] = useState('Active');
+    const [discoveryLayout, setDiscoveryLayout] = useState(defaultDiscoveryLayout);
+
+    useEffect(() => {
+        let ignore = false;
+
+        apiRequest('/v0/content/market-discovery/markets', {
+            fallbackMessage: 'Failed to load market discovery layout',
+        })
+            .then((layout) => {
+                if (!ignore) {
+                    setDiscoveryLayout({ ...defaultDiscoveryLayout, ...layout });
+                }
+            })
+            .catch(() => {
+                if (!ignore) {
+                    setDiscoveryLayout(defaultDiscoveryLayout);
+                }
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, []);
 
     const handleSearchResults = (results) => {
         setSearchResults(results);
@@ -25,28 +85,28 @@ function Markets() {
             label: 'Active', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="active" />,
+                <MarketsByStatusTable status="active" limit={discoveryLayout.recommendationLimit} />,
             onSelect: () => handleTabChange('Active')
         },
         { 
             label: 'Closed', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="closed" />,
+                <MarketsByStatusTable status="closed" limit={discoveryLayout.recommendationLimit} />,
             onSelect: () => handleTabChange('Closed')
         },
         { 
             label: 'Resolved', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="resolved" />,
+                <MarketsByStatusTable status="resolved" limit={discoveryLayout.recommendationLimit} />,
             onSelect: () => handleTabChange('Resolved')
         },
         { 
             label: 'All', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="all" />,
+                <MarketsByStatusTable status="all" limit={discoveryLayout.recommendationLimit} />,
             onSelect: () => handleTabChange('All')
         },
     ];
@@ -55,7 +115,10 @@ function Markets() {
         <div className='App'>
             <div className='Center-content'>
                 <div className='Center-content-header'>
-                    <h1 className='text-2xl font-semibold text-gray-300 mb-6'>Markets</h1>
+                    <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
+                    {discoveryLayout.description && (
+                        <p className="mb-6 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
+                    )}
                 </div>
                 <div className='Center-content-table'>
                     {/* Global Search Bar - Always visible at top */}
@@ -65,6 +128,7 @@ function Markets() {
                         isSearching={isSearching}
                         setIsSearching={setIsSearching}
                     />
+                    {!isSearching && <DiscoveryPlaceholderPanel layout={discoveryLayout} />}
                     
                     {/* Tabs with Content */}
                     <SiteTabs 

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -4,8 +4,10 @@ import SiteTabs from '../../components/tabs/SiteTabs';
 import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
 import GlobalSearchBar from '../../components/search/GlobalSearchBar';
 import SearchResultsTable from '../../components/tables/SearchResultsTable';
+import { marketTagChipClassFor } from '../../components/markets/MarketTagChips';
 import { TAB_TO_STATUS } from '../../utils/statusMap';
 import { apiRequest } from '../../api/httpClient';
+import { listMarketTags } from '../../api/marketTagsApi';
 
 const defaultDiscoveryLayout = {
     title: 'Markets',
@@ -48,15 +50,14 @@ const normalizeDiscoveryLayout = (layout, fallback = {}) => ({
     pins: sortBySortOrder(layout?.pins || []),
 });
 
-const DiscoveryBadge = ({ children, tone = 'sky' }) => {
+const DiscoveryBadge = ({ children, tag }) => {
     const tones = {
         sky: 'border-sky-500/40 bg-sky-950/40 text-sky-100',
-        emerald: 'border-emerald-500/40 bg-emerald-950/40 text-emerald-100',
-        amber: 'border-amber-500/40 bg-amber-950/40 text-amber-100',
     };
+    const className = tag ? marketTagChipClassFor(tag) : tones.sky;
 
     return (
-        <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${tones[tone] || tones.sky}`}>
+        <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${className}`}>
             {children}
         </span>
     );
@@ -76,7 +77,8 @@ const TopicNav = ({ topicPins = [] }) => {
                     <Link
                         key={`topic-${pin.id || pin.targetPageSlug || pin.sortOrder}`}
                         to={pin.targetPageSlug ? `/markets/topic/${pin.targetPageSlug}` : '#'}
-                        className="rounded-full border border-gray-700 bg-gray-900/80 px-4 py-2 text-sm font-semibold text-gray-200 transition hover:border-sky-400/70 hover:bg-sky-950/40 hover:text-white"
+                        className={`rounded-full border px-4 py-2 text-sm font-semibold transition hover:brightness-125 ${marketTagChipClassFor(pin.tag)}`}
+                        title={pin.tag?.description || pin.label || pin.targetPageSlug}
                     >
                         {pin.label || slugTitle(pin.targetPageSlug) || 'Topic'}
                     </Link>
@@ -317,6 +319,32 @@ function Markets() {
     const [activeTab, setActiveTab] = useState('Active');
     const [discoveryLayout, setDiscoveryLayout] = useState(defaultDiscoveryLayout);
     const [persistentTopicPins, setPersistentTopicPins] = useState([]);
+    const [marketTagsBySlug, setMarketTagsBySlug] = useState({});
+
+    useEffect(() => {
+        let ignore = false;
+
+        listMarketTags()
+            .then((result) => {
+                if (ignore) return;
+                const bySlug = {};
+                (result.tags || []).forEach((tag) => {
+                    if (tag.slug) {
+                        bySlug[tag.slug] = tag;
+                    }
+                });
+                setMarketTagsBySlug(bySlug);
+            })
+            .catch(() => {
+                if (!ignore) {
+                    setMarketTagsBySlug({});
+                }
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, []);
 
     useEffect(() => {
         let ignore = false;
@@ -354,7 +382,9 @@ function Markets() {
                         ? normalizeDiscoveryLayout(topLayout || {}, {})
                         : normalizedLayout;
                     const topTopicPins = topNavLayout.featuredTopicsEnabled
-                        ? sortBySortOrder(topNavLayout.pins || []).filter((pin) => pin.pinType === 'discovery_page')
+                        ? sortBySortOrder(topNavLayout.pins || [])
+                            .filter((pin) => pin.pinType === 'discovery_page')
+                            .map((pin) => ({ ...pin, tag: marketTagsBySlug[pin.targetPageSlug] }))
                         : [];
 
                     setDiscoveryLayout(normalizedLayout);
@@ -373,7 +403,7 @@ function Markets() {
         return () => {
             ignore = true;
         };
-    }, [isTopicPage, topicSlug]);
+    }, [isTopicPage, topicSlug, marketTagsBySlug]);
 
     const tagScope = isTopicPage
         ? topicSlug
@@ -434,7 +464,7 @@ function Markets() {
                             <div className="space-y-2 md:text-right">
                                 {tagScope && (
                                     <div className="md:flex md:justify-end">
-                                        <DiscoveryBadge>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                                        <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
                                     </div>
                                 )}
                             </div>
@@ -447,7 +477,7 @@ function Markets() {
                             )}
                             {tagScope && (
                                 <div className="mb-6">
-                                    <DiscoveryBadge>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                                    <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
                                 </div>
                             )}
                         </>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -14,16 +14,14 @@ const defaultDiscoveryLayout = {
     description: '',
     featuredTopicsEnabled: false,
     featuredMarketsEnabled: false,
-    sectionsEnabled: false,
     recommendationLimit: 20,
     primaryTagSlug: '',
     searchScope: 'all',
-    sections: [],
     pins: [],
 };
 
 const hasCuratedBlocks = (layout) => (
-    layout?.featuredTopicsEnabled || layout?.featuredMarketsEnabled || layout?.sectionsEnabled
+    layout?.featuredTopicsEnabled || layout?.featuredMarketsEnabled
 );
 
 const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortOrder || 0) - Number(b.sortOrder || 0));
@@ -46,7 +44,6 @@ const normalizeDiscoveryLayout = (layout, fallback = {}) => ({
     ...defaultDiscoveryLayout,
     ...fallback,
     ...layout,
-    sections: sortBySortOrder(layout?.sections || []),
     pins: sortBySortOrder(layout?.pins || []),
 });
 
@@ -275,7 +272,6 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
 
 const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins = true }) => {
     const pins = sortBySortOrder(layout.pins || []);
-    const sections = sortBySortOrder(layout.sections || []).filter((section) => section.isActive !== false);
     const topicPins = persistentTopicPins.length > 0
         ? persistentTopicPins
         : (useLayoutTopicPins ? pins.filter((pin) => pin.pinType === 'discovery_page') : []);
@@ -289,23 +285,6 @@ const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins =
             {hasTopicNav && <TopicNav topicPins={topicPins} />}
 
             {layout.featuredMarketsEnabled && <FeaturedMarketPins marketPins={marketPins} />}
-
-            {layout.sectionsEnabled && sections.length > 0 && (
-                <section>
-                    <div className="flex flex-wrap gap-2" aria-label="Market discovery sections">
-                        {sections.map((section) => (
-                            <Link
-                                key={`section-${section.id || section.slug || section.sortOrder}`}
-                                to={section.tagFilterSlug ? `/markets/topic/${section.tagFilterSlug}` : '#'}
-                                className="rounded-full border border-amber-500/30 bg-amber-950/20 px-3 py-1.5 text-xs font-semibold text-amber-100 transition hover:border-amber-300/60 hover:bg-amber-900/30"
-                                title={section.description || section.title}
-                            >
-                                {section.title}
-                            </Link>
-                        ))}
-                    </div>
-                </section>
-            )}
         </div>
     );
 };
@@ -356,7 +335,6 @@ function Markets() {
                 primaryTagSlug: topicSlug,
                 searchScope: 'tag',
                 featuredMarketsEnabled: true,
-                sectionsEnabled: true,
                 recommendationLimit: 5,
             }
             : {};

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -73,6 +73,26 @@ const DiscoveryCard = ({ eyebrow, title, description, children, to, tone = 'sky'
     return content;
 };
 
+const TopicNav = ({ topicPins = [] }) => {
+    if (!topicPins.length) return null;
+
+    return (
+        <nav className="mb-5 overflow-x-auto border-b border-gray-800 pb-3" aria-label="Market topics">
+            <div className="flex min-w-max items-center gap-2">
+                {topicPins.map((pin) => (
+                    <Link
+                        key={`topic-${pin.id || pin.targetPageSlug || pin.sortOrder}`}
+                        to={pin.targetPageSlug ? `/markets/topic/${pin.targetPageSlug}` : '#'}
+                        className="rounded-full border border-gray-700 bg-gray-900/80 px-4 py-2 text-sm font-semibold text-gray-200 transition hover:border-sky-400/70 hover:bg-sky-950/40 hover:text-white"
+                    >
+                        {pin.label || slugTitle(pin.targetPageSlug) || 'Topic'}
+                    </Link>
+                ))}
+            </div>
+        </nav>
+    );
+};
+
 const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
     if (!hasCuratedBlocks(layout)) return null;
 
@@ -82,45 +102,13 @@ const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
     const marketPins = pins.filter((pin) => pin.pinType === 'market');
 
     return (
-        <div className="mb-6 space-y-5 rounded-xl border border-gray-700 bg-gray-900/70 p-4 text-gray-200">
-            <div>
-                <p className="font-mono text-xs uppercase tracking-[0.18em] text-sky-300">
-                    CMS Market Discovery
-                </p>
-                <h2 className="mt-2 text-lg font-semibold text-white">Curated discovery</h2>
-                <p className="mt-1 text-sm text-gray-400">
-                    Recommendations below are compacted to {layout.recommendationLimit} markets when curated blocks are enabled.
-                </p>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-                {layout.featuredTopicsEnabled && !isTopicPage && <DiscoveryBadge>Featured topics</DiscoveryBadge>}
-                {layout.featuredMarketsEnabled && <DiscoveryBadge tone="emerald">Featured markets</DiscoveryBadge>}
-                {layout.sectionsEnabled && <DiscoveryBadge tone="amber">Sections</DiscoveryBadge>}
-            </div>
-
-            {!isTopicPage && layout.featuredTopicsEnabled && topicPins.length > 0 && (
-                <section>
-                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-300">Featured Topics</h3>
-                    <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                        {topicPins.map((pin) => (
-                            <DiscoveryCard
-                                key={`topic-${pin.id || pin.targetPageSlug || pin.sortOrder}`}
-                                eyebrow="Topic"
-                                title={pin.label || slugTitle(pin.targetPageSlug) || 'Topic'}
-                                description={pin.targetPageSlug ? `Topic slug: ${pin.targetPageSlug}` : 'CMS-managed topic page'}
-                                to={pin.targetPageSlug ? `/markets/topic/${pin.targetPageSlug}` : undefined}
-                                tone="sky"
-                            />
-                        ))}
-                    </div>
-                </section>
-            )}
+        <div className="mb-6 space-y-5 text-gray-200">
+            {!isTopicPage && layout.featuredTopicsEnabled && <TopicNav topicPins={topicPins} />}
 
             {layout.featuredMarketsEnabled && marketPins.length > 0 && (
                 <section>
-                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-300">Featured Markets</h3>
-                    <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                    <h2 className="mb-3 text-xl font-bold text-white">Featured markets</h2>
+                    <div className="grid gap-4 lg:grid-cols-2">
                         {marketPins.map((pin) => (
                             <DiscoveryCard
                                 key={`market-${pin.id || pin.marketId || pin.sortOrder}`}
@@ -137,23 +125,16 @@ const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
 
             {layout.sectionsEnabled && sections.length > 0 && (
                 <section>
-                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-300">Sections</h3>
-                    <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                    <div className="flex flex-wrap gap-2" aria-label="Market discovery sections">
                         {sections.map((section) => (
-                            <DiscoveryCard
+                            <Link
                                 key={`section-${section.id || section.slug || section.sortOrder}`}
-                                eyebrow="Section"
-                                title={section.title}
-                                description={section.description || 'Curated CMS section'}
-                                to={section.tagFilterSlug ? `/markets/topic/${section.tagFilterSlug}` : undefined}
-                                tone="sky"
+                                to={section.tagFilterSlug ? `/markets/topic/${section.tagFilterSlug}` : '#'}
+                                className="rounded-full border border-amber-500/30 bg-amber-950/20 px-3 py-1.5 text-xs font-semibold text-amber-100 transition hover:border-amber-300/60 hover:bg-amber-900/30"
+                                title={section.description || section.title}
                             >
-                                {section.tagFilterSlug && (
-                                    <div className="mt-3">
-                                        <DiscoveryBadge>{section.tagFilterSlug}</DiscoveryBadge>
-                                    </div>
-                                )}
-                            </DiscoveryCard>
+                                {section.title}
+                            </Link>
                         ))}
                     </div>
                 </section>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import SiteTabs from '../../components/tabs/SiteTabs';
 import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
 import GlobalSearchBar from '../../components/search/GlobalSearchBar';
@@ -13,31 +14,134 @@ const defaultDiscoveryLayout = {
     featuredMarketsEnabled: false,
     sectionsEnabled: false,
     recommendationLimit: 20,
+    sections: [],
+    pins: [],
 };
 
 const hasCuratedBlocks = (layout) => (
     layout?.featuredTopicsEnabled || layout?.featuredMarketsEnabled || layout?.sectionsEnabled
 );
 
-const DiscoveryPlaceholderPanel = ({ layout }) => {
-    if (!hasCuratedBlocks(layout)) return null;
+const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortOrder || 0) - Number(b.sortOrder || 0));
+
+const DiscoveryBadge = ({ children, tone = 'sky' }) => {
+    const tones = {
+        sky: 'border-sky-500/40 bg-sky-950/40 text-sky-100',
+        emerald: 'border-emerald-500/40 bg-emerald-950/40 text-emerald-100',
+        amber: 'border-amber-500/40 bg-amber-950/40 text-amber-100',
+    };
 
     return (
-        <div className="mb-6 grid gap-4 rounded-xl border border-gray-700 bg-gray-900/70 p-4 text-gray-200">
+        <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${tones[tone] || tones.sky}`}>
+            {children}
+        </span>
+    );
+};
+
+const DiscoveryCard = ({ eyebrow, title, description, children, to, tone = 'sky' }) => {
+    const toneClass = tone === 'emerald'
+        ? 'border-emerald-500/30 hover:border-emerald-400/60'
+        : 'border-sky-500/30 hover:border-sky-400/60';
+    const content = (
+        <div className={`h-full rounded-xl border bg-gray-950/70 p-4 transition ${toneClass}`}>
+            {eyebrow && <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-gray-400">{eyebrow}</p>}
+            <h3 className="mt-2 text-lg font-semibold text-white">{title}</h3>
+            {description && <p className="mt-2 text-sm text-gray-400">{description}</p>}
+            {children}
+        </div>
+    );
+
+    if (to) {
+        return <Link to={to} className="block h-full no-underline">{content}</Link>;
+    }
+    return content;
+};
+
+const DiscoveryPanel = ({ layout }) => {
+    if (!hasCuratedBlocks(layout)) return null;
+
+    const pins = sortBySortOrder(layout.pins || []);
+    const sections = sortBySortOrder(layout.sections || []).filter((section) => section.isActive !== false);
+    const topicPins = pins.filter((pin) => pin.pinType === 'discovery_page');
+    const marketPins = pins.filter((pin) => pin.pinType === 'market');
+
+    return (
+        <div className="mb-6 space-y-5 rounded-xl border border-gray-700 bg-gray-900/70 p-4 text-gray-200">
             <div>
                 <p className="font-mono text-xs uppercase tracking-[0.18em] text-sky-300">
                     CMS Market Discovery
                 </p>
-                <h2 className="mt-2 text-lg font-semibold text-white">Curated discovery blocks enabled</h2>
+                <h2 className="mt-2 text-lg font-semibold text-white">Curated discovery</h2>
                 <p className="mt-1 text-sm text-gray-400">
-                    Pins and sections are persisted next; recommendations below are compacted to {layout.recommendationLimit} markets while curation is enabled.
+                    Recommendations below are compacted to {layout.recommendationLimit} markets when curated blocks are enabled.
                 </p>
             </div>
+
             <div className="flex flex-wrap gap-2">
-                {layout.featuredTopicsEnabled && <span className="rounded-full border border-sky-500/40 bg-sky-950/40 px-3 py-1 text-xs font-semibold text-sky-100">Featured topics</span>}
-                {layout.featuredMarketsEnabled && <span className="rounded-full border border-emerald-500/40 bg-emerald-950/40 px-3 py-1 text-xs font-semibold text-emerald-100">Featured markets</span>}
-                {layout.sectionsEnabled && <span className="rounded-full border border-violet-500/40 bg-violet-950/40 px-3 py-1 text-xs font-semibold text-violet-100">Sections</span>}
+                {layout.featuredTopicsEnabled && <DiscoveryBadge>Featured topics</DiscoveryBadge>}
+                {layout.featuredMarketsEnabled && <DiscoveryBadge tone="emerald">Featured markets</DiscoveryBadge>}
+                {layout.sectionsEnabled && <DiscoveryBadge tone="amber">Sections</DiscoveryBadge>}
             </div>
+
+            {layout.featuredTopicsEnabled && topicPins.length > 0 && (
+                <section>
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-300">Featured Topics</h3>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        {topicPins.map((pin) => (
+                            <DiscoveryCard
+                                key={`topic-${pin.id || pin.targetPageSlug || pin.sortOrder}`}
+                                eyebrow="Topic"
+                                title={pin.label || pin.targetPageSlug || 'Topic'}
+                                description={pin.targetPageSlug ? `Topic slug: ${pin.targetPageSlug}` : 'CMS-managed topic page'}
+                                tone="sky"
+                            >
+                                <p className="mt-3 text-xs text-sky-200">Secondary route support is planned next.</p>
+                            </DiscoveryCard>
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {layout.featuredMarketsEnabled && marketPins.length > 0 && (
+                <section>
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-300">Featured Markets</h3>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        {marketPins.map((pin) => (
+                            <DiscoveryCard
+                                key={`market-${pin.id || pin.marketId || pin.sortOrder}`}
+                                eyebrow="Pinned Market"
+                                title={pin.label || `Market #${pin.marketId}`}
+                                description={pin.marketId ? `Market ID: ${pin.marketId}` : 'Set a market ID in CMS.'}
+                                to={pin.marketId ? `/markets/${pin.marketId}` : undefined}
+                                tone="emerald"
+                            />
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {layout.sectionsEnabled && sections.length > 0 && (
+                <section>
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-300">Sections</h3>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        {sections.map((section) => (
+                            <DiscoveryCard
+                                key={`section-${section.id || section.slug || section.sortOrder}`}
+                                eyebrow="Section"
+                                title={section.title}
+                                description={section.description || 'Curated CMS section'}
+                                tone="sky"
+                            >
+                                {section.tagFilterSlug && (
+                                    <div className="mt-3">
+                                        <DiscoveryBadge>{section.tagFilterSlug}</DiscoveryBadge>
+                                    </div>
+                                )}
+                            </DiscoveryCard>
+                        ))}
+                    </div>
+                </section>
+            )}
         </div>
     );
 };
@@ -56,7 +160,12 @@ function Markets() {
         })
             .then((layout) => {
                 if (!ignore) {
-                    setDiscoveryLayout({ ...defaultDiscoveryLayout, ...layout });
+                    setDiscoveryLayout({
+                        ...defaultDiscoveryLayout,
+                        ...layout,
+                        sections: sortBySortOrder(layout.sections || []),
+                        pins: sortBySortOrder(layout.pins || []),
+                    });
                 }
             })
             .catch(() => {
@@ -76,8 +185,7 @@ function Markets() {
 
     const handleTabChange = (tabLabel) => {
         setActiveTab(tabLabel);
-        // Don't clear search when switching tabs - let GlobalSearchBar re-execute with new status
-        // The search will automatically re-execute due to currentStatus change in GlobalSearchBar
+        // Don't clear search when switching tabs; GlobalSearchBar re-executes with currentStatus.
     };
 
     const tabsData = [
@@ -121,16 +229,14 @@ function Markets() {
                     )}
                 </div>
                 <div className='Center-content-table'>
-                    {/* Global Search Bar - Always visible at top */}
                     <GlobalSearchBar 
                         onSearchResults={handleSearchResults}
                         currentStatus={TAB_TO_STATUS[activeTab]}
                         isSearching={isSearching}
                         setIsSearching={setIsSearching}
                     />
-                    {!isSearching && <DiscoveryPlaceholderPanel layout={discoveryLayout} />}
+                    {!isSearching && <DiscoveryPanel layout={discoveryLayout} />}
                     
-                    {/* Tabs with Content */}
                     <SiteTabs 
                         tabs={tabsData} 
                         onTabChange={handleTabChange}

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -408,6 +408,7 @@ function Markets() {
     const tagScope = isTopicPage
         ? topicSlug
         : (discoveryLayout.searchScope === 'tag' ? discoveryLayout.primaryTagSlug : '');
+    const tagScopeLabel = marketTagsBySlug[tagScope]?.displayName || slugTitle(tagScope) || tagScope;
 
     const handleSearchResults = (results) => {
         setSearchResults(results);
@@ -464,7 +465,7 @@ function Markets() {
                             <div className="space-y-2 md:text-right">
                                 {tagScope && (
                                     <div className="md:flex md:justify-end">
-                                        <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                                        <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{tagScopeLabel}</DiscoveryBadge>
                                     </div>
                                 )}
                             </div>
@@ -477,7 +478,7 @@ function Markets() {
                             )}
                             {tagScope && (
                                 <div className="mb-6">
-                                    <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                                    <DiscoveryBadge tag={marketTagsBySlug[tagScope]}>{tagScopeLabel}</DiscoveryBadge>
                                 </div>
                             )}
                         </>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -4,7 +4,6 @@ import SiteTabs from '../../components/tabs/SiteTabs';
 import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
 import GlobalSearchBar from '../../components/search/GlobalSearchBar';
 import SearchResultsTable from '../../components/tables/SearchResultsTable';
-import MarketChart from '../../components/charts/MarketChart';
 import { TAB_TO_STATUS } from '../../utils/statusMap';
 import { apiRequest } from '../../api/httpClient';
 
@@ -102,6 +101,74 @@ const currentProbabilityFromDetails = (details) => {
     return toNumber(details?.lastProbability ?? details?.LastProbability ?? details?.market?.initialProbability);
 };
 
+const chartPointsFromDetails = (details) => {
+    const changes = normalizeProbabilityChanges(details?.probabilityChanges ?? details?.ProbabilityChanges);
+    const currentProbability = currentProbabilityFromDetails(details);
+    const points = changes.length > 0
+        ? changes.map((change) => toNumber(change.probability, currentProbability))
+        : [currentProbability];
+
+    if (points.length === 1) {
+        return [points[0], points[0]];
+    }
+
+    return points;
+};
+
+const pointsToPolyline = (points, width, height, inset) => {
+    const usableWidth = width - inset * 2;
+    const usableHeight = height - inset * 2;
+    const maxIndex = Math.max(points.length - 1, 1);
+
+    return points
+        .map((probability, index) => {
+            const x = inset + (index / maxIndex) * usableWidth;
+            const y = inset + (1 - Math.max(0, Math.min(1, probability))) * usableHeight;
+            return `${x.toFixed(2)},${y.toFixed(2)}`;
+        })
+        .join(' ');
+};
+
+const PinnedMarketSparkline = ({ details }) => {
+    const width = 960;
+    const height = 260;
+    const inset = 18;
+    const points = chartPointsFromDetails(details);
+    const linePoints = pointsToPolyline(points, width, height, inset);
+    const linePointPairs = linePoints.split(' ');
+    const lastPoint = linePointPairs[linePointPairs.length - 1]?.split(',') || [];
+    const firstX = inset;
+    const lastX = width - inset;
+    const floorY = height - inset;
+    const areaPoints = `${firstX},${floorY} ${linePoints} ${lastX},${floorY}`;
+    const currentProbability = currentProbabilityFromDetails(details);
+
+    return (
+        <svg
+            viewBox={`0 0 ${width} ${height}`}
+            className="h-full w-full"
+            preserveAspectRatio="none"
+            role="img"
+            aria-label={`Pinned market probability ${(currentProbability * 100).toFixed(0)} percent`}
+        >
+            <defs>
+                <linearGradient id="pinned-market-area" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#22d3ee" stopOpacity="0.58" />
+                    <stop offset="100%" stopColor="#0e7490" stopOpacity="0.16" />
+                </linearGradient>
+            </defs>
+            <rect width={width} height={height} rx="18" fill="#101827" />
+            <line x1="0" x2={width} y1={height / 2} y2={height / 2} stroke="#334155" strokeWidth="2" strokeDasharray="10 12" opacity="0.45" />
+            <polygon points={areaPoints} fill="url(#pinned-market-area)" />
+            <polyline points={linePoints} fill="none" stroke="#22d3ee" strokeWidth="8" strokeLinecap="round" strokeLinejoin="round" />
+            <circle cx={lastX} cy={lastPoint[1] || height / 2} r="10" fill="#22d3ee" />
+            <text x={width - 28} y="42" textAnchor="end" fill="#e2e8f0" fontSize="28" fontWeight="700">
+                {(currentProbability * 100).toFixed(0)}%
+            </text>
+        </svg>
+    );
+};
+
 const FeaturedMarketPins = ({ marketPins = [] }) => {
     const [pinnedMarkets, setPinnedMarkets] = useState([]);
     const pinKey = marketPins
@@ -145,8 +212,6 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
             {pinnedMarkets.map(({ pin, details }) => {
                 const market = details.market || {};
                 const marketId = market.id || pin.marketId;
-                const probabilityChanges = normalizeProbabilityChanges(details.probabilityChanges);
-                const currentProbability = currentProbabilityFromDetails(details);
                 return (
                     <Link
                         key={`market-${pin.id || marketId || pin.sortOrder}`}
@@ -156,19 +221,8 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
                         <h3 className="mb-2 line-clamp-2 min-h-[2.5rem] text-sm font-semibold leading-5 text-white">
                             {market.questionTitle || pin.label || `Market #${marketId}`}
                         </h3>
-                        <div className="h-36 overflow-hidden rounded-lg border border-gray-800 bg-gray-900/60 sm:h-44">
-                            <MarketChart
-                                data={probabilityChanges}
-                                currentProbability={currentProbability}
-                                title=""
-                                className="h-full w-full"
-                                closeDateTime={market.resolutionDateTime}
-                                yesLabel={market.yesLabel || 'YES'}
-                                noLabel={market.noLabel || 'NO'}
-                                showHeader={false}
-                                compact
-                                height={176}
-                            />
+                        <div className="h-36 overflow-hidden rounded-lg border border-gray-800 bg-gray-900/60 sm:h-52">
+                            <PinnedMarketSparkline details={details} />
                         </div>
                     </Link>
                 );

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -101,46 +101,82 @@ const currentProbabilityFromDetails = (details) => {
     return toNumber(details?.lastProbability ?? details?.LastProbability ?? details?.market?.initialProbability);
 };
 
-const chartPointsFromDetails = (details) => {
+const chartSamplesFromDetails = (details) => {
     const changes = normalizeProbabilityChanges(details?.probabilityChanges ?? details?.ProbabilityChanges);
     const currentProbability = currentProbabilityFromDetails(details);
-    const points = changes.length > 0
-        ? changes.map((change) => toNumber(change.probability, currentProbability))
-        : [currentProbability];
+    const market = details?.market || {};
+    const fallbackTimestamp = market.createdAt || market.CreatedAt || new Date().toISOString();
+    const samples = changes.length > 0
+        ? changes.map((change) => ({
+            probability: toNumber(change.probability, currentProbability),
+            timestamp: new Date(change.timestamp).getTime(),
+        }))
+        : [{
+            probability: currentProbability,
+            timestamp: new Date(fallbackTimestamp).getTime(),
+        }];
 
-    if (points.length === 1) {
-        return [points[0], points[0]];
+    const validSamples = samples
+        .filter((sample) => Number.isFinite(sample.timestamp))
+        .sort((left, right) => left.timestamp - right.timestamp);
+
+    if (validSamples.length === 0) {
+        return [{
+            probability: currentProbability,
+            timestamp: Date.now(),
+        }];
     }
 
-    return points;
+    return validSamples;
 };
 
-const pointsToPolyline = (points, width, height, inset) => {
+const sampleToPoint = (sample, minTime, maxTime, width, height, inset) => {
     const usableWidth = width - inset * 2;
     const usableHeight = height - inset * 2;
-    const maxIndex = Math.max(points.length - 1, 1);
+    const timeSpan = Math.max(maxTime - minTime, 1);
+    const probability = Math.max(0, Math.min(1, sample.probability));
 
-    return points
-        .map((probability, index) => {
-            const x = inset + (index / maxIndex) * usableWidth;
-            const y = inset + (1 - Math.max(0, Math.min(1, probability))) * usableHeight;
-            return `${x.toFixed(2)},${y.toFixed(2)}`;
-        })
-        .join(' ');
+    return {
+        x: inset + ((sample.timestamp - minTime) / timeSpan) * usableWidth,
+        y: inset + (1 - probability) * usableHeight,
+    };
+};
+
+const buildStepPath = (points) => {
+    if (points.length === 0) {
+        return '';
+    }
+    const [first, ...rest] = points;
+    const commands = [`M ${first.x.toFixed(2)} ${first.y.toFixed(2)}`];
+
+    rest.forEach((point) => {
+        commands.push(`H ${point.x.toFixed(2)}`);
+        commands.push(`V ${point.y.toFixed(2)}`);
+    });
+
+    if (points.length === 1) {
+        commands.push(`H ${first.x.toFixed(2)}`);
+    }
+
+    return commands.join(' ');
 };
 
 const PinnedMarketSparkline = ({ details }) => {
     const width = 960;
     const height = 260;
     const inset = 18;
-    const points = chartPointsFromDetails(details);
-    const linePoints = pointsToPolyline(points, width, height, inset);
-    const linePointPairs = linePoints.split(' ');
-    const lastPoint = linePointPairs[linePointPairs.length - 1]?.split(',') || [];
+    const samples = chartSamplesFromDetails(details);
+    const currentTime = Date.now();
+    const minTime = Math.min(...samples.map((sample) => sample.timestamp));
+    const maxSampleTime = Math.max(...samples.map((sample) => sample.timestamp));
+    const maxTime = Math.max(maxSampleTime, currentTime, minTime + 1);
+    const points = samples.map((sample) => sampleToPoint(sample, minTime, maxTime, width, height, inset));
     const firstX = inset;
     const lastX = width - inset;
     const floorY = height - inset;
-    const areaPoints = `${firstX},${floorY} ${linePoints} ${lastX},${floorY}`;
+    const lastPoint = points[points.length - 1] || { x: lastX, y: height / 2 };
+    const stepPath = `${buildStepPath(points)} H ${lastX.toFixed(2)}`;
+    const areaPath = `${stepPath} L ${lastX} ${floorY} L ${firstX} ${floorY} Z`;
     const currentProbability = currentProbabilityFromDetails(details);
 
     return (
@@ -159,9 +195,9 @@ const PinnedMarketSparkline = ({ details }) => {
             </defs>
             <rect width={width} height={height} rx="18" fill="#101827" />
             <line x1="0" x2={width} y1={height / 2} y2={height / 2} stroke="#334155" strokeWidth="2" strokeDasharray="10 12" opacity="0.45" />
-            <polygon points={areaPoints} fill="url(#pinned-market-area)" />
-            <polyline points={linePoints} fill="none" stroke="#22d3ee" strokeWidth="8" strokeLinecap="round" strokeLinejoin="round" />
-            <circle cx={lastX} cy={lastPoint[1] || height / 2} r="10" fill="#22d3ee" />
+            <path d={areaPath} fill="url(#pinned-market-area)" />
+            <path d={stepPath} fill="none" stroke="#22d3ee" strokeWidth="8" strokeLinecap="round" strokeLinejoin="round" />
+            <circle cx={lastX} cy={lastPoint.y || height / 2} r="10" fill="#22d3ee" />
             <text x={width - 28} y="58" textAnchor="end" fill="#e2e8f0" fontSize="24" fontWeight="700">
                 {(currentProbability * 100).toFixed(0)}%
             </text>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -162,7 +162,7 @@ const PinnedMarketSparkline = ({ details }) => {
             <polygon points={areaPoints} fill="url(#pinned-market-area)" />
             <polyline points={linePoints} fill="none" stroke="#22d3ee" strokeWidth="8" strokeLinecap="round" strokeLinejoin="round" />
             <circle cx={lastX} cy={lastPoint[1] || height / 2} r="10" fill="#22d3ee" />
-            <text x={width - 28} y="42" textAnchor="end" fill="#e2e8f0" fontSize="28" fontWeight="700">
+            <text x={width - 28} y="58" textAnchor="end" fill="#e2e8f0" fontSize="24" fontWeight="700">
                 {(currentProbability * 100).toFixed(0)}%
             </text>
         </svg>
@@ -208,7 +208,7 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
     if (!pinnedMarkets.length) return null;
 
     return (
-        <section className="grid gap-3" aria-label="Pinned markets">
+        <section className="grid gap-3 lg:grid-cols-2" aria-label="Pinned markets">
             {pinnedMarkets.map(({ pin, details }) => {
                 const market = details.market || {};
                 const marketId = market.id || pin.marketId;

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -430,11 +430,13 @@ function Markets() {
                 <div className='Center-content-header'>
                     {isTopicPage ? (
                         <div className="mb-6 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(260px,420px)] md:items-start">
-                            <h1 className='text-2xl font-semibold text-gray-300'>{discoveryLayout.title || 'Markets'}</h1>
-                            <div className="space-y-2 md:text-right">
+                            <div>
+                                <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
                                 {discoveryLayout.description && (
-                                    <p className="text-sm text-gray-400">{discoveryLayout.description}</p>
+                                    <p className="max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
                                 )}
+                            </div>
+                            <div className="space-y-2 md:text-right">
                                 {tagScope && (
                                     <div className="md:flex md:justify-end">
                                         <DiscoveryBadge>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -271,7 +271,7 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
     );
 };
 
-const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins = true, showBackToMarkets = false }) => {
+const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins = true }) => {
     const pins = sortBySortOrder(layout.pins || []);
     const sections = sortBySortOrder(layout.sections || []).filter((section) => section.isActive !== false);
     const topicPins = persistentTopicPins.length > 0
@@ -285,11 +285,6 @@ const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins =
     return (
         <div className="mb-6 space-y-5 text-gray-200">
             {hasTopicNav && <TopicNav topicPins={topicPins} />}
-            {showBackToMarkets && (
-                <Link to="/markets" className="-mt-3 inline-flex text-sm font-semibold text-sky-300 hover:text-sky-200">
-                    Back to all markets
-                </Link>
-            )}
 
             {layout.featuredMarketsEnabled && <FeaturedMarketPins marketPins={marketPins} />}
 
@@ -429,11 +424,11 @@ function Markets() {
             <div className='Center-content'>
                 <div className='Center-content-header'>
                     {isTopicPage ? (
-                        <div className="mb-6 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(260px,420px)] md:items-start">
+                        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(260px,420px)] md:items-start">
                             <div>
                                 <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
                                 {discoveryLayout.description && (
-                                    <p className="max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
+                                    <p className="mb-3 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
                                 )}
                             </div>
                             <div className="space-y-2 md:text-right">
@@ -471,7 +466,6 @@ function Markets() {
                             layout={discoveryLayout}
                             persistentTopicPins={persistentTopicPins}
                             useLayoutTopicPins={!isTopicPage}
-                            showBackToMarkets={isTopicPage}
                         />
                     )}
                     

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -267,17 +267,20 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
     );
 };
 
-const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
-    if (!hasCuratedBlocks(layout)) return null;
-
+const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins = true }) => {
     const pins = sortBySortOrder(layout.pins || []);
     const sections = sortBySortOrder(layout.sections || []).filter((section) => section.isActive !== false);
-    const topicPins = pins.filter((pin) => pin.pinType === 'discovery_page');
+    const topicPins = persistentTopicPins.length > 0
+        ? persistentTopicPins
+        : (useLayoutTopicPins ? pins.filter((pin) => pin.pinType === 'discovery_page') : []);
     const marketPins = pins.filter((pin) => pin.pinType === 'market');
+    const hasTopicNav = topicPins.length > 0;
+
+    if (!hasCuratedBlocks(layout) && !hasTopicNav) return null;
 
     return (
         <div className="mb-6 space-y-5 text-gray-200">
-            {!isTopicPage && layout.featuredTopicsEnabled && <TopicNav topicPins={topicPins} />}
+            {hasTopicNav && <TopicNav topicPins={topicPins} />}
 
             {layout.featuredMarketsEnabled && <FeaturedMarketPins marketPins={marketPins} />}
 
@@ -309,6 +312,7 @@ function Markets() {
     const [isSearching, setIsSearching] = useState(false);
     const [activeTab, setActiveTab] = useState('Active');
     const [discoveryLayout, setDiscoveryLayout] = useState(defaultDiscoveryLayout);
+    const [persistentTopicPins, setPersistentTopicPins] = useState([]);
 
     useEffect(() => {
         let ignore = false;
@@ -328,19 +332,39 @@ function Markets() {
         setSearchResults(null);
         setIsSearching(false);
 
-        apiRequest(`/v0/content/market-discovery/${discoverySlug}`, {
-            fallbackMessage: 'Failed to load market discovery layout',
-        })
-            .then((layout) => {
+        const loadDiscovery = async () => {
+            try {
+                const [layout, topLayout] = await Promise.all([
+                    apiRequest(`/v0/content/market-discovery/${discoverySlug}`, {
+                        fallbackMessage: 'Failed to load market discovery layout',
+                    }),
+                    isTopicPage
+                        ? apiRequest('/v0/content/market-discovery/markets', {
+                            fallbackMessage: 'Failed to load market topic navigation',
+                        })
+                        : Promise.resolve(null),
+                ]);
                 if (!ignore) {
-                    setDiscoveryLayout(normalizeDiscoveryLayout(layout, fallback));
+                    const normalizedLayout = normalizeDiscoveryLayout(layout, fallback);
+                    const topNavLayout = isTopicPage
+                        ? normalizeDiscoveryLayout(topLayout || {}, {})
+                        : normalizedLayout;
+                    const topTopicPins = topNavLayout.featuredTopicsEnabled
+                        ? sortBySortOrder(topNavLayout.pins || []).filter((pin) => pin.pinType === 'discovery_page')
+                        : [];
+
+                    setDiscoveryLayout(normalizedLayout);
+                    setPersistentTopicPins(topTopicPins);
                 }
-            })
-            .catch(() => {
+            } catch {
                 if (!ignore) {
                     setDiscoveryLayout(normalizeDiscoveryLayout({}, fallback));
+                    setPersistentTopicPins([]);
                 }
-            });
+            }
+        };
+
+        loadDiscovery();
 
         return () => {
             ignore = true;
@@ -418,7 +442,7 @@ function Markets() {
                         setIsSearching={setIsSearching}
                         tagSlug={tagScope}
                     />
-                    {!isSearching && <DiscoveryPanel layout={discoveryLayout} isTopicPage={isTopicPage} />}
+                    {!isSearching && <DiscoveryPanel layout={discoveryLayout} persistentTopicPins={persistentTopicPins} useLayoutTopicPins={!isTopicPage} />}
                     
                     <SiteTabs 
                         tabs={tabsData} 

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import SiteTabs from '../../components/tabs/SiteTabs';
 import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
 import GlobalSearchBar from '../../components/search/GlobalSearchBar';
@@ -14,6 +14,8 @@ const defaultDiscoveryLayout = {
     featuredMarketsEnabled: false,
     sectionsEnabled: false,
     recommendationLimit: 20,
+    primaryTagSlug: '',
+    searchScope: 'all',
     sections: [],
     pins: [],
 };
@@ -23,6 +25,20 @@ const hasCuratedBlocks = (layout) => (
 );
 
 const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortOrder || 0) - Number(b.sortOrder || 0));
+
+const slugTitle = (slug = '') => slug
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+const normalizeDiscoveryLayout = (layout, fallback = {}) => ({
+    ...defaultDiscoveryLayout,
+    ...fallback,
+    ...layout,
+    sections: sortBySortOrder(layout?.sections || []),
+    pins: sortBySortOrder(layout?.pins || []),
+});
 
 const DiscoveryBadge = ({ children, tone = 'sky' }) => {
     const tones = {
@@ -57,7 +73,7 @@ const DiscoveryCard = ({ eyebrow, title, description, children, to, tone = 'sky'
     return content;
 };
 
-const DiscoveryPanel = ({ layout }) => {
+const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
     if (!hasCuratedBlocks(layout)) return null;
 
     const pins = sortBySortOrder(layout.pins || []);
@@ -78,12 +94,12 @@ const DiscoveryPanel = ({ layout }) => {
             </div>
 
             <div className="flex flex-wrap gap-2">
-                {layout.featuredTopicsEnabled && <DiscoveryBadge>Featured topics</DiscoveryBadge>}
+                {layout.featuredTopicsEnabled && !isTopicPage && <DiscoveryBadge>Featured topics</DiscoveryBadge>}
                 {layout.featuredMarketsEnabled && <DiscoveryBadge tone="emerald">Featured markets</DiscoveryBadge>}
                 {layout.sectionsEnabled && <DiscoveryBadge tone="amber">Sections</DiscoveryBadge>}
             </div>
 
-            {layout.featuredTopicsEnabled && topicPins.length > 0 && (
+            {!isTopicPage && layout.featuredTopicsEnabled && topicPins.length > 0 && (
                 <section>
                     <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-300">Featured Topics</h3>
                     <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
@@ -91,12 +107,11 @@ const DiscoveryPanel = ({ layout }) => {
                             <DiscoveryCard
                                 key={`topic-${pin.id || pin.targetPageSlug || pin.sortOrder}`}
                                 eyebrow="Topic"
-                                title={pin.label || pin.targetPageSlug || 'Topic'}
+                                title={pin.label || slugTitle(pin.targetPageSlug) || 'Topic'}
                                 description={pin.targetPageSlug ? `Topic slug: ${pin.targetPageSlug}` : 'CMS-managed topic page'}
+                                to={pin.targetPageSlug ? `/markets/topic/${pin.targetPageSlug}` : undefined}
                                 tone="sky"
-                            >
-                                <p className="mt-3 text-xs text-sky-200">Secondary route support is planned next.</p>
-                            </DiscoveryCard>
+                            />
                         ))}
                     </div>
                 </section>
@@ -130,6 +145,7 @@ const DiscoveryPanel = ({ layout }) => {
                                 eyebrow="Section"
                                 title={section.title}
                                 description={section.description || 'Curated CMS section'}
+                                to={section.tagFilterSlug ? `/markets/topic/${section.tagFilterSlug}` : undefined}
                                 tone="sky"
                             >
                                 {section.tagFilterSlug && (
@@ -147,6 +163,9 @@ const DiscoveryPanel = ({ layout }) => {
 };
 
 function Markets() {
+    const { slug: topicSlugParam } = useParams();
+    const topicSlug = topicSlugParam || '';
+    const isTopicPage = !!topicSlug;
     const [searchResults, setSearchResults] = useState(null);
     const [isSearching, setIsSearching] = useState(false);
     const [activeTab, setActiveTab] = useState('Active');
@@ -154,30 +173,44 @@ function Markets() {
 
     useEffect(() => {
         let ignore = false;
+        const discoverySlug = isTopicPage ? topicSlug : 'markets';
+        const fallback = isTopicPage
+            ? {
+                title: slugTitle(topicSlug) || 'Topic Markets',
+                description: 'Browse and search markets in this topic.',
+                primaryTagSlug: topicSlug,
+                searchScope: 'tag',
+                featuredMarketsEnabled: true,
+                sectionsEnabled: true,
+                recommendationLimit: 5,
+            }
+            : {};
 
-        apiRequest('/v0/content/market-discovery/markets', {
+        setSearchResults(null);
+        setIsSearching(false);
+
+        apiRequest(`/v0/content/market-discovery/${discoverySlug}`, {
             fallbackMessage: 'Failed to load market discovery layout',
         })
             .then((layout) => {
                 if (!ignore) {
-                    setDiscoveryLayout({
-                        ...defaultDiscoveryLayout,
-                        ...layout,
-                        sections: sortBySortOrder(layout.sections || []),
-                        pins: sortBySortOrder(layout.pins || []),
-                    });
+                    setDiscoveryLayout(normalizeDiscoveryLayout(layout, fallback));
                 }
             })
             .catch(() => {
                 if (!ignore) {
-                    setDiscoveryLayout(defaultDiscoveryLayout);
+                    setDiscoveryLayout(normalizeDiscoveryLayout({}, fallback));
                 }
             });
 
         return () => {
             ignore = true;
         };
-    }, []);
+    }, [isTopicPage, topicSlug]);
+
+    const tagScope = discoveryLayout.searchScope === 'tag'
+        ? (discoveryLayout.primaryTagSlug || topicSlug)
+        : '';
 
     const handleSearchResults = (results) => {
         setSearchResults(results);
@@ -193,28 +226,28 @@ function Markets() {
             label: 'Active', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="active" limit={discoveryLayout.recommendationLimit} />,
+                <MarketsByStatusTable status="active" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('Active')
         },
         { 
             label: 'Closed', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="closed" limit={discoveryLayout.recommendationLimit} />,
+                <MarketsByStatusTable status="closed" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('Closed')
         },
         { 
             label: 'Resolved', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="resolved" limit={discoveryLayout.recommendationLimit} />,
+                <MarketsByStatusTable status="resolved" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('Resolved')
         },
         { 
             label: 'All', 
             content: isSearching ? 
                 <SearchResultsTable searchResults={searchResults} /> : 
-                <MarketsByStatusTable status="all" limit={discoveryLayout.recommendationLimit} />,
+                <MarketsByStatusTable status="all" limit={discoveryLayout.recommendationLimit} tagSlug={tagScope} />,
             onSelect: () => handleTabChange('All')
         },
     ];
@@ -223,9 +256,19 @@ function Markets() {
         <div className='App'>
             <div className='Center-content'>
                 <div className='Center-content-header'>
+                    {isTopicPage && (
+                        <Link to="/markets" className="mb-3 inline-flex text-sm font-semibold text-sky-300 hover:text-sky-200">
+                            Back to all markets
+                        </Link>
+                    )}
                     <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
                     {discoveryLayout.description && (
-                        <p className="mb-6 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
+                        <p className="mb-3 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
+                    )}
+                    {tagScope && (
+                        <div className="mb-6">
+                            <DiscoveryBadge>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                        </div>
                     )}
                 </div>
                 <div className='Center-content-table'>
@@ -234,8 +277,9 @@ function Markets() {
                         currentStatus={TAB_TO_STATUS[activeTab]}
                         isSearching={isSearching}
                         setIsSearching={setIsSearching}
+                        tagSlug={tagScope}
                     />
-                    {!isSearching && <DiscoveryPanel layout={discoveryLayout} />}
+                    {!isSearching && <DiscoveryPanel layout={discoveryLayout} isTopicPage={isTopicPage} />}
                     
                     <SiteTabs 
                         tabs={tabsData} 

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -1,9 +1,10 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import SiteTabs from '../../components/tabs/SiteTabs';
 import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
 import GlobalSearchBar from '../../components/search/GlobalSearchBar';
 import SearchResultsTable from '../../components/tables/SearchResultsTable';
+import MarketChart from '../../components/charts/MarketChart';
 import { TAB_TO_STATUS } from '../../utils/statusMap';
 import { apiRequest } from '../../api/httpClient';
 
@@ -25,6 +26,14 @@ const hasCuratedBlocks = (layout) => (
 );
 
 const sortBySortOrder = (items = []) => [...items].sort((a, b) => Number(a.sortOrder || 0) - Number(b.sortOrder || 0));
+
+const toNumber = (value, fallback = 0) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : fallback;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
 
 const slugTitle = (slug = '') => slug
     .split('-')
@@ -54,25 +63,6 @@ const DiscoveryBadge = ({ children, tone = 'sky' }) => {
     );
 };
 
-const DiscoveryCard = ({ eyebrow, title, description, children, to, tone = 'sky' }) => {
-    const toneClass = tone === 'emerald'
-        ? 'border-emerald-500/30 hover:border-emerald-400/60'
-        : 'border-sky-500/30 hover:border-sky-400/60';
-    const content = (
-        <div className={`h-full rounded-xl border bg-gray-950/70 p-4 transition ${toneClass}`}>
-            {eyebrow && <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-gray-400">{eyebrow}</p>}
-            <h3 className="mt-2 text-lg font-semibold text-white">{title}</h3>
-            {description && <p className="mt-2 text-sm text-gray-400">{description}</p>}
-            {children}
-        </div>
-    );
-
-    if (to) {
-        return <Link to={to} className="block h-full no-underline">{content}</Link>;
-    }
-    return content;
-};
-
 const TopicNav = ({ topicPins = [] }) => {
     if (!topicPins.length) return null;
 
@@ -93,62 +83,96 @@ const TopicNav = ({ topicPins = [] }) => {
     );
 };
 
-const FeaturedMarketSlider = ({ marketPins = [] }) => {
-    const sliderRef = useRef(null);
-    if (!marketPins.length) return null;
+const normalizeProbabilityChanges = (raw = []) => (
+    Array.isArray(raw)
+        ? raw
+            .map((change) => ({
+                probability: toNumber(change?.probability ?? change?.Probability),
+                timestamp: change?.timestamp ?? change?.Timestamp ?? change?.createdAt ?? change?.CreatedAt,
+            }))
+            .filter((change) => change.timestamp)
+        : []
+);
 
-    const scroll = (direction) => {
-        const slider = sliderRef.current;
-        if (!slider) return;
-        const amount = Math.max(320, Math.floor(slider.clientWidth * 0.86));
-        slider.scrollBy({ left: direction * amount, behavior: 'smooth' });
-    };
+const currentProbabilityFromDetails = (details) => {
+    const changes = normalizeProbabilityChanges(details?.probabilityChanges ?? details?.ProbabilityChanges);
+    if (changes.length > 0) {
+        return toNumber(changes[changes.length - 1].probability);
+    }
+    return toNumber(details?.lastProbability ?? details?.LastProbability ?? details?.market?.initialProbability);
+};
+
+const FeaturedMarketPins = ({ marketPins = [] }) => {
+    const [pinnedMarkets, setPinnedMarkets] = useState([]);
+    const pinKey = marketPins
+        .map((pin) => `${pin.id || ''}:${pin.marketId || ''}:${pin.sortOrder || ''}`)
+        .join('|');
+
+    useEffect(() => {
+        let ignore = false;
+        const pinsWithIds = marketPins.filter((pin) => Number(pin.marketId) > 0);
+
+        if (pinsWithIds.length === 0) {
+            setPinnedMarkets([]);
+            return () => {
+                ignore = true;
+            };
+        }
+
+        Promise.all(
+            pinsWithIds.map((pin) => (
+                apiRequest(`/v0/markets/${pin.marketId}`, {
+                    fallbackMessage: `Failed to load pinned market ${pin.marketId}`,
+                })
+                    .then((details) => ({ pin, details }))
+                    .catch(() => null)
+            )),
+        ).then((items) => {
+            if (!ignore) {
+                setPinnedMarkets(items.filter((item) => item?.details?.market));
+            }
+        });
+
+        return () => {
+            ignore = true;
+        };
+    }, [pinKey]);
+
+    if (!pinnedMarkets.length) return null;
 
     return (
-        <section>
-            <div className="mb-3 flex items-center justify-between gap-3">
-                <h2 className="text-xl font-bold text-white">Featured markets</h2>
-                {marketPins.length > 1 && (
-                    <div className="flex gap-2">
-                        <button
-                            type="button"
-                            onClick={() => scroll(-1)}
-                            className="rounded-full border border-gray-700 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-gray-200 transition hover:border-sky-400/70 hover:text-white"
-                            aria-label="Scroll featured markets left"
-                        >
-                            ‹
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => scroll(1)}
-                            className="rounded-full border border-gray-700 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-gray-200 transition hover:border-sky-400/70 hover:text-white"
-                            aria-label="Scroll featured markets right"
-                        >
-                            ›
-                        </button>
-                    </div>
-                )}
-            </div>
-            <div
-                ref={sliderRef}
-                className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-3"
-                aria-label="Featured market carousel"
-            >
-                {marketPins.map((pin) => (
-                    <div
-                        key={`market-${pin.id || pin.marketId || pin.sortOrder}`}
-                        className="min-w-[min(88vw,720px)] snap-start md:min-w-[560px] xl:min-w-[680px]"
+        <section className="flex flex-wrap gap-3" aria-label="Pinned markets">
+            {pinnedMarkets.map(({ pin, details }) => {
+                const market = details.market || {};
+                const marketId = market.id || pin.marketId;
+                const probabilityChanges = normalizeProbabilityChanges(details.probabilityChanges);
+                const currentProbability = currentProbabilityFromDetails(details);
+                return (
+                    <Link
+                        key={`market-${pin.id || marketId || pin.sortOrder}`}
+                        to={marketId ? `/markets/${marketId}` : '#'}
+                        className="block w-full max-w-sm rounded-xl border border-gray-700 bg-gray-950/80 p-3 no-underline shadow-lg transition hover:border-sky-400/60 hover:bg-gray-900 sm:w-[320px]"
                     >
-                        <DiscoveryCard
-                            eyebrow="Pinned Market"
-                            title={pin.label || `Market #${pin.marketId}`}
-                            description={pin.marketId ? `Market ID: ${pin.marketId}` : 'Set a market ID in CMS.'}
-                            to={pin.marketId ? `/markets/${pin.marketId}` : undefined}
-                            tone="emerald"
-                        />
-                    </div>
-                ))}
-            </div>
+                        <h3 className="mb-2 line-clamp-2 min-h-[2.5rem] text-sm font-semibold leading-5 text-white">
+                            {market.questionTitle || pin.label || `Market #${marketId}`}
+                        </h3>
+                        <div className="h-28 overflow-hidden rounded-lg border border-gray-800 bg-gray-900/60">
+                            <MarketChart
+                                data={probabilityChanges}
+                                currentProbability={currentProbability}
+                                title=""
+                                className="h-full w-full"
+                                closeDateTime={market.resolutionDateTime}
+                                yesLabel={market.yesLabel || 'YES'}
+                                noLabel={market.noLabel || 'NO'}
+                                showHeader={false}
+                                compact
+                                height={112}
+                            />
+                        </div>
+                    </Link>
+                );
+            })}
         </section>
     );
 };
@@ -165,7 +189,7 @@ const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
         <div className="mb-6 space-y-5 text-gray-200">
             {!isTopicPage && layout.featuredTopicsEnabled && <TopicNav topicPins={topicPins} />}
 
-            {layout.featuredMarketsEnabled && <FeaturedMarketSlider marketPins={marketPins} />}
+            {layout.featuredMarketsEnabled && <FeaturedMarketPins marketPins={marketPins} />}
 
             {layout.sectionsEnabled && sections.length > 0 && (
                 <section>

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -234,7 +234,7 @@ function Markets() {
     }, [isTopicPage, topicSlug]);
 
     const tagScope = isTopicPage
-        ? (discoveryLayout.primaryTagSlug || topicSlug)
+        ? topicSlug
         : (discoveryLayout.searchScope === 'tag' ? discoveryLayout.primaryTagSlug : '');
 
     const handleSearchResults = (results) => {

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import SiteTabs from '../../components/tabs/SiteTabs';
 import MarketsByStatusTable from '../../components/tables/MarketsByStatusTable';
@@ -93,6 +93,66 @@ const TopicNav = ({ topicPins = [] }) => {
     );
 };
 
+const FeaturedMarketSlider = ({ marketPins = [] }) => {
+    const sliderRef = useRef(null);
+    if (!marketPins.length) return null;
+
+    const scroll = (direction) => {
+        const slider = sliderRef.current;
+        if (!slider) return;
+        const amount = Math.max(320, Math.floor(slider.clientWidth * 0.86));
+        slider.scrollBy({ left: direction * amount, behavior: 'smooth' });
+    };
+
+    return (
+        <section>
+            <div className="mb-3 flex items-center justify-between gap-3">
+                <h2 className="text-xl font-bold text-white">Featured markets</h2>
+                {marketPins.length > 1 && (
+                    <div className="flex gap-2">
+                        <button
+                            type="button"
+                            onClick={() => scroll(-1)}
+                            className="rounded-full border border-gray-700 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-gray-200 transition hover:border-sky-400/70 hover:text-white"
+                            aria-label="Scroll featured markets left"
+                        >
+                            ‹
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => scroll(1)}
+                            className="rounded-full border border-gray-700 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-gray-200 transition hover:border-sky-400/70 hover:text-white"
+                            aria-label="Scroll featured markets right"
+                        >
+                            ›
+                        </button>
+                    </div>
+                )}
+            </div>
+            <div
+                ref={sliderRef}
+                className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-3"
+                aria-label="Featured market carousel"
+            >
+                {marketPins.map((pin) => (
+                    <div
+                        key={`market-${pin.id || pin.marketId || pin.sortOrder}`}
+                        className="min-w-[min(88vw,720px)] snap-start md:min-w-[560px] xl:min-w-[680px]"
+                    >
+                        <DiscoveryCard
+                            eyebrow="Pinned Market"
+                            title={pin.label || `Market #${pin.marketId}`}
+                            description={pin.marketId ? `Market ID: ${pin.marketId}` : 'Set a market ID in CMS.'}
+                            to={pin.marketId ? `/markets/${pin.marketId}` : undefined}
+                            tone="emerald"
+                        />
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+};
+
 const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
     if (!hasCuratedBlocks(layout)) return null;
 
@@ -105,23 +165,7 @@ const DiscoveryPanel = ({ layout, isTopicPage = false }) => {
         <div className="mb-6 space-y-5 text-gray-200">
             {!isTopicPage && layout.featuredTopicsEnabled && <TopicNav topicPins={topicPins} />}
 
-            {layout.featuredMarketsEnabled && marketPins.length > 0 && (
-                <section>
-                    <h2 className="mb-3 text-xl font-bold text-white">Featured markets</h2>
-                    <div className="grid gap-4 lg:grid-cols-2">
-                        {marketPins.map((pin) => (
-                            <DiscoveryCard
-                                key={`market-${pin.id || pin.marketId || pin.sortOrder}`}
-                                eyebrow="Pinned Market"
-                                title={pin.label || `Market #${pin.marketId}`}
-                                description={pin.marketId ? `Market ID: ${pin.marketId}` : 'Set a market ID in CMS.'}
-                                to={pin.marketId ? `/markets/${pin.marketId}` : undefined}
-                                tone="emerald"
-                            />
-                        ))}
-                    </div>
-                </section>
-            )}
+            {layout.featuredMarketsEnabled && <FeaturedMarketSlider marketPins={marketPins} />}
 
             {layout.sectionsEnabled && sections.length > 0 && (
                 <section>
@@ -189,9 +233,9 @@ function Markets() {
         };
     }, [isTopicPage, topicSlug]);
 
-    const tagScope = discoveryLayout.searchScope === 'tag'
+    const tagScope = isTopicPage
         ? (discoveryLayout.primaryTagSlug || topicSlug)
-        : '';
+        : (discoveryLayout.searchScope === 'tag' ? discoveryLayout.primaryTagSlug : '');
 
     const handleSearchResults = (results) => {
         setSearchResults(results);

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -63,11 +63,15 @@ const DiscoveryBadge = ({ children, tone = 'sky' }) => {
 };
 
 const TopicNav = ({ topicPins = [] }) => {
-    if (!topicPins.length) return null;
-
     return (
         <nav className="mb-5 overflow-x-auto border-b border-gray-800 pb-3" aria-label="Market topics">
             <div className="flex min-w-max items-center gap-2">
+                <Link
+                    to="/markets"
+                    className="rounded-full border border-sky-500/50 bg-sky-950/40 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:border-sky-300/70 hover:bg-sky-900/50 hover:text-white"
+                >
+                    Markets
+                </Link>
                 {topicPins.map((pin) => (
                     <Link
                         key={`topic-${pin.id || pin.targetPageSlug || pin.sortOrder}`}

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -267,7 +267,7 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
     );
 };
 
-const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins = true }) => {
+const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins = true, showBackToMarkets = false }) => {
     const pins = sortBySortOrder(layout.pins || []);
     const sections = sortBySortOrder(layout.sections || []).filter((section) => section.isActive !== false);
     const topicPins = persistentTopicPins.length > 0
@@ -281,6 +281,11 @@ const DiscoveryPanel = ({ layout, persistentTopicPins = [], useLayoutTopicPins =
     return (
         <div className="mb-6 space-y-5 text-gray-200">
             {hasTopicNav && <TopicNav topicPins={topicPins} />}
+            {showBackToMarkets && (
+                <Link to="/markets" className="-mt-3 inline-flex text-sm font-semibold text-sky-300 hover:text-sky-200">
+                    Back to all markets
+                </Link>
+            )}
 
             {layout.featuredMarketsEnabled && <FeaturedMarketPins marketPins={marketPins} />}
 
@@ -419,19 +424,32 @@ function Markets() {
         <div className='App'>
             <div className='Center-content'>
                 <div className='Center-content-header'>
-                    {isTopicPage && (
-                        <Link to="/markets" className="mb-3 inline-flex text-sm font-semibold text-sky-300 hover:text-sky-200">
-                            Back to all markets
-                        </Link>
-                    )}
-                    <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
-                    {discoveryLayout.description && (
-                        <p className="mb-3 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
-                    )}
-                    {tagScope && (
-                        <div className="mb-6">
-                            <DiscoveryBadge>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                    {isTopicPage ? (
+                        <div className="mb-6 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(260px,420px)] md:items-start">
+                            <h1 className='text-2xl font-semibold text-gray-300'>{discoveryLayout.title || 'Markets'}</h1>
+                            <div className="space-y-2 md:text-right">
+                                {discoveryLayout.description && (
+                                    <p className="text-sm text-gray-400">{discoveryLayout.description}</p>
+                                )}
+                                {tagScope && (
+                                    <div className="md:flex md:justify-end">
+                                        <DiscoveryBadge>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                                    </div>
+                                )}
+                            </div>
                         </div>
+                    ) : (
+                        <>
+                            <h1 className='text-2xl font-semibold text-gray-300 mb-2'>{discoveryLayout.title || 'Markets'}</h1>
+                            {discoveryLayout.description && (
+                                <p className="mb-3 max-w-3xl text-sm text-gray-400">{discoveryLayout.description}</p>
+                            )}
+                            {tagScope && (
+                                <div className="mb-6">
+                                    <DiscoveryBadge>{`Filtered by tag: ${tagScope}`}</DiscoveryBadge>
+                                </div>
+                            )}
+                        </>
                     )}
                 </div>
                 <div className='Center-content-table'>
@@ -442,7 +460,14 @@ function Markets() {
                         setIsSearching={setIsSearching}
                         tagSlug={tagScope}
                     />
-                    {!isSearching && <DiscoveryPanel layout={discoveryLayout} persistentTopicPins={persistentTopicPins} useLayoutTopicPins={!isTopicPage} />}
+                    {!isSearching && (
+                        <DiscoveryPanel
+                            layout={discoveryLayout}
+                            persistentTopicPins={persistentTopicPins}
+                            useLayoutTopicPins={!isTopicPage}
+                            showBackToMarkets={isTopicPage}
+                        />
+                    )}
                     
                     <SiteTabs 
                         tabs={tabsData} 

--- a/frontend/src/pages/markets/Markets.jsx
+++ b/frontend/src/pages/markets/Markets.jsx
@@ -141,7 +141,7 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
     if (!pinnedMarkets.length) return null;
 
     return (
-        <section className="flex flex-wrap gap-3" aria-label="Pinned markets">
+        <section className="grid gap-3" aria-label="Pinned markets">
             {pinnedMarkets.map(({ pin, details }) => {
                 const market = details.market || {};
                 const marketId = market.id || pin.marketId;
@@ -151,12 +151,12 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
                     <Link
                         key={`market-${pin.id || marketId || pin.sortOrder}`}
                         to={marketId ? `/markets/${marketId}` : '#'}
-                        className="block w-full max-w-sm rounded-xl border border-gray-700 bg-gray-950/80 p-3 no-underline shadow-lg transition hover:border-sky-400/60 hover:bg-gray-900 sm:w-[320px]"
+                        className="block w-full rounded-xl border border-gray-700 bg-gray-950/80 p-3 no-underline shadow-lg transition hover:border-sky-400/60 hover:bg-gray-900"
                     >
                         <h3 className="mb-2 line-clamp-2 min-h-[2.5rem] text-sm font-semibold leading-5 text-white">
                             {market.questionTitle || pin.label || `Market #${marketId}`}
                         </h3>
-                        <div className="h-28 overflow-hidden rounded-lg border border-gray-800 bg-gray-900/60">
+                        <div className="h-36 overflow-hidden rounded-lg border border-gray-800 bg-gray-900/60 sm:h-44">
                             <MarketChart
                                 data={probabilityChanges}
                                 currentProbability={currentProbability}
@@ -167,7 +167,7 @@ const FeaturedMarketPins = ({ marketPins = [] }) => {
                                 noLabel={market.noLabel || 'NO'}
                                 showHeader={false}
                                 compact
-                                height={112}
+                                height={176}
                             />
                         </div>
                     </Link>

--- a/frontend/src/pages/style/Style.jsx
+++ b/frontend/src/pages/style/Style.jsx
@@ -31,6 +31,7 @@ import { SharesBadge } from '../../components/buttons/trade/SellButtons';
 import ExpandableText from '../../components/utils/ExpandableText';
 import ExpandableLink from '../../components/utils/ExpandableLink';
 import TradeCTA from '../../components/TradeCTA';
+import MarketTagChips, { MARKET_TAG_COLOR_OPTIONS } from '../../components/markets/MarketTagChips';
 
 const Style = () => {
   const [isSelected, setIsSelected] = useState(false);
@@ -353,6 +354,29 @@ const Style = () => {
             <div className='text-white text-sm font-medium'>NO Probability</div>
             <div className='text-gray-400 text-xs'>red-btn: #D00000</div>
             <div className='text-gray-500 text-xs mt-1'>Used when showing dual probabilities</div>
+          </div>
+        </div>
+
+        {/* Market Tag Colors Section */}
+        <h3 className='text-xl font-bold text-white mb-4 mt-8'>Market Tag Colors</h3>
+        <div className='bg-gray-900 p-4 rounded-lg border border-gray-700 mb-8'>
+          <p className='text-gray-300 text-sm mb-4'>
+            Tag chips use color as a secondary cue. Keep the palette intentionally limited:
+            roughly 8-10 colors is the practical upper bound before users rely more on text than hue.
+          </p>
+          <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4'>
+            {MARKET_TAG_COLOR_OPTIONS.map((option) => (
+              <div key={option.key} className='rounded-lg border border-gray-700 bg-primary-background p-4'>
+                <MarketTagChips tags={[{
+                  slug: option.key,
+                  displayName: option.label,
+                  colorKey: option.key,
+                  description: option.guidance,
+                }]} />
+                <div className='mt-3 font-mono text-xs text-gray-400'>{option.key}</div>
+                <div className='mt-1 text-xs text-gray-500'>{option.guidance}</div>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/style/Style.jsx
+++ b/frontend/src/pages/style/Style.jsx
@@ -371,10 +371,10 @@ const Style = () => {
                   slug: option.key,
                   displayName: option.label,
                   colorKey: option.key,
-                  description: option.guidance,
+                  description: option.label,
                 }]} />
                 <div className='mt-3 font-mono text-xs text-gray-400'>{option.key}</div>
-                <div className='mt-1 text-xs text-gray-500'>{option.guidance}</div>
+                <div className='mt-1 text-xs text-gray-500'>Color key only</div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Adds timestamped market tag and market tag assignment migrations.
- Adds backend domain/repository/handler support for admin-managed tags and moderator-selected market tags.
- Adds public active-tag listing, admin tag create/list/update endpoints, OpenAPI coverage, and tests.
- Adds frontend tag chips, moderator create-market tag selection, admin review/profile/market display chips, and an admin Tags tab for create/deactivate/reactivate.

## Verification
- `go test ./...` from `backend/`
- `npm run build` from `frontend/`

## Deferred
- Tag-filtered search/listing.
- Admin adjustment of tags during proposal review.
- CMS discovery pages, sections, pins, and recommendation read models.
- Schemathesis/go-kin API validation after deeper OpenAPI workflow is run.