### PR TITLE
Add moderator work profit payouts

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/11/11-read-model-caching-performance.md
+++ b/README/PRODUCTION-NOTES/FEATURES/11/11-read-model-caching-performance.md
@@ -110,6 +110,7 @@ These are good early candidates because they are read-heavy and not directly res
 | Individual user financial metrics | user P/L, resolved/unresolved exposure, historical positions, market-by-market financial summaries | about 1-10m; load on demand and refresh after user-initiated transaction success |
 | Global leaderboard | user ranking, profit summaries, resolved market counts | about 1h |
 | Market leaderboard | per-market participant ranking | about 10m |
+| Market positions | per-market YES/NO position cards | about 10m |
 | Market cards | title, status, probability, volume, users, tags, steward, close time | about 10m |
 | `/markets` page | discovery cards, pinned market summaries, topic navigation payloads | about 10m |
 | `/markets/topic/:slug` page | filtered topic cards and pinned topic markets | about 10m |

--- a/README/PRODUCTION-NOTES/FEATURES/11/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/11/DESIGN.md
@@ -61,6 +61,7 @@ Primary inputs:
 | Market bet table display | recent bets | Paginate; do not cache, or refresh/poll around 10 seconds so accepted bets appear quickly. |
 | Discovery display | `/markets`, topic pages, pinned cards, compact charts | Cache around 10 minutes. |
 | Market leaderboard display | participant ranking for one market | Cache around 10 minutes and paginate. |
+| Market positions display | paginated YES/NO position cards for one market | Cache around 10 minutes and expose freshness metadata. |
 | Dashboard analytics | system metrics, global leaderboard | Cache around 1 hour or scheduled refresh; paginate leaderboard. |
 | User financial display | individual user P/L, exposure, financial summaries, historical position views | Cache authenticated display snapshots around 1-10 minutes; never use for spend checks or settlement. |
 | Audit/reconciliation | raw bets, migrations, payout verification | Recompute from source of truth. |
@@ -245,7 +246,7 @@ Caching alone is not enough. Heavy lists should also be paginated or hidden behi
 Recommended display changes:
 
 - market page bets table defaults to latest 20 rows
-- positions and leaderboard widgets are paginated
+- positions and leaderboard widgets are paginated and cache-backed display read models
 - global leaderboard is paginated
 - system financial metrics show a simplified summary first
 - complex financial paths are behind expansion buttons

--- a/README/PRODUCTION-NOTES/FEATURES/11/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/11/PLAN.md
@@ -172,5 +172,7 @@ Checklist:
 - [x] Add handler/domain tests proving order endpoints do not read from display caches and only mark read models stale after success.
 - [ ] Add load-test scenario for cached discovery pages.
 - [x] Add market detail UI/API pagination for bets, positions, and leaderboard display.
+- [x] Expose market leaderboard snapshot freshness in the API and UI.
+- [x] Keep market positions as live paginated display data rather than a cached snapshot.
 - [ ] Capture before/after latency and CPU metrics.
 - [ ] Update performance dossier with results.

--- a/README/PRODUCTION-NOTES/FEATURES/11/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/11/PLAN.md
@@ -173,6 +173,6 @@ Checklist:
 - [ ] Add load-test scenario for cached discovery pages.
 - [x] Add market detail UI/API pagination for bets, positions, and leaderboard display.
 - [x] Expose market leaderboard snapshot freshness in the API and UI.
-- [x] Keep market positions as live paginated display data rather than a cached snapshot.
+- [x] Cache market positions as a display/read-model snapshot with freshness metadata.
 - [ ] Capture before/after latency and CPU metrics.
 - [ ] Update performance dossier with results.

--- a/README/PRODUCTION-NOTES/FEATURES/12/12-moderator-work-profits.md
+++ b/README/PRODUCTION-NOTES/FEATURES/12/12-moderator-work-profits.md
@@ -1,0 +1,57 @@
+---
+title: Moderator Work Profits
+document_type: feature-overview
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-07T00:00:00Z
+updated_at_display: "Sunday, June 7, 2026"
+update_reason: "Define stateless moderator work-profit payout and financial reporting for resolved markets."
+status: draft
+---
+
+# Moderator Work Profits
+
+## Purpose
+
+Moderators pay to create markets. If those markets attract participants, the current steward who governs and resolves the market should later receive income from the first-participation fees collected on that market. This feature treats that income as moderator work profit while preserving transaction correctness and existing canonical tables.
+
+## Rule Summary
+
+- The market creator pays the existing market creation/proposal cost when creating the market.
+- Each unique participant pays the existing initial market entry fee the first time they place a positive bet on that market.
+- Selling out and buying back in does not create another initial entry fee for the same user on the same market.
+- Collected entry fees remain server-side until market resolution.
+- After a market resolves to `YES` or `NO`, ordinary winner payouts run first.
+- After ordinary payout, the current steward/resolver receives the derived collected entry-fee income as a `WORK_PROFIT` balance credit.
+- `N/A` refund resolutions do not pay moderator work profit in this baseline.
+- User financial display derives net work profit for resolved markets stewarded by that user. If the steward was also the creator, display subtracts the market creation/proposal fee; if the steward took over later, display does not subtract someone else's creation cost.
+
+## Stateless Accounting
+
+This feature does not add new database columns or tables. Work-profit income is derived from existing market and bet records:
+
+```text
+uniquePositiveParticipants = count(distinct username where market_id = M and bet.amount > 0)
+marketFeeIncome = uniquePositiveParticipants * initialBetFee
+marketCreationFee = market.proposalCost if steward is creator, otherwise 0
+netWorkProfit = marketFeeIncome - marketCreationFee
+```
+
+Resolution-time payout credits only `marketFeeIncome`; the creation fee has already been deducted from the original creator when the market was created. Financial display subtracts the creation fee only when the work-profit beneficiary is also the market creator.
+
+## Boundary Notes
+
+- Payout decisions use canonical bet history, not cached/read-model snapshots.
+- Work-profit display may appear in user financial read models, but those read models remain display-only.
+- System metrics should treat participation fees on resolved `YES`/`NO` markets as redistributed steward work income, not retained system fees, to avoid double-counting the same money.
+- The payout goes to the current steward who governs resolution. A reassigned steward receives the work income; the original creator does not receive it unless they remain steward.
+- Future historical policy changes may require durable per-market fee policy capture. The current implementation intentionally uses existing state and current economics config to avoid adding new state for this baseline.
+
+## Acceptance Criteria
+
+- Resolving a non-`N/A` market pays ordinary winners first.
+- Resolving a non-`N/A` market then credits the current steward/resolver for one initial fee per unique positive-bet participant.
+- Resolving `N/A` refunds participant bet amounts and does not credit work profit.
+- User financials show `workProfits` for resolved markets stewarded by that user, subtracting market creation/proposal cost only when that user was also the creator.
+- Tests prove repeated participation by the same user is counted once.
+- Tests prove sale/negative bet rows do not create extra work-profit income.

--- a/README/PRODUCTION-NOTES/FEATURES/12/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/12/DESIGN.md
@@ -1,0 +1,81 @@
+---
+title: Moderator Work Profits Design
+document_type: feature-design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-07T00:00:00Z
+updated_at_display: "Sunday, June 7, 2026"
+update_reason: "Specify domain boundaries, payout timing, and stateless derivation for moderator work profits."
+status: draft
+---
+
+# Moderator Work Profits Design
+
+## Design Posture
+
+This design follows the canonical design plan's boundary posture:
+
+- Prediction market accounting remains backend-owned domain truth.
+- Financial read models are display-only and must not decide transaction outcomes.
+- New economic behavior should be implemented at explicit service-policy seams.
+- Additive persistence is preferred when state is required; this baseline avoids new persistence because the existing market and bet tables are sufficient.
+
+## Domain Language
+
+| Term | Meaning |
+| --- | --- |
+| Market creator | Immutable user who created the market and paid the proposal/creation cost. |
+| Steward | Current operational owner who can govern the market; not necessarily the creator. |
+| Initial entry fee | Existing first-positive-bet fee charged once per user per market. |
+| Work income | Gross entry-fee income credited to the current steward/resolver after normal resolution payout. |
+| Work profit | Display-only net value: work income minus the market creation/proposal cost only when the steward was also the creator. |
+
+## Payout Timing
+
+```mermaid
+flowchart TD
+  A[Admin or authorized steward resolves market] --> B{Resolution outcome}
+  B -->|N/A| C[Refund participant bet amounts]
+  B -->|YES or NO| D[Resolve market state]
+  D --> E[Pay winning participant positions]
+  E --> F[Derive unique positive-bet participants]
+  F --> G[Credit steward WORK_PROFIT income]
+  C --> H[No work-profit payout]
+  G --> I[Financial display derives net work profit]
+```
+
+## Derivation
+
+Work income is derived from canonical market bet history at resolution time:
+
+- Count each username once when they have at least one positive bet on the market.
+- Ignore sell rows and zero-value rows.
+- Ignore repeated buy rows from the same user.
+- Multiply unique participant count by `InitialBetFee`.
+
+Financial display separately computes net work profit:
+
+```text
+workProfits = sum(resolved stewarded markets) {
+  uniquePositiveParticipants * InitialBetFee - creationCostIfStewardIsCreator
+}
+```
+
+If a legacy market has no stored proposal cost, display logic falls back to the current `CreateMarketCost` config.
+
+## Critical Decisions
+
+| Decision | Uses cached/read-model data? | Reason |
+| --- | --- | --- |
+| Winner payout | No | Must use canonical market state and payout positions. |
+| Work-profit payout | No | Must use canonical bet history at resolution time. |
+| Balance mutation | No | User balance writes are transaction truth. |
+| Retained participation-fee metric | No | Resolved `YES`/`NO` market fees are redistributed as work income and should not be double-counted as retained system fees. |
+| User financial display | May use read models | Display-only summary can be stale, but must be marked as such. |
+
+## Out Of Scope
+
+- Changing steward attribution after resolution. Steward reassignment is blocked once resolved so stateless derivation remains stable.
+- Paying work income on `N/A` refund resolutions.
+- Adding durable per-market initial-fee policy capture.
+- Changing how initial entry fees are charged during bet placement.

--- a/README/PRODUCTION-NOTES/FEATURES/12/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/12/PLAN.md
@@ -1,0 +1,65 @@
+---
+title: Moderator Work Profits Plan
+document_type: feature-plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-07T00:00:00Z
+updated_at_display: "Sunday, June 7, 2026"
+update_reason: "Track implementation slices for moderator work-profit payout and financial reporting."
+status: draft
+---
+
+# Moderator Work Profits Plan
+
+## Purpose
+
+This plan turns [12-moderator-work-profits.md](./12-moderator-work-profits.md) and [DESIGN.md](./DESIGN.md) into implementation slices.
+
+## 01. Feature Artifact And Design Alignment
+
+Checklist:
+
+- [x] Create `README/PRODUCTION-NOTES/FEATURES/12/`.
+- [x] Add feature overview.
+- [x] Add design artifact.
+- [x] Add implementation plan.
+- [x] Align terminology with market creator, steward, work income, and work profit.
+
+## 02. Resolution-Time Payout
+
+Checklist:
+
+- [x] Add explicit `WORK_PROFIT` balance transaction type.
+- [x] Wire `InitialBetFee` into the market service config.
+- [x] Derive unique positive-bet participants from canonical bet history.
+- [x] Credit work income after ordinary winner payout.
+- [x] Skip work-profit payout for `N/A` refund resolution.
+- [x] Add service tests for payout ordering and unique participant counting.
+
+## 03. Financial Display
+
+Checklist:
+
+- [x] Derive user `workProfits` from resolved markets stewarded by that user.
+- [x] Use stored `ProposalCost` as the market creation fee when available.
+- [x] Fall back to configured `CreateMarketCost` for legacy rows with no proposal cost.
+- [x] Include work profits in direct financial calculations.
+- [x] Include work profits in user financial read-model refresh.
+- [x] Update retained participation-fee system metric semantics to avoid double-counting paid-out steward work income.
+- [x] Add tests for net work-profit derivation.
+
+## 04. API And Frontend Surface
+
+Checklist:
+
+- [x] Reuse existing user financial `workProfits` response field.
+- [ ] Add copy or tooltip if users need an explanation of work profits in the financial UI.
+- [ ] Consider market-level steward earnings display after product language is settled.
+
+## 05. Future Decisions
+
+Checklist:
+
+- [ ] Decide whether future economics changes require durable per-market initial fee capture.
+- [ ] Decide whether cancelled/yanked markets should ever pay work income.
+- [ ] Decide whether future governance needs durable resolved-by attribution beyond current steward-at-resolution.

--- a/backend/handlers/markets/discovery_read_model.go
+++ b/backend/handlers/markets/discovery_read_model.go
@@ -56,7 +56,7 @@ type marketDiscoveryReadModelResponse struct {
 	Markets       []*dto.MarketOverviewResponse `json:"markets"`
 	PinnedMarkets []pinnedMarketResponse        `json:"pinnedMarkets"`
 	Total         int                           `json:"total"`
-	Freshness     readModelFreshnessResponse    `json:"freshness"`
+	Freshness     dto.Freshness                 `json:"freshness"`
 }
 
 type discoveryPageResponse struct {

--- a/backend/handlers/markets/dto/responses.go
+++ b/backend/handlers/markets/dto/responses.go
@@ -1,8 +1,6 @@
 package dto
 
-import (
-	"time"
-)
+import "time"
 
 // MarketResponse represents the HTTP response for a market
 type MarketResponse struct {
@@ -157,6 +155,18 @@ type LeaderboardResponse struct {
 	MarketID    int64            `json:"marketId"`
 	Leaderboard []LeaderboardRow `json:"leaderboard"`
 	Total       int              `json:"total"`
+	Freshness   *Freshness       `json:"freshness,omitempty"`
+}
+
+// Freshness represents display/read-model freshness metadata.
+type Freshness struct {
+	GeneratedAt            time.Time  `json:"generatedAt"`
+	Source                 string     `json:"source"`
+	TargetFreshnessSeconds int        `json:"targetFreshnessSeconds"`
+	TransactionSafeRead    bool       `json:"transactionSafeRead"`
+	IsStale                bool       `json:"isStale"`
+	StaleReason            string     `json:"staleReason,omitempty"`
+	MarkedStaleAt          *time.Time `json:"markedStaleAt,omitempty"`
 }
 
 // ProbabilityProjectionResponse represents the HTTP response for probability projection

--- a/backend/handlers/markets/handler.go
+++ b/backend/handlers/markets/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"socialpredict/handlers"
 	"socialpredict/handlers/markets/dto"
@@ -42,6 +43,11 @@ type Handler struct {
 
 type readModelInvalidator interface {
 	InvalidateAfterMarketTransaction(ctx context.Context, username string, marketID int64, reason string) error
+}
+
+type marketLeaderboardReadModelService interface {
+	GetMarketLeaderboardReadModel(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketLeaderboardSnapshot, error)
+	RefreshMarketLeaderboardSnapshot(ctx context.Context, marketID int64) (*dmarkets.MarketLeaderboardSnapshot, error)
 }
 
 // NewHandler creates a new markets handler
@@ -421,10 +427,22 @@ func (h *Handler) MarketLeaderboard(w http.ResponseWriter, r *http.Request) {
 
 	page := parsePagination(r, 100)
 
-	leaderboard, err := h.service.GetMarketLeaderboard(r.Context(), id, page)
-	if err != nil {
-		writeLeaderboardError(w, err)
-		return
+	var leaderboard []*dmarkets.LeaderboardRow
+	var freshness *dto.Freshness
+	if snapshot, snapshotErr := h.marketLeaderboardReadModel(r.Context(), id, page); snapshotErr == nil && snapshot != nil {
+		leaderboard = snapshot.Rows
+		freshnessResponse := readModelFreshnessToResponse(snapshot.Freshness())
+		freshness = &freshnessResponse
+	} else {
+		if snapshotErr != nil {
+			logger.LogError("MarketLeaderboard", "GetMarketLeaderboardReadModel", snapshotErr)
+		}
+		var err error
+		leaderboard, err = h.service.GetMarketLeaderboard(r.Context(), id, page)
+		if err != nil {
+			writeLeaderboardError(w, err)
+			return
+		}
 	}
 
 	leaderRows := buildLeaderboardRows(leaderboard)
@@ -433,9 +451,37 @@ func (h *Handler) MarketLeaderboard(w http.ResponseWriter, r *http.Request) {
 		MarketID:    id,
 		Leaderboard: leaderRows,
 		Total:       len(leaderRows),
+		Freshness:   freshness,
 	}
 
 	_ = handlers.WriteResult(w, http.StatusOK, response)
+}
+
+func (h *Handler) marketLeaderboardReadModel(ctx context.Context, marketID int64, page dmarkets.Page) (*dmarkets.MarketLeaderboardSnapshot, error) {
+	service, ok := h.service.(marketLeaderboardReadModelService)
+	if !ok {
+		return nil, nil
+	}
+
+	snapshot, err := service.GetMarketLeaderboardReadModel(ctx, marketID, page)
+	if err != nil {
+		return nil, err
+	}
+
+	if snapshot == nil || snapshot.IsStale || snapshot.GeneratedAt.IsZero() || time.Since(snapshot.GeneratedAt) > dmarkets.MarketLeaderboardSnapshotTargetFreshness {
+		if _, refreshErr := service.RefreshMarketLeaderboardSnapshot(ctx, marketID); refreshErr != nil {
+			if snapshot != nil {
+				return snapshot, nil
+			}
+			return nil, refreshErr
+		}
+		snapshot, err = service.GetMarketLeaderboardReadModel(ctx, marketID, page)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return snapshot, nil
 }
 
 // ProjectProbability handles GET /markets/{id}/projection

--- a/backend/handlers/markets/handler_status_leaderboard_test.go
+++ b/backend/handlers/markets/handler_status_leaderboard_test.go
@@ -119,6 +119,71 @@ func TestMarketLeaderboardHandler_Smoke(t *testing.T) {
 	}
 }
 
+func TestMarketLeaderboardHandler_UsesSnapshotFreshnessWhenAvailable(t *testing.T) {
+	generatedAt := time.Now().UTC().Add(-2 * time.Minute)
+	svc := &readModelLeaderboardServiceMock{
+		MockService: MockService{
+			MarketLeaderboardFn: func(ctx context.Context, marketID int64, p dmarkets.Page) ([]*dmarkets.LeaderboardRow, error) {
+				t.Fatalf("raw leaderboard calculator should not be used when snapshot is available")
+				return nil, nil
+			},
+		},
+		ReadModelFn: func(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketLeaderboardSnapshot, error) {
+			if marketID != 77 {
+				t.Fatalf("expected marketID 77, got %d", marketID)
+			}
+			if p.Limit != 25 {
+				t.Fatalf("expected limit 25, got %d", p.Limit)
+			}
+			return &dmarkets.MarketLeaderboardSnapshot{
+				MarketID:    marketID,
+				GeneratedAt: generatedAt,
+				Source:      "read_model",
+				Rows: []*dmarkets.LeaderboardRow{{
+					Username:     "snapshot_alice",
+					Profit:       8,
+					CurrentValue: 42,
+					TotalSpent:   34,
+					Position:     "YES",
+					Rank:         1,
+				}},
+			}, nil
+		},
+	}
+
+	handler := NewHandler(svc, nil, security.NewSecurityService())
+	req := httptest.NewRequest(http.MethodGet, "/v0/markets/77/leaderboard?limit=25", nil)
+	rr := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/v0/markets/{id}/leaderboard", handler.MarketLeaderboard)
+
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp handlers.SuccessEnvelope[dto.LeaderboardResponse]
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Result.Leaderboard) != 1 || resp.Result.Leaderboard[0].Username != "snapshot_alice" {
+		t.Fatalf("unexpected leaderboard payload: %+v", resp.Result.Leaderboard)
+	}
+	if resp.Result.Freshness == nil {
+		t.Fatalf("expected snapshot freshness metadata")
+	}
+	if !resp.Result.Freshness.GeneratedAt.Equal(generatedAt) {
+		t.Fatalf("freshness generatedAt = %s, want %s", resp.Result.Freshness.GeneratedAt, generatedAt)
+	}
+	if resp.Result.Freshness.TargetFreshnessSeconds != int(dmarkets.MarketLeaderboardSnapshotTargetFreshness.Seconds()) {
+		t.Fatalf("freshness target = %d, want %d", resp.Result.Freshness.TargetFreshnessSeconds, int(dmarkets.MarketLeaderboardSnapshotTargetFreshness.Seconds()))
+	}
+	if resp.Result.Freshness.TransactionSafeRead {
+		t.Fatalf("leaderboard snapshot must not be marked transaction safe")
+	}
+}
+
 func TestMarketLeaderboardHandler_FailureEnvelope(t *testing.T) {
 	svc := &MockService{}
 	svc.MarketLeaderboardFn = func(ctx context.Context, marketID int64, p dmarkets.Page) ([]*dmarkets.LeaderboardRow, error) {
@@ -144,6 +209,26 @@ func TestMarketLeaderboardHandler_FailureEnvelope(t *testing.T) {
 	if resp.Reason != string(handlers.ReasonInternalError) {
 		t.Fatalf("expected reason %q, got %q", handlers.ReasonInternalError, resp.Reason)
 	}
+}
+
+type readModelLeaderboardServiceMock struct {
+	MockService
+	ReadModelFn func(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketLeaderboardSnapshot, error)
+	RefreshFn   func(ctx context.Context, marketID int64) (*dmarkets.MarketLeaderboardSnapshot, error)
+}
+
+func (m *readModelLeaderboardServiceMock) GetMarketLeaderboardReadModel(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketLeaderboardSnapshot, error) {
+	if m.ReadModelFn != nil {
+		return m.ReadModelFn(ctx, marketID, p)
+	}
+	return nil, nil
+}
+
+func (m *readModelLeaderboardServiceMock) RefreshMarketLeaderboardSnapshot(ctx context.Context, marketID int64) (*dmarkets.MarketLeaderboardSnapshot, error) {
+	if m.RefreshFn != nil {
+		return m.RefreshFn(ctx, marketID)
+	}
+	return nil, nil
 }
 
 func TestListUserOwnedMarketsHandlerRequiresLogin(t *testing.T) {

--- a/backend/handlers/markets/summary_read_model.go
+++ b/backend/handlers/markets/summary_read_model.go
@@ -3,7 +3,6 @@ package marketshandlers
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"socialpredict/handlers"
 	"socialpredict/handlers/markets/dto"
@@ -23,21 +22,11 @@ type marketSummaryReadModelResponse struct {
 	NumUsers    int                             `json:"numUsers"`
 	TotalVolume int64                           `json:"totalVolume"`
 	MarketDust  int64                           `json:"marketDust"`
-	Freshness   readModelFreshnessResponse      `json:"freshness"`
+	Freshness   dto.Freshness                   `json:"freshness"`
 }
 
-type readModelFreshnessResponse struct {
-	GeneratedAt            time.Time  `json:"generatedAt"`
-	Source                 string     `json:"source"`
-	TargetFreshnessSeconds int        `json:"targetFreshnessSeconds"`
-	TransactionSafeRead    bool       `json:"transactionSafeRead"`
-	IsStale                bool       `json:"isStale"`
-	StaleReason            string     `json:"staleReason,omitempty"`
-	MarkedStaleAt          *time.Time `json:"markedStaleAt,omitempty"`
-}
-
-func readModelFreshnessToResponse(freshness readmodels.Freshness) readModelFreshnessResponse {
-	return readModelFreshnessResponse{
+func readModelFreshnessToResponse(freshness readmodels.Freshness) dto.Freshness {
+	return dto.Freshness{
 		GeneratedAt:            freshness.GeneratedAt,
 		Source:                 freshness.Source,
 		TargetFreshnessSeconds: freshness.TargetFreshnessSeconds,

--- a/backend/handlers/positions/positionshandler.go
+++ b/backend/handlers/positions/positionshandler.go
@@ -1,16 +1,30 @@
 package positions
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"socialpredict/handlers"
+	"socialpredict/handlers/markets/dto"
 	dmarkets "socialpredict/internal/domain/markets"
+	"socialpredict/internal/domain/readmodels"
 	"socialpredict/logger"
 
 	"github.com/gorilla/mux"
 )
+
+type marketPositionsResponse struct {
+	Positions []userPositionResponse `json:"positions"`
+	Freshness *dto.Freshness         `json:"freshness,omitempty"`
+}
+
+type marketPositionsReadModelService interface {
+	GetMarketPositionsReadModel(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketPositionsSnapshot, error)
+	RefreshMarketPositionsSnapshot(ctx context.Context, marketID int64) (*dmarkets.MarketPositionsSnapshot, error)
+}
 
 // MarketPositionsHandlerWithService creates a service-injected positions handler for all users
 func MarketPositionsHandlerWithService(svc dmarkets.ServiceInterface) http.HandlerFunc {
@@ -26,7 +40,7 @@ func MarketPositionsHandlerWithService(svc dmarkets.ServiceInterface) http.Handl
 			return
 		}
 
-		positions, err := getMarketPositions(r, svc, marketID)
+		positions, freshness, err := getMarketPositions(r, svc, marketID)
 		if err != nil {
 			writePositionsError(w, marketID, err)
 			return
@@ -34,18 +48,76 @@ func MarketPositionsHandlerWithService(svc dmarkets.ServiceInterface) http.Handl
 
 		responses := mapPositionsToResponses(positions)
 
-		if err := handlers.WriteResult(w, http.StatusOK, responses); err != nil {
+		payload := any(responses)
+		if hasPaginationQuery(r) {
+			payload = marketPositionsResponse{
+				Positions: responses,
+				Freshness: freshness,
+			}
+		}
+
+		if err := handlers.WriteResult(w, http.StatusOK, payload); err != nil {
 			logger.LogError("MarketPositions", "WriteResponse", err)
 			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
 		}
 	}
 }
 
-func getMarketPositions(r *http.Request, svc dmarkets.ServiceInterface, marketID int64) (dmarkets.MarketPositions, error) {
+func getMarketPositions(r *http.Request, svc dmarkets.ServiceInterface, marketID int64) (dmarkets.MarketPositions, *dto.Freshness, error) {
 	if !hasPaginationQuery(r) {
-		return svc.GetMarketPositions(r.Context(), marketID)
+		positions, err := svc.GetMarketPositions(r.Context(), marketID)
+		return positions, nil, err
 	}
-	return svc.GetMarketPositionsPage(r.Context(), marketID, parsePage(r, 20))
+	page := parsePage(r, 20)
+	if snapshot, err := marketPositionsReadModel(r.Context(), svc, marketID, page); err == nil && snapshot != nil {
+		freshness := readModelFreshnessToResponse(snapshot.Freshness())
+		return snapshot.Positions, &freshness, nil
+	} else if err != nil {
+		logger.LogError("MarketPositions", "GetMarketPositionsReadModel", err)
+	}
+
+	positions, err := svc.GetMarketPositionsPage(r.Context(), marketID, page)
+	freshness := readModelFreshnessToResponse(readmodels.NewFreshness(time.Now().UTC(), "live", dmarkets.MarketPositionsSnapshotTargetFreshness, false))
+	return positions, &freshness, err
+}
+
+func marketPositionsReadModel(ctx context.Context, svc dmarkets.ServiceInterface, marketID int64, page dmarkets.Page) (*dmarkets.MarketPositionsSnapshot, error) {
+	service, ok := svc.(marketPositionsReadModelService)
+	if !ok {
+		return nil, nil
+	}
+
+	snapshot, err := service.GetMarketPositionsReadModel(ctx, marketID, page)
+	if err != nil {
+		return nil, err
+	}
+
+	if snapshot == nil || snapshot.IsStale || snapshot.GeneratedAt.IsZero() || time.Since(snapshot.GeneratedAt) > dmarkets.MarketPositionsSnapshotTargetFreshness {
+		if _, refreshErr := service.RefreshMarketPositionsSnapshot(ctx, marketID); refreshErr != nil {
+			if snapshot != nil {
+				return snapshot, nil
+			}
+			return nil, refreshErr
+		}
+		snapshot, err = service.GetMarketPositionsReadModel(ctx, marketID, page)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return snapshot, nil
+}
+
+func readModelFreshnessToResponse(freshness readmodels.Freshness) dto.Freshness {
+	return dto.Freshness{
+		GeneratedAt:            freshness.GeneratedAt,
+		Source:                 freshness.Source,
+		TargetFreshnessSeconds: freshness.TargetFreshnessSeconds,
+		TransactionSafeRead:    freshness.TransactionSafeRead,
+		IsStale:                freshness.IsStale,
+		StaleReason:            freshness.StaleReason,
+		MarkedStaleAt:          freshness.MarkedStaleAt,
+	}
 }
 
 // MarketUserPositionHandlerWithService creates a service-injected handler for a specific user's position

--- a/backend/handlers/positions/positionshandler_test.go
+++ b/backend/handlers/positions/positionshandler_test.go
@@ -296,6 +296,59 @@ func TestMarketPositionsHandlerWithService_UsesPaginationQuery(t *testing.T) {
 	}
 }
 
+func TestMarketPositionsHandlerWithService_UsesSnapshotFreshnessWhenAvailable(t *testing.T) {
+	generatedAt := time.Now().UTC().Add(-3 * time.Minute)
+	mockSvc := &readModelPositionsService{
+		mockPositionsService: mockPositionsService{
+			positionsPage: dmarkets.MarketPositions{
+				{Username: "raw_alice", MarketID: 7, YesSharesOwned: 99},
+			},
+		},
+		readModel: &dmarkets.MarketPositionsSnapshot{
+			MarketID:    7,
+			GeneratedAt: generatedAt,
+			Source:      "read_model",
+			Positions: dmarkets.MarketPositions{
+				{Username: "snapshot_alice", MarketID: 7, YesSharesOwned: 3},
+			},
+		},
+	}
+	handler := MarketPositionsHandlerWithService(mockSvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/markets/positions/7?limit=20&offset=0", nil)
+	req = mux.SetURLVars(req, map[string]string{"marketId": "7"})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if mockSvc.page != nil {
+		t.Fatalf("raw paginated position calculation should not be used when snapshot is available")
+	}
+
+	var resp handlers.SuccessEnvelope[marketPositionsResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode success envelope: %v", err)
+	}
+	if len(resp.Result.Positions) != 1 || resp.Result.Positions[0].Username != "snapshot_alice" {
+		t.Fatalf("unexpected positions payload: %+v", resp.Result.Positions)
+	}
+	if resp.Result.Freshness == nil {
+		t.Fatalf("expected freshness metadata")
+	}
+	if !resp.Result.Freshness.GeneratedAt.Equal(generatedAt) {
+		t.Fatalf("freshness generatedAt = %s, want %s", resp.Result.Freshness.GeneratedAt, generatedAt)
+	}
+	if resp.Result.Freshness.TargetFreshnessSeconds != int(dmarkets.MarketPositionsSnapshotTargetFreshness.Seconds()) {
+		t.Fatalf("freshness target = %d, want %d", resp.Result.Freshness.TargetFreshnessSeconds, int(dmarkets.MarketPositionsSnapshotTargetFreshness.Seconds()))
+	}
+	if resp.Result.Freshness.TransactionSafeRead {
+		t.Fatalf("positions snapshot must not be marked transaction safe")
+	}
+}
+
 func TestMarketUserPositionHandlerWithService_FailureEnvelope(t *testing.T) {
 	handler := MarketUserPositionHandlerWithService(&mockUserPositionService{
 		mockPositionsService: mockPositionsService{err: errors.New("boom")},
@@ -321,6 +374,31 @@ func TestMarketUserPositionHandlerWithService_FailureEnvelope(t *testing.T) {
 	if resp.Reason != string(handlers.ReasonInternalError) {
 		t.Fatalf("expected reason %q, got %q", handlers.ReasonInternalError, resp.Reason)
 	}
+}
+
+type readModelPositionsService struct {
+	mockPositionsService
+	readModel *dmarkets.MarketPositionsSnapshot
+}
+
+func (m *readModelPositionsService) GetMarketPositionsReadModel(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketPositionsSnapshot, error) {
+	if m.readModel == nil {
+		return nil, nil
+	}
+	return &dmarkets.MarketPositionsSnapshot{
+		MarketID:            m.readModel.MarketID,
+		Positions:           m.readModel.Positions,
+		GeneratedAt:         m.readModel.GeneratedAt,
+		Source:              m.readModel.Source,
+		TransactionSafeRead: m.readModel.TransactionSafeRead,
+		IsStale:             m.readModel.IsStale,
+		StaleReason:         m.readModel.StaleReason,
+		MarkedStaleAt:       m.readModel.MarkedStaleAt,
+	}, nil
+}
+
+func (m *readModelPositionsService) RefreshMarketPositionsSnapshot(ctx context.Context, marketID int64) (*dmarkets.MarketPositionsSnapshot, error) {
+	return m.readModel, nil
 }
 
 type mockUserPositionService struct {

--- a/backend/internal/app/container.go
+++ b/backend/internal/app/container.go
@@ -129,6 +129,7 @@ func (c *Container) InitializeServices() {
 	marketsConfig := dmarkets.Config{
 		MinimumFutureHours:     c.config.Economics.MarketCreation.MinimumFutureHours,
 		CreateMarketCost:       c.config.Economics.MarketIncentives.CreateMarketCost,
+		InitialBetFee:          c.config.Economics.Betting.BetFees.InitialBetFee,
 		MaximumDebtAllowed:     c.config.Economics.User.MaximumDebtAllowed,
 		GameMode:               c.config.Game.Mode,
 		MarketApprovalRequired: c.config.Game.Moderation.MarketApprovalRequired,

--- a/backend/internal/app/readmodelinvalidation/invalidation.go
+++ b/backend/internal/app/readmodelinvalidation/invalidation.go
@@ -9,6 +9,7 @@ import (
 type MarketInvalidator interface {
 	MarkMarketAccountingSnapshotStale(ctx context.Context, marketID int64, reason string) error
 	MarkMarketLeaderboardSnapshotStale(ctx context.Context, marketID int64, reason string) error
+	MarkMarketPositionsSnapshotStale(ctx context.Context, marketID int64, reason string) error
 }
 
 // AnalyticsInvalidator marks analytics-owned display read models stale.
@@ -47,6 +48,9 @@ func (s *Service) InvalidateAfterMarketTransaction(ctx context.Context, username
 			errs = append(errs, err)
 		}
 		if err := s.markets.MarkMarketLeaderboardSnapshotStale(ctx, marketID, reason); err != nil {
+			errs = append(errs, err)
+		}
+		if err := s.markets.MarkMarketPositionsSnapshotStale(ctx, marketID, reason); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/backend/internal/domain/analytics/financials.go
+++ b/backend/internal/domain/analytics/financials.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"socialpredict/internal/domain/boundary"
 	positionsmath "socialpredict/internal/domain/math/positions"
 )
 
@@ -23,8 +24,67 @@ func (s *Service) ComputeUserFinancials(ctx context.Context, req FinancialSnapsh
 		return nil, err
 	}
 
+	workProfits, err := s.computeUserWorkProfits(ctx, req.Username)
+	if err != nil {
+		return nil, err
+	}
+	req.WorkProfits = workProfits
+
 	snapshot := NewUserFinancialMetricSnapshotCalculator(s.config).Calculate(req, positions, time.Time{})
 	return &snapshot.Financial, nil
+}
+
+func (s *Service) computeUserWorkProfits(ctx context.Context, username string) (int64, error) {
+	if s.financialsRepo == nil {
+		return 0, errors.New("financials repository not provided")
+	}
+	markets, err := s.financialsRepo.UserWorkProfitResolvedMarkets(ctx, username)
+	if err != nil {
+		return 0, err
+	}
+
+	var total int64
+	for _, market := range markets {
+		if !market.IsResolved || market.ResolutionResult == "N/A" {
+			continue
+		}
+		bets, err := s.financialsRepo.ListBetsForMarket(ctx, market.ID)
+		if err != nil {
+			return 0, err
+		}
+		creationCost := int64(0)
+		if market.CreatorUsername == username {
+			creationCost = creationCostForWorkProfit(market.ProposalCost, s.config.CreateMarketCost)
+		}
+		total += stewardMarketWorkProfit(bets, s.config.InitialBetFee, creationCost)
+	}
+
+	return total, nil
+}
+
+func stewardMarketWorkProfit(bets []boundary.Bet, initialBetFee int64, creationCost int64) int64 {
+	return participationFeeIncome(bets, initialBetFee) - creationCost
+}
+
+func participationFeeIncome(bets []boundary.Bet, initialBetFee int64) int64 {
+	if initialBetFee <= 0 {
+		return 0
+	}
+	participants := make(map[string]struct{})
+	for _, bet := range bets {
+		if bet.Amount <= 0 || bet.Username == "" {
+			continue
+		}
+		participants[bet.Username] = struct{}{}
+	}
+	return int64(len(participants)) * initialBetFee
+}
+
+func creationCostForWorkProfit(proposalCost int64, fallbackCreateMarketCost int64) int64 {
+	if proposalCost > 0 {
+		return proposalCost
+	}
+	return fallbackCreateMarketCost
 }
 
 // UserFinancialMetricSnapshotCalculator calculates display-only user financial
@@ -41,6 +101,7 @@ func (c UserFinancialMetricSnapshotCalculator) Calculate(req FinancialSnapshotRe
 	financial := FinancialSnapshot{
 		AccountBalance:     req.AccountBalance,
 		MaximumDebtAllowed: c.config.MaximumDebtAllowed,
+		WorkProfits:        req.WorkProfits,
 	}
 	for _, pos := range positions {
 		profit := pos.Value - pos.TotalSpent

--- a/backend/internal/domain/analytics/financialsnapshot_test.go
+++ b/backend/internal/domain/analytics/financialsnapshot_test.go
@@ -159,3 +159,99 @@ func TestComputeUserFinancials_WithActivePositions(t *testing.T) {
 		t.Errorf("expected total spent > 0")
 	}
 }
+
+func TestComputeUserFinancials_DerivesModeratorWorkProfitsFromResolvedStewardedMarkets(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	creator := modelstesting.GenerateUser("moderator", 500)
+	steward := modelstesting.GenerateUser("steward", 500)
+	alice := modelstesting.GenerateUser("alice", 500)
+	bob := modelstesting.GenerateUser("bob", 500)
+	for _, user := range []models.User{creator, steward, alice, bob} {
+		if err := db.Create(&user).Error; err != nil {
+			t.Fatalf("create user %s: %v", user.Username, err)
+		}
+	}
+
+	market := modelstesting.GenerateMarket(1, creator.Username)
+	market.IsResolved = true
+	market.ResolutionResult = "YES"
+	market.ProposalCost = 10
+	market.StewardUsername = steward.Username
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+
+	bets := []models.Bet{
+		modelstesting.GenerateBet(100, "YES", alice.Username, uint(market.ID), 0),
+		modelstesting.GenerateBet(-20, "YES", alice.Username, uint(market.ID), time.Minute),
+		modelstesting.GenerateBet(50, "NO", bob.Username, uint(market.ID), 2*time.Minute),
+		modelstesting.GenerateBet(10, "YES", bob.Username, uint(market.ID), 3*time.Minute),
+	}
+	for _, bet := range bets {
+		if err := db.Create(&bet).Error; err != nil {
+			t.Fatalf("create bet: %v", err)
+		}
+	}
+
+	econ := modelstesting.GenerateEconomicConfig()
+	econ.Economics.Betting.BetFees.InitialBetFee = 7
+	econ.Economics.MarketIncentives.CreateMarketCost = 99
+	svc := newAnalyticsService(t, db, econ)
+
+	creatorSnapshot := requireFinancialSnapshot(t, svc, creator)
+	if creatorSnapshot.WorkProfits != 0 {
+		t.Fatalf("creator work profits = %d, want 0 after steward reassignment", creatorSnapshot.WorkProfits)
+	}
+
+	stewardSnapshot := requireFinancialSnapshot(t, svc, steward)
+
+	expectedWorkProfits := int64(14)
+	if stewardSnapshot.WorkProfits != expectedWorkProfits {
+		t.Fatalf("steward work profits = %d, want %d", stewardSnapshot.WorkProfits, expectedWorkProfits)
+	}
+	if stewardSnapshot.TotalProfits != stewardSnapshot.TradingProfits+expectedWorkProfits {
+		t.Fatalf("total profits = %d, want trading %d + work %d", stewardSnapshot.TotalProfits, stewardSnapshot.TradingProfits, expectedWorkProfits)
+	}
+}
+
+func TestComputeUserFinancials_SubtractsCreationCostWhenCreatorRemainsSteward(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	creator := modelstesting.GenerateUser("creator_steward", 500)
+	alice := modelstesting.GenerateUser("alice2", 500)
+	bob := modelstesting.GenerateUser("bob2", 500)
+	for _, user := range []models.User{creator, alice, bob} {
+		if err := db.Create(&user).Error; err != nil {
+			t.Fatalf("create user %s: %v", user.Username, err)
+		}
+	}
+
+	market := modelstesting.GenerateMarket(2, creator.Username)
+	market.IsResolved = true
+	market.ResolutionResult = "YES"
+	market.ProposalCost = 10
+	market.StewardUsername = creator.Username
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+
+	bets := []models.Bet{
+		modelstesting.GenerateBet(100, "YES", alice.Username, uint(market.ID), 0),
+		modelstesting.GenerateBet(50, "NO", bob.Username, uint(market.ID), time.Minute),
+	}
+	for _, bet := range bets {
+		if err := db.Create(&bet).Error; err != nil {
+			t.Fatalf("create bet: %v", err)
+		}
+	}
+
+	econ := modelstesting.GenerateEconomicConfig()
+	econ.Economics.Betting.BetFees.InitialBetFee = 7
+	svc := newAnalyticsService(t, db, econ)
+
+	snapshot := requireFinancialSnapshot(t, svc, creator)
+
+	expectedWorkProfits := int64(4)
+	if snapshot.WorkProfits != expectedWorkProfits {
+		t.Fatalf("creator-steward work profits = %d, want %d", snapshot.WorkProfits, expectedWorkProfits)
+	}
+}

--- a/backend/internal/domain/analytics/models.go
+++ b/backend/internal/domain/analytics/models.go
@@ -21,6 +21,17 @@ type MarketRecord struct {
 	ResolutionResult string
 }
 
+// WorkProfitMarketRecord captures the resolved market fields needed to derive
+// steward work profit without adding separate accounting state.
+type WorkProfitMarketRecord struct {
+	ID               uint
+	CreatorUsername  string
+	StewardUsername  string
+	IsResolved       bool
+	ResolutionResult string
+	ProposalCost     int64
+}
+
 // Snapshot converts the record into the shared math snapshot.
 func (m MarketRecord) Snapshot() positionsmath.MarketSnapshot {
 	return positionsmath.MarketSnapshot{
@@ -203,6 +214,7 @@ type FinancialSnapshotRequestReader interface {
 type FinancialSnapshotRequest struct {
 	Username       string
 	AccountBalance int64
+	WorkProfits    int64
 }
 
 func (r FinancialSnapshotRequest) UsernameValue() string      { return r.Username }

--- a/backend/internal/domain/analytics/repository.go
+++ b/backend/internal/domain/analytics/repository.go
@@ -181,6 +181,22 @@ func (r *GormRepository) UserMarketPositions(ctx context.Context, username strin
 	return positions, nil
 }
 
+func (r *GormRepository) UserWorkProfitResolvedMarkets(ctx context.Context, username string) ([]WorkProfitMarketRecord, error) {
+	db, err := r.dbWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var markets []analyticsWorkProfitMarketRow
+	if err := db.Table("markets").
+		Select("id", "creator_username", "steward_username", "is_resolved", "resolution_result", "proposal_cost").
+		Where("COALESCE(NULLIF(steward_username, ''), creator_username) = ? AND is_resolved = ?", username, true).
+		Order("id ASC").
+		Find(&markets).Error; err != nil {
+		return nil, err
+	}
+	return mapWorkProfitMarkets(markets), nil
+}
+
 func (r *GormRepository) listUserBets(db *gorm.DB, username string) ([]boundary.Bet, error) {
 	var userBets []analyticsBetRow
 	if err := db.Table("bets").
@@ -301,6 +317,15 @@ type analyticsMarketRow struct {
 	ResolutionResult string
 }
 
+type analyticsWorkProfitMarketRow struct {
+	ID               uint
+	CreatorUsername  string
+	StewardUsername  string
+	IsResolved       bool
+	ResolutionResult string
+	ProposalCost     int64
+}
+
 type analyticsBetRow struct {
 	ID        uint
 	Username  string
@@ -330,6 +355,25 @@ func mapMarkets(dbMarkets []analyticsMarketRow) []MarketRecord {
 			CreatedAt:        market.CreatedAt,
 			IsResolved:       market.IsResolved,
 			ResolutionResult: market.ResolutionResult,
+		}
+	}
+	return markets
+}
+
+func mapWorkProfitMarkets(dbMarkets []analyticsWorkProfitMarketRow) []WorkProfitMarketRecord {
+	markets := make([]WorkProfitMarketRecord, len(dbMarkets))
+	for i, market := range dbMarkets {
+		stewardUsername := market.StewardUsername
+		if stewardUsername == "" {
+			stewardUsername = market.CreatorUsername
+		}
+		markets[i] = WorkProfitMarketRecord{
+			ID:               market.ID,
+			CreatorUsername:  market.CreatorUsername,
+			StewardUsername:  stewardUsername,
+			IsResolved:       market.IsResolved,
+			ResolutionResult: market.ResolutionResult,
+			ProposalCost:     market.ProposalCost,
 		}
 	}
 	return markets

--- a/backend/internal/domain/analytics/service.go
+++ b/backend/internal/domain/analytics/service.go
@@ -20,6 +20,7 @@ type VolumeRepository interface {
 
 // FeeRepository exposes the ordered bet data needed for participation fee calculations.
 type FeeRepository interface {
+	ListMarkets(ctx context.Context) ([]MarketRecord, error)
 	ListBetsOrdered(ctx context.Context) ([]boundary.Bet, error)
 }
 
@@ -32,6 +33,8 @@ type LeaderboardRepository interface {
 // FinancialsRepository provides the data required for per-user financial snapshots.
 type FinancialsRepository interface {
 	UserMarketPositions(ctx context.Context, username string) ([]positionsmath.MarketPosition, error)
+	UserWorkProfitResolvedMarkets(ctx context.Context, username string) ([]WorkProfitMarketRecord, error)
+	ListBetsForMarket(ctx context.Context, marketID uint) ([]boundary.Bet, error)
 }
 
 // UserFinancialMetricSnapshotRepository persists authenticated display-only

--- a/backend/internal/domain/analytics/system_metrics.go
+++ b/backend/internal/domain/analytics/system_metrics.go
@@ -108,6 +108,10 @@ func (c DefaultVolumeCalculator) Calculate(ctx context.Context, repo VolumeRepos
 type DefaultFeeCalculator struct{}
 
 func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, repo FeeRepository, config Config) (int64, error) {
+	markets, err := repo.ListMarkets(ctx)
+	if err != nil {
+		return 0, err
+	}
 	betsOrdered, err := repo.ListBetsOrdered(ctx)
 	if err != nil {
 		return 0, err
@@ -118,11 +122,18 @@ func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, re
 		username string
 	}
 
+	paidOutMarket := make(map[uint]bool, len(markets))
+	for _, market := range markets {
+		if market.IsResolved && market.ResolutionResult != "N/A" {
+			paidOutMarket[market.ID] = true
+		}
+	}
+
 	seen := make(map[userMarket]bool)
 	var participationFees int64
 
 	for _, b := range betsOrdered {
-		if b.Amount <= 0 {
+		if b.Amount <= 0 || paidOutMarket[b.MarketID] {
 			continue
 		}
 		key := userMarket{marketID: b.MarketID, username: b.Username}
@@ -153,7 +164,7 @@ func (a DefaultMetricsAssembler) Assemble(debt *DebtStats, volume *MarketVolumeS
 			UnusedDebt:         NewInt64Metric(debt.UnusedDebt, "Σ(maxDebtPerUser - max(0, -balance))", "Remaining borrowing capacity available to users"),
 			ActiveBetVolume:    NewInt64Metric(volume.ActiveBetVolume, "Σ(unresolved_market_volumes)", "Total value of bets currently active in unresolved markets (excludes fees and subsidies)"),
 			MarketCreationFees: NewInt64Metric(volume.MarketCreationFees, "number_of_markets × creation_fee_per_market", "Fees collected from users creating new markets"),
-			ParticipationFees:  NewInt64Metric(participationFees, "Σ(first_bet_per_user_per_market × participation_fee)", "Fees collected from first-time participation in each market"),
+			ParticipationFees:  NewInt64Metric(participationFees, "Σ(unpaid_first_bet_per_user_per_market × participation_fee)", "Retained fees collected from first-time participation before eligible resolved markets redistribute them as steward work profit"),
 			BonusesPaid:        NewInt64Metric(bonusesPaid, "", "System bonuses paid to users and realized profits currently held in user balances"),
 			TotalUtilized:      NewInt64Metric(totalUtilized, "unusedDebt + activeBetVolume + marketCreationFees + participationFees + bonusesPaid", "Total debt capacity that has been utilized across all categories"),
 		},

--- a/backend/internal/domain/analytics/systemmetrics_test.go
+++ b/backend/internal/domain/analytics/systemmetrics_test.go
@@ -106,6 +106,53 @@ func TestComputeSystemMetrics_WithData(t *testing.T) {
 	}
 }
 
+func TestComputeSystemMetrics_ParticipationFeesExcludeResolvedWorkProfitMarkets(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	econ := modelstesting.GenerateEconomicConfig()
+	econ.Economics.Betting.BetFees.InitialBetFee = 5
+
+	creator := modelstesting.GenerateUser("creator", 0)
+	participant := modelstesting.GenerateUser("participant", 0)
+	for _, user := range []models.User{creator, participant} {
+		if err := db.Create(&user).Error; err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+	}
+
+	activeMarket := modelstesting.GenerateMarket(11, creator.Username)
+	activeMarket.IsResolved = false
+	resolvedWorkProfitMarket := modelstesting.GenerateMarket(12, creator.Username)
+	resolvedWorkProfitMarket.IsResolved = true
+	resolvedWorkProfitMarket.ResolutionResult = "YES"
+	resolvedNAMarket := modelstesting.GenerateMarket(13, creator.Username)
+	resolvedNAMarket.IsResolved = true
+	resolvedNAMarket.ResolutionResult = "N/A"
+	for _, market := range []models.Market{activeMarket, resolvedWorkProfitMarket, resolvedNAMarket} {
+		if err := db.Create(&market).Error; err != nil {
+			t.Fatalf("create market: %v", err)
+		}
+	}
+
+	bets := []models.Bet{
+		modelstesting.GenerateBet(10, "YES", participant.Username, uint(activeMarket.ID), 0),
+		modelstesting.GenerateBet(10, "YES", participant.Username, uint(resolvedWorkProfitMarket.ID), 0),
+		modelstesting.GenerateBet(10, "YES", participant.Username, uint(resolvedNAMarket.ID), 0),
+	}
+	for _, bet := range bets {
+		if err := db.Create(&bet).Error; err != nil {
+			t.Fatalf("create bet: %v", err)
+		}
+	}
+
+	svc := newAnalyticsService(t, db, econ)
+	metrics := requireSystemMetrics(t, svc)
+
+	expectedRetainedFees := int64(10)
+	if got := requireMetricInt64(t, metrics.MoneyUtilized.ParticipationFees); got != expectedRetainedFees {
+		t.Fatalf("retained participation fees = %d, want %d", got, expectedRetainedFees)
+	}
+}
+
 func TestComputeSystemMetrics_UsesInjectedSnapshot(t *testing.T) {
 	db := modelstesting.NewFakeDB(t)
 	econ := modelstesting.GenerateEconomicConfig()

--- a/backend/internal/domain/analytics/user_financial_metric_snapshot_refresh.go
+++ b/backend/internal/domain/analytics/user_financial_metric_snapshot_refresh.go
@@ -25,6 +25,11 @@ func (s *Service) RefreshUserFinancialMetricSnapshot(ctx context.Context, req Fi
 	if err != nil {
 		return nil, err
 	}
+	workProfits, err := s.computeUserWorkProfits(ctx, req.Username)
+	if err != nil {
+		return nil, err
+	}
+	req.WorkProfits = workProfits
 
 	snapshot := NewUserFinancialMetricSnapshotCalculator(s.config).
 		Calculate(req, positions, generatedAt)

--- a/backend/internal/domain/markets/market_positions_snapshot.go
+++ b/backend/internal/domain/markets/market_positions_snapshot.go
@@ -1,0 +1,120 @@
+package markets
+
+import (
+	"context"
+	"time"
+
+	"socialpredict/internal/domain/readmodels"
+)
+
+const MarketPositionsSnapshotTargetFreshness = 10 * time.Minute
+
+// MarketPositionsSnapshot is a display/read-model snapshot for market position
+// rows. It must not be used for order, payout, refund, or balance decisions.
+type MarketPositionsSnapshot struct {
+	MarketID            int64
+	Positions           MarketPositions
+	GeneratedAt         time.Time
+	Source              string
+	TransactionSafeRead bool
+	IsStale             bool
+	StaleReason         string
+	MarkedStaleAt       *time.Time
+}
+
+// MarketPositionsSnapshotRepository persists display-only market position
+// snapshots separately from transaction repository interfaces.
+type MarketPositionsSnapshotRepository interface {
+	GetMarketPositionsSnapshot(ctx context.Context, marketID int64) (*MarketPositionsSnapshot, error)
+	UpsertMarketPositionsSnapshot(ctx context.Context, snapshot MarketPositionsSnapshot) error
+	MarkMarketPositionsSnapshotStale(ctx context.Context, marketID int64, reason string) error
+}
+
+func (s MarketPositionsSnapshot) Freshness() readmodels.Freshness {
+	if s.IsStale {
+		return readmodels.NewStaleFreshness(
+			s.GeneratedAt,
+			s.Source,
+			MarketPositionsSnapshotTargetFreshness,
+			s.TransactionSafeRead,
+			s.StaleReason,
+			s.MarkedStaleAt,
+		)
+	}
+	return readmodels.NewFreshness(
+		s.GeneratedAt,
+		s.Source,
+		MarketPositionsSnapshotTargetFreshness,
+		s.TransactionSafeRead,
+	)
+}
+
+// RefreshMarketPositionsSnapshot recomputes and stores the display-only market
+// positions snapshot from canonical market and bet data.
+func (s *Service) RefreshMarketPositionsSnapshot(ctx context.Context, marketID int64) (*MarketPositionsSnapshot, error) {
+	if marketID <= 0 {
+		return nil, ErrInvalidInput
+	}
+	snapshotRepo, ok := s.repo.(MarketPositionsSnapshotRepository)
+	if !ok {
+		return nil, ErrInvalidState
+	}
+
+	positions, err := s.GetMarketPositions(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+	positions = activeMarketPositions(positions)
+	sortMarketPositionsByTotalShares(positions)
+
+	snapshot := MarketPositionsSnapshot{
+		MarketID:    marketID,
+		Positions:   positions,
+		GeneratedAt: time.Now().UTC(),
+		Source:      "read_model",
+	}
+	if err := snapshotRepo.UpsertMarketPositionsSnapshot(ctx, snapshot); err != nil {
+		return nil, err
+	}
+	return &snapshot, nil
+}
+
+// GetMarketPositionsReadModel returns a page from the stored display-only
+// market positions snapshot. A missing snapshot is not an error.
+func (s *Service) GetMarketPositionsReadModel(ctx context.Context, marketID int64, p Page) (*MarketPositionsSnapshot, error) {
+	if marketID <= 0 {
+		return nil, ErrInvalidInput
+	}
+	snapshotRepo, ok := s.repo.(MarketPositionsSnapshotRepository)
+	if !ok {
+		return nil, ErrInvalidState
+	}
+	snapshot, err := snapshotRepo.GetMarketPositionsSnapshot(ctx, marketID)
+	if err != nil || snapshot == nil {
+		return nil, err
+	}
+	p = s.statusPolicy.NormalizePage(p, 20, 100)
+	return &MarketPositionsSnapshot{
+		MarketID:            snapshot.MarketID,
+		Positions:           paginateMarketPositions(snapshot.Positions, p),
+		GeneratedAt:         snapshot.GeneratedAt,
+		Source:              snapshot.Source,
+		TransactionSafeRead: snapshot.TransactionSafeRead,
+		IsStale:             snapshot.IsStale,
+		StaleReason:         snapshot.StaleReason,
+		MarkedStaleAt:       snapshot.MarkedStaleAt,
+	}, nil
+}
+
+// MarkMarketPositionsSnapshotStale marks a display positions snapshot stale
+// after canonical market activity. It does not update market/bet truth.
+func (s *Service) MarkMarketPositionsSnapshotStale(ctx context.Context, marketID int64, reason string) error {
+	if marketID <= 0 {
+		return ErrInvalidInput
+	}
+	snapshotRepo, ok := s.repo.(MarketPositionsSnapshotRepository)
+	if !ok {
+		return ErrInvalidState
+	}
+	return snapshotRepo.MarkMarketPositionsSnapshotStale(ctx, marketID, reason)
+}

--- a/backend/internal/domain/markets/market_positions_snapshot_test.go
+++ b/backend/internal/domain/markets/market_positions_snapshot_test.go
@@ -1,0 +1,72 @@
+package markets_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	markets "socialpredict/internal/domain/markets"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestServiceRefreshMarketPositionsSnapshotMatchesRawRecomputation(t *testing.T) {
+	service, db, _ := setupServiceWithDB(t)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("positions_snapshot_creator", 0)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("create creator: %v", err)
+	}
+	market := modelstesting.GenerateMarket(8083, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+	bets := []models.Bet{
+		modelstesting.GenerateBet(100, "YES", "alice", uint(market.ID), time.Minute),
+		modelstesting.GenerateBet(70, "NO", "bob", uint(market.ID), 2*time.Minute),
+		modelstesting.GenerateBet(40, "YES", "carol", uint(market.ID), 3*time.Minute),
+	}
+	for i := range bets {
+		if err := db.Create(&bets[i]).Error; err != nil {
+			t.Fatalf("create bet %d: %v", i, err)
+		}
+	}
+
+	raw, err := service.GetMarketPositionsPage(ctx, market.ID, markets.Page{Limit: 1000})
+	if err != nil {
+		t.Fatalf("GetMarketPositionsPage returned error: %v", err)
+	}
+	snapshot, err := service.RefreshMarketPositionsSnapshot(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("RefreshMarketPositionsSnapshot returned error: %v", err)
+	}
+	if len(snapshot.Positions) != len(raw) {
+		t.Fatalf("snapshot position count = %d, want %d", len(snapshot.Positions), len(raw))
+	}
+	if snapshot.Freshness().TransactionSafeRead {
+		t.Fatalf("market positions snapshot must not be transaction safe")
+	}
+
+	page, err := service.GetMarketPositionsReadModel(ctx, market.ID, markets.Page{Limit: 1, Offset: 1})
+	if err != nil {
+		t.Fatalf("GetMarketPositionsReadModel returned error: %v", err)
+	}
+	if page == nil || len(page.Positions) != 1 {
+		t.Fatalf("expected one paged position, got %+v", page)
+	}
+	if page.Positions[0].Username != raw[1].Username || page.Positions[0].YesSharesOwned != raw[1].YesSharesOwned {
+		t.Fatalf("paged position mismatch:\ngot  %+v\nwant %+v", page.Positions[0], raw[1])
+	}
+
+	if err := service.MarkMarketPositionsSnapshotStale(ctx, market.ID, "bet_accepted"); err != nil {
+		t.Fatalf("MarkMarketPositionsSnapshotStale returned error: %v", err)
+	}
+	stale, err := service.GetMarketPositionsReadModel(ctx, market.ID, markets.Page{Limit: 20})
+	if err != nil {
+		t.Fatalf("GetMarketPositionsReadModel stale returned error: %v", err)
+	}
+	if stale == nil || !stale.Freshness().IsStale {
+		t.Fatalf("expected stale freshness, got %+v", stale)
+	}
+}

--- a/backend/internal/domain/markets/market_resolution.go
+++ b/backend/internal/domain/markets/market_resolution.go
@@ -2,6 +2,8 @@ package markets
 
 import (
 	"context"
+
+	users "socialpredict/internal/domain/users"
 )
 
 // ResolveMarket resolves a market with a given outcome.
@@ -33,5 +35,52 @@ func (s *Service) ResolveMarket(ctx context.Context, marketID int64, resolution 
 		return err
 	}
 
-	return s.resolutionPolicy.Resolve(ctx, s.repo, s.userService, marketID, outcome)
+	if err := s.resolutionPolicy.Resolve(ctx, s.repo, s.userService, marketID, outcome); err != nil {
+		return err
+	}
+
+	return s.applyModeratorWorkProfit(ctx, market, outcome, resolverUsername)
+}
+
+func (s *Service) applyModeratorWorkProfit(ctx context.Context, market *Market, outcome string, stewardUsername string) error {
+	if market == nil || outcome == "N/A" || stewardUsername == "" || s.config.InitialBetFee <= 0 {
+		return nil
+	}
+
+	income, err := s.calculateModeratorWorkFeeIncome(ctx, market.ID)
+	if err != nil {
+		return err
+	}
+	if income <= 0 {
+		return nil
+	}
+
+	return s.userService.ApplyTransaction(ctx, stewardUsername, income, users.TransactionWorkProfit)
+}
+
+func (s *Service) calculateModeratorWorkFeeIncome(ctx context.Context, marketID int64) (int64, error) {
+	bets, err := s.repo.ListBetsForMarket(ctx, marketID)
+	if err != nil {
+		return 0, err
+	}
+	return ModeratorWorkFeeIncome(bets, s.config.InitialBetFee), nil
+}
+
+// ModeratorWorkFeeIncome derives the first-participation fee income for a
+// market from canonical bet history. Positive buy bets count once per unique
+// participant; sell rows and later re-entry do not create additional income.
+func ModeratorWorkFeeIncome(bets []*Bet, initialBetFee int64) int64 {
+	if initialBetFee <= 0 {
+		return 0
+	}
+
+	participants := make(map[string]struct{})
+	for _, bet := range bets {
+		if bet == nil || bet.Amount <= 0 || bet.Username == "" {
+			continue
+		}
+		participants[bet.Username] = struct{}{}
+	}
+
+	return int64(len(participants)) * initialBetFee
 }

--- a/backend/internal/domain/markets/market_stewardship.go
+++ b/backend/internal/domain/markets/market_stewardship.go
@@ -36,6 +36,9 @@ func (s *Service) ReassignMarketSteward(ctx context.Context, marketID int64, new
 	if err != nil {
 		return nil, err
 	}
+	if market.IsResolved() {
+		return nil, ErrInvalidState
+	}
 
 	if err := s.validateAssignableSteward(ctx, newStewardUsername); err != nil {
 		return nil, err

--- a/backend/internal/domain/markets/service.go
+++ b/backend/internal/domain/markets/service.go
@@ -104,6 +104,7 @@ type UserService interface {
 type Config struct {
 	MinimumFutureHours     float64
 	CreateMarketCost       int64
+	InitialBetFee          int64
 	MaximumDebtAllowed     int64
 	GameMode               string
 	MarketApprovalRequired bool

--- a/backend/internal/domain/markets/service_resolve_test.go
+++ b/backend/internal/domain/markets/service_resolve_test.go
@@ -291,7 +291,7 @@ func TestResolveMarketRefundsOnNA(t *testing.T) {
 		}),
 	)
 	userSvc := newResolveUserService()
-	service := markets.NewService(repo, userSvc, newNopClock(marketsTestTime()), markets.Config{})
+	service := markets.NewService(repo, userSvc, newNopClock(marketsTestTime()), markets.Config{InitialBetFee: 3})
 
 	if err := service.ResolveMarket(context.Background(), 1, "N/A", "creator"); err != nil {
 		t.Fatalf("ResolveMarket returned error: %v", err)
@@ -355,6 +355,53 @@ func TestResolveMarketPaysWinners(t *testing.T) {
 
 	if _, err := (&resolveRepo{}).CalculatePayoutPositions(context.Background(), 1); !errors.Is(err, errUnexpectedMarketsTestCall) {
 		t.Fatalf("expected zero-value repo to fail predictably, got %v", err)
+	}
+}
+
+func TestResolveMarketPaysStewardWorkProfitAfterWinnerPayouts(t *testing.T) {
+	market := &markets.Market{
+		ID:              42,
+		CreatorUsername: "creator",
+		StewardUsername: "backup",
+		Status:          "active",
+	}
+	repo := newResolveRepo(
+		withResolveRepoMarket(market),
+		withResolveRepoResolve(func(context.Context, int64, string) error {
+			market.Status = "resolved"
+			return nil
+		}),
+		withResolveRepoPayouts([]*markets.PayoutPosition{
+			{Username: "winner", Value: 120},
+			{Username: "loser", Value: 0},
+		}),
+		withResolveRepoBets([]*markets.Bet{
+			{Username: "alice", Amount: 100},
+			{Username: "alice", Amount: -20},
+			{Username: "bob", Amount: 50},
+			{Username: "bob", Amount: 10},
+			{Username: "creator", Amount: 0},
+		}),
+	)
+	userSvc := newResolveUserService()
+	service := markets.NewService(repo, userSvc, newNopClock(marketsTestTime()), markets.Config{InitialBetFee: 3})
+
+	if err := service.ResolveMarket(context.Background(), 42, "YES", "backup"); err != nil {
+		t.Fatalf("ResolveMarket returned error: %v", err)
+	}
+
+	if len(userSvc.applied) != 2 {
+		t.Fatalf("expected winner payout and work-profit payout, got %d: %+v", len(userSvc.applied), userSvc.applied)
+	}
+
+	winnerCall := userSvc.applied[0]
+	if winnerCall.username != "winner" || winnerCall.amount != 120 || winnerCall.txType != users.TransactionWin {
+		t.Fatalf("unexpected winner payout %+v", winnerCall)
+	}
+
+	workProfitCall := userSvc.applied[1]
+	if workProfitCall.username != "backup" || workProfitCall.amount != 6 || workProfitCall.txType != users.TransactionWorkProfit {
+		t.Fatalf("unexpected work-profit payout %+v", workProfitCall)
 	}
 }
 

--- a/backend/internal/domain/markets/service_stewardship_test.go
+++ b/backend/internal/domain/markets/service_stewardship_test.go
@@ -108,3 +108,23 @@ func TestResolveMarketBlocksSuspendedSteward(t *testing.T) {
 		t.Fatalf("suspended steward resolve error = %v, want ErrUnauthorized", err)
 	}
 }
+
+func TestReassignMarketStewardRejectsResolvedMarket(t *testing.T) {
+	market := &markets.Market{ID: 14, CreatorUsername: "creator", StewardUsername: "creator", Status: markets.MarketStatusResolved, LifecycleStatus: markets.MarketLifecyclePublished}
+	repo := newProjectionRepo(withProjectionRepoMarket(market), func(repo *projectionRepo) {
+		repo.reassignMarketStewardFunc = func(context.Context, int64, string, string, string, string, time.Time) error {
+			t.Fatalf("repository reassign should not be called")
+			return nil
+		}
+	})
+	usersSvc := newNoopUserService(func(service *noopUserService) {
+		service.getPublicUserFunc = func(_ context.Context, username string) (*users.PublicUser, error) {
+			return &users.PublicUser{Username: username, UserType: string(users.UserTypeModerator), ModeratorStatus: users.ModeratorStatusActive}, nil
+		}
+	})
+	service := markets.NewService(repo, usersSvc, newFixedClock(marketsTestTime()), markets.Config{GameMode: "moderator"})
+
+	if _, err := service.ReassignMarketSteward(context.Background(), market.ID, "backup", "admin", "resolved already"); !errors.Is(err, markets.ErrInvalidState) {
+		t.Fatalf("reassign resolved market error = %v, want ErrInvalidState", err)
+	}
+}

--- a/backend/internal/domain/users/service_transactions_test.go
+++ b/backend/internal/domain/users/service_transactions_test.go
@@ -92,9 +92,10 @@ func TestServiceApplyTransaction(t *testing.T) {
 		{"win adds funds", users.TransactionWin, 50, 150, false},
 		{"refund adds funds", users.TransactionRefund, 30, 180, false},
 		{"sale adds funds", users.TransactionSale, 20, 200, false},
-		{"buy subtracts funds", users.TransactionBuy, 40, 160, false},
-		{"fee subtracts funds", users.TransactionFee, 10, 150, false},
-		{"invalid type", "UNKNOWN", 5, 150, true},
+		{"work profit adds funds", users.TransactionWorkProfit, 12, 212, false},
+		{"buy subtracts funds", users.TransactionBuy, 40, 172, false},
+		{"fee subtracts funds", users.TransactionFee, 10, 162, false},
+		{"invalid type", "UNKNOWN", 5, 162, true},
 	}
 
 	ctx := context.Background()

--- a/backend/internal/domain/users/transactions.go
+++ b/backend/internal/domain/users/transactions.go
@@ -14,19 +14,21 @@ type TransactionType = string
 
 // Transaction types supported when adjusting user balances.
 const (
-	TransactionWin    TransactionType = "WIN"
-	TransactionRefund TransactionType = "REFUND"
-	TransactionSale   TransactionType = "SALE"
-	TransactionBuy    TransactionType = "BUY"
-	TransactionFee    TransactionType = "FEE"
+	TransactionWin        TransactionType = "WIN"
+	TransactionRefund     TransactionType = "REFUND"
+	TransactionSale       TransactionType = "SALE"
+	TransactionWorkProfit TransactionType = "WORK_PROFIT"
+	TransactionBuy        TransactionType = "BUY"
+	TransactionFee        TransactionType = "FEE"
 )
 
 var transactionBalanceAdjustments = map[TransactionType]balanceAdjustment{
-	TransactionWin:    balanceAdjustmentFunc(creditBalance),
-	TransactionRefund: balanceAdjustmentFunc(creditBalance),
-	TransactionSale:   balanceAdjustmentFunc(creditBalance),
-	TransactionBuy:    balanceAdjustmentFunc(debitBalance),
-	TransactionFee:    balanceAdjustmentFunc(debitBalance),
+	TransactionWin:        balanceAdjustmentFunc(creditBalance),
+	TransactionRefund:     balanceAdjustmentFunc(creditBalance),
+	TransactionSale:       balanceAdjustmentFunc(creditBalance),
+	TransactionWorkProfit: balanceAdjustmentFunc(creditBalance),
+	TransactionBuy:        balanceAdjustmentFunc(debitBalance),
+	TransactionFee:        balanceAdjustmentFunc(debitBalance),
 }
 
 func creditBalance(balance int64, amount int64) int64 {

--- a/backend/internal/repository/markets/market_positions_snapshots.go
+++ b/backend/internal/repository/markets/market_positions_snapshots.go
@@ -1,0 +1,128 @@
+package markets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	dmarkets "socialpredict/internal/domain/markets"
+	"socialpredict/models"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const marketPositionsSnapshotKind = "market_positions"
+
+// GetMarketPositionsSnapshot returns a display-only market positions snapshot.
+// Missing snapshots are not errors.
+func (r *GormRepository) GetMarketPositionsSnapshot(ctx context.Context, marketID int64) (*dmarkets.MarketPositionsSnapshot, error) {
+	if marketID <= 0 {
+		return nil, dmarkets.ErrInvalidInput
+	}
+	var snapshot models.AnalyticsReadModelSnapshot
+	if err := r.db.WithContext(ctx).
+		Where("snapshot_key = ?", marketPositionsSnapshotStorageKey(marketID)).
+		First(&snapshot).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return modelMarketPositionsSnapshotToDomain(marketID, &snapshot)
+}
+
+// UpsertMarketPositionsSnapshot stores display-only market positions rows.
+func (r *GormRepository) UpsertMarketPositionsSnapshot(ctx context.Context, snapshot dmarkets.MarketPositionsSnapshot) error {
+	if snapshot.MarketID <= 0 {
+		return dmarkets.ErrInvalidInput
+	}
+	dbSnapshot, err := domainMarketPositionsSnapshotToModel(snapshot)
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "snapshot_key"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"kind",
+				"payload_json",
+				"generated_at",
+				"source",
+				"is_stale",
+				"stale_reason",
+				"marked_stale_at",
+				"updated_at",
+			}),
+		}).
+		Create(&dbSnapshot).Error
+}
+
+// MarkMarketPositionsSnapshotStale marks an existing positions display snapshot
+// stale after canonical market activity. Missing snapshots are ignored.
+func (r *GormRepository) MarkMarketPositionsSnapshotStale(ctx context.Context, marketID int64, reason string) error {
+	if marketID <= 0 {
+		return dmarkets.ErrInvalidInput
+	}
+	now := time.Now().UTC()
+	return r.db.WithContext(ctx).
+		Model(&models.AnalyticsReadModelSnapshot{}).
+		Where("snapshot_key = ?", marketPositionsSnapshotStorageKey(marketID)).
+		Updates(map[string]interface{}{
+			"is_stale":        true,
+			"stale_reason":    reason,
+			"marked_stale_at": now,
+			"updated_at":      now,
+		}).Error
+}
+
+func marketPositionsSnapshotStorageKey(marketID int64) string {
+	return fmt.Sprintf("market_positions:%d", marketID)
+}
+
+func domainMarketPositionsSnapshotToModel(snapshot dmarkets.MarketPositionsSnapshot) (models.AnalyticsReadModelSnapshot, error) {
+	payload, err := json.Marshal(snapshot.Positions.Normalize())
+	if err != nil {
+		return models.AnalyticsReadModelSnapshot{}, err
+	}
+	source := snapshot.Source
+	if source == "" {
+		source = "read_model"
+	}
+	return models.AnalyticsReadModelSnapshot{
+		SnapshotKey:   marketPositionsSnapshotStorageKey(snapshot.MarketID),
+		Kind:          marketPositionsSnapshotKind,
+		PayloadJSON:   string(payload),
+		GeneratedAt:   snapshot.GeneratedAt,
+		Source:        source,
+		IsStale:       snapshot.IsStale,
+		StaleReason:   snapshot.StaleReason,
+		MarkedStaleAt: timeFromPointer(snapshot.MarkedStaleAt),
+	}, nil
+}
+
+func modelMarketPositionsSnapshotToDomain(marketID int64, snapshot *models.AnalyticsReadModelSnapshot) (*dmarkets.MarketPositionsSnapshot, error) {
+	if snapshot == nil {
+		return nil, nil
+	}
+	positions := dmarkets.MarketPositions{}
+	if snapshot.PayloadJSON != "" {
+		if err := json.Unmarshal([]byte(snapshot.PayloadJSON), &positions); err != nil {
+			return nil, err
+		}
+	}
+	return &dmarkets.MarketPositionsSnapshot{
+		MarketID:            marketID,
+		Positions:           positions.Normalize(),
+		GeneratedAt:         snapshot.GeneratedAt,
+		Source:              snapshot.Source,
+		TransactionSafeRead: false,
+		IsStale:             snapshot.IsStale,
+		StaleReason:         snapshot.StaleReason,
+		MarkedStaleAt:       timePointerFromValue(snapshot.MarkedStaleAt),
+	}, nil
+}
+
+var _ dmarkets.MarketPositionsSnapshotRepository = (*GormRepository)(nil)

--- a/frontend/src/components/charts/MarketChart.jsx
+++ b/frontend/src/components/charts/MarketChart.jsx
@@ -21,7 +21,7 @@ const MarketChart = ({
     let dataPoints = [];
     const now = new Date();
     const closeDate = closeDateTime ? new Date(closeDateTime) : null;
-    const isMarketClosed = closeDate && closeDate < now;
+    const isMarketClosed = closeDate && closeDate <= now;
 
     if (data && Array.isArray(data)) {
       // Filter out any probability changes that occurred after the close date for closed markets
@@ -35,8 +35,19 @@ const MarketChart = ({
       }));
     }
 
-    // For active markets: append current probability with current timestamp
-    // For closed markets: don't extend beyond close date
+    if (currentProbability !== undefined && currentProbability !== null && isMarketClosed && closeDate) {
+      const lastPoint = dataPoints[dataPoints.length - 1];
+      const lastY = lastPoint?.y ?? (isInverse ? 1 - currentProbability : currentProbability);
+      if (!lastPoint || lastPoint.x.getTime() < closeDate.getTime()) {
+        dataPoints.push({
+          x: closeDate,
+          y: lastY,
+        });
+      }
+    }
+
+    // For active markets: append current probability with current timestamp.
+    // Closed markets end at the close date above and never extend to now.
     if (currentProbability !== undefined && currentProbability !== null && !isMarketClosed) {
       dataPoints.push({
         x: now,

--- a/frontend/src/components/layouts/activity/leaderboard/LeaderboardActivity.jsx
+++ b/frontend/src/components/layouts/activity/leaderboard/LeaderboardActivity.jsx
@@ -23,16 +23,17 @@ const paginationButtonClass = [
     'disabled:opacity-60',
 ].join(' ');
 
-const LeaderboardActivity = ({ marketId, market }) => {
+const LeaderboardActivity = ({ marketId, market, refreshTrigger }) => {
     const pageSize = 20;
     const [leaderboard, setLeaderboard] = useState([]);
+    const [freshness, setFreshness] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [page, setPage] = useState(0);
 
     useEffect(() => {
         setPage(0);
-    }, [marketId]);
+    }, [marketId, refreshTrigger]);
 
     useEffect(() => {
         const fetchLeaderboard = async () => {
@@ -44,13 +45,17 @@ const LeaderboardActivity = ({ marketId, market }) => {
                     const data = unwrapApiResponse(await response.json());
                     const rows = Array.isArray(data?.leaderboard) ? data.leaderboard : [];
                     setLeaderboard(rows);
+                    setFreshness(data?.freshness || null);
+                    setError(null);
                 } else {
                     console.error('Error fetching leaderboard:', response.statusText);
                     setError('Failed to load leaderboard data');
+                    setFreshness(null);
                 }
             } catch (err) {
                 console.error('Error fetching leaderboard:', err);
                 setError('Failed to load leaderboard data');
+                setFreshness(null);
             } finally {
                 setLoading(false);
             }
@@ -59,7 +64,11 @@ const LeaderboardActivity = ({ marketId, market }) => {
         if (marketId) {
             fetchLeaderboard();
         }
-    }, [marketId, page]);
+    }, [marketId, page, refreshTrigger]);
+
+    const freshnessLabel = freshness?.generatedAt
+        ? new Date(freshness.generatedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' })
+        : null;
 
     const formatCurrency = (amount) => {
         return amount.toLocaleString();
@@ -123,8 +132,15 @@ const LeaderboardActivity = ({ marketId, market }) => {
     return (
         <div className="p-4">
             <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div className="text-xs uppercase tracking-[0.16em] text-gray-400">
-                    Showing leaderboard page {page + 1}
+                <div>
+                    <div className="text-xs uppercase tracking-[0.16em] text-gray-400">
+                        Showing leaderboard page {page + 1}
+                    </div>
+                    {freshnessLabel && (
+                        <div className="mt-1 text-xs text-gray-500">
+                            Leaderboard generated at {freshnessLabel}. Trade confirmations remain authoritative.
+                        </div>
+                    )}
                 </div>
                 <div className="flex gap-2">
                     <button

--- a/frontend/src/components/layouts/activity/positions/PositionsActivity.jsx
+++ b/frontend/src/components/layouts/activity/positions/PositionsActivity.jsx
@@ -40,6 +40,7 @@ const paginationButtonClass = [
 const PositionsActivityLayout = ({ marketId, market, refreshTrigger }) => {
   const pageSize = 20;
   const [positions, setPositions] = useState([]);
+  const [freshness, setFreshness] = useState(null);
   const [page, setPage] = useState(0);
   const [hasNextPage, setHasNextPage] = useState(false);
   const { token } = useAuth();
@@ -52,6 +53,7 @@ const PositionsActivityLayout = ({ marketId, market, refreshTrigger }) => {
     const fetchPositions = async () => {
       if (!token) {
         setPositions([]);
+        setFreshness(null);
         setHasNextPage(false);
         return;
       }
@@ -66,22 +68,32 @@ const PositionsActivityLayout = ({ marketId, market, refreshTrigger }) => {
 
       if (!response.ok) {
         setPositions([]);
+        setFreshness(null);
         setHasNextPage(false);
         return;
       }
 
       const rawData = unwrapApiResponse(await response.json());
-      const filteredSorted = rawData
+      const positionRows = Array.isArray(rawData?.positions)
+        ? rawData.positions
+        : Array.isArray(rawData)
+          ? rawData
+          : [];
+      const filteredSorted = positionRows
         .filter(user => user.noSharesOwned > 0 || user.yesSharesOwned > 0)
         .sort((a, b) => (b.noSharesOwned + b.yesSharesOwned) - (a.noSharesOwned + a.yesSharesOwned));
 
       setPositions(filteredSorted);
-      setHasNextPage(rawData.length === pageSize);
+      setFreshness(rawData?.freshness || null);
+      setHasNextPage(positionRows.length === pageSize);
     };
 
     fetchPositions();
   }, [marketId, refreshTrigger, token, page]);
 
+  const freshnessLabel = freshness?.generatedAt
+    ? new Date(freshness.generatedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' })
+    : null;
   const labels = market ? getMarketLabels(market) : { yes: "YES", no: "NO" };
   const pageStart = page * pageSize;
   const canPageBack = page > 0;
@@ -90,8 +102,15 @@ const PositionsActivityLayout = ({ marketId, market, refreshTrigger }) => {
   return (
     <div className="p-4">
       <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="text-xs uppercase tracking-[0.16em] text-gray-400">
-          Showing positions page {page + 1}{positions.length ? ` (${pageStart + 1}-${pageStart + positions.length})` : ''}
+        <div>
+          <div className="text-xs uppercase tracking-[0.16em] text-gray-400">
+            Showing positions page {page + 1}{positions.length ? ` (${pageStart + 1}-${pageStart + positions.length})` : ''}
+          </div>
+          {freshnessLabel && (
+            <div className="mt-1 text-xs text-gray-500">
+              Positions generated at {freshnessLabel}. Trade confirmations remain authoritative.
+            </div>
+          )}
         </div>
         <div className="flex gap-2">
           <button

--- a/frontend/src/components/tables/MarketsByStatusTable.jsx
+++ b/frontend/src/components/tables/MarketsByStatusTable.jsx
@@ -214,7 +214,8 @@ function MarketsByStatusTable({ status, limit = DEFAULT_LIMIT, tagSlug = '', dis
       }
 
       const data = await response.json();
-      const rawMarkets = Array.isArray(data.markets) ? data.markets : [];
+      const payload = data?.result && typeof data.result === 'object' ? data.result : data;
+      const rawMarkets = Array.isArray(payload.markets) ? payload.markets : [];
       const normalized = rawMarkets
         .map(normalizeMarketOverview)
         .filter((item) => item !== null);

--- a/frontend/src/components/tabs/ActivityTabs.jsx
+++ b/frontend/src/components/tabs/ActivityTabs.jsx
@@ -8,7 +8,7 @@ const ActivityTabs = ({ marketId, market, refreshTrigger }) => {
     const tabsData = [
         { label: 'Bets', content: <BetsActivityLayout marketId={marketId} refreshTrigger={refreshTrigger} /> },
         { label: 'Positions', content: <PositionsActivityLayout marketId={marketId} market={market} refreshTrigger={refreshTrigger} /> },
-        { label: 'Leaderboard', content: <LeaderboardActivity marketId={marketId} market={market} /> },
+        { label: 'Leaderboard', content: <LeaderboardActivity marketId={marketId} market={market} refreshTrigger={refreshTrigger} /> },
         { label: 'Comments', content: <div>Comments Go here...</div> },
     ];
 

--- a/frontend/src/hooks/useMarketDetails.jsx
+++ b/frontend/src/hooks/useMarketDetails.jsx
@@ -39,6 +39,10 @@ const normalizeProbabilityChanges = (raw) => {
     .filter((item) => item !== null);
 };
 
+const unwrapApiEnvelope = (data) => (
+  data?.result && typeof data.result === 'object' ? data.result : data
+);
+
 const normalizeMarketTag = (tag) => {
   if (!tag || typeof tag !== 'object') {
     return null;
@@ -234,14 +238,16 @@ export const useMarketDetails = () => {
         if (!detailsResponse.ok) {
           throw new Error('Failed to fetch market data');
         }
-        const data = await detailsResponse.json();
+        const data = unwrapApiEnvelope(await detailsResponse.json());
         let normalized = normalizeMarketDetails(data);
         if (summaryResponse?.ok) {
-          const summary = normalizeMarketDetails(await summaryResponse.json());
+          const summary = normalizeMarketDetails(unwrapApiEnvelope(await summaryResponse.json()));
           if (summary) {
             normalized = {
               ...normalized,
-              probabilityChanges: summary.probabilityChanges,
+              probabilityChanges: summary.probabilityChanges.length > 0
+                ? summary.probabilityChanges
+                : normalized.probabilityChanges,
               numUsers: summary.numUsers,
               totalVolume: summary.totalVolume,
               marketDust: summary.marketDust,


### PR DESCRIPTION
## Summary
- Add Feature 12 docs for stateless moderator/steward work-profit payout and financial reporting.
- Credit the current steward/resolver with one initial-entry fee per unique positive-bet participant after non-N/A resolution, after ordinary winner payouts.
- Derive user financial workProfits from resolved markets stewarded by the user; subtract proposal/create cost only when the steward was also the creator.
- Block steward reassignment after resolution so stateless steward-at-resolution financial derivation remains stable.
- Update retained participation-fee metrics so fees redistributed as steward work income are not double-counted as system-retained fees.

## Design boundaries
- No new database tables or columns.
- Payout decisions use canonical bet history, not read-model snapshots.
- Financial read models remain display-only.
- Work-profit attribution goes to the current steward who governs resolution, not automatically to the original market creator.

## Tests
- go test ./internal/domain/markets ./internal/domain/analytics ./internal/domain/users ./internal/app