### PR TITLE
Fix sale dust net proceeds accounting

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -5249,11 +5249,15 @@ components:
         saleValue:
           type: integer
           format: int64
-          description: Actual credits deposited after whole-share rounding.
+          description: Gross whole-share sale value before dust is retained.
         dust:
           type: integer
           format: int64
-          description: Requested credits minus actual saleValue, retained by the market due to rounding.
+          description: Dust fee retained by the market due to whole-share rounding.
+        netProceeds:
+          type: integer
+          format: int64
+          description: Actual credits deposited to the seller wallet after subtracting dust from saleValue.
         outcome:
           type: string
         transactionAt:
@@ -5280,11 +5284,15 @@ components:
         saleValue:
           type: integer
           format: int64
-          description: Credits that would be deposited after whole-share rounding.
+          description: Gross whole-share sale value before dust would be retained.
         dust:
           type: integer
           format: int64
           description: Capped rounding remainder retained by the market if submitted.
+        netProceeds:
+          type: integer
+          format: int64
+          description: Credits that would be deposited to the seller wallet after subtracting dust from saleValue.
         maxDust:
           type: integer
           format: int64

--- a/backend/handlers/bets/README_SELL.md
+++ b/backend/handlers/bets/README_SELL.md
@@ -7,7 +7,7 @@ POST /v0/sell
 { marketId, outcome, amount }
 ```
 
-`amount` is the number of credits the user is requesting from the sale. The sell domain calculates the current integer value per share, rounds the sale down to whole shares, credits the user with the actual sale value, and reports any remainder as transaction-time dust.
+`amount` is the number of credits the user is requesting from the sale. The sell domain calculates the current integer value per share, rounds the sale down to whole shares, retains any dust fee, credits the user with net proceeds, and reports the retained remainder as transaction-time dust.
 
 ```text
 valuePerShare = position.Value / sharesOwned
@@ -15,6 +15,7 @@ sharesSold    = requestedCredits / valuePerShare
 saleValue     = sharesSold * valuePerShare
 rawDust       = requestedCredits - saleValue
 dust          = min(rawDust, maxDustPerSale)
+netProceeds   = saleValue - dust
 ```
 
 If the raw remainder exceeds `economics.betting.maxDustPerSale` from `setup.yaml`, the executable Sale Order is rounded down to the nearest allowed value. With the default `maxDustPerSale: 1`, an over-remainder sale is still allowed, but the charged dust fee is capped at `1`.
@@ -37,6 +38,7 @@ The quote endpoint is read-only. It uses the same backend sale calculator as
   "sharesSold": 3,
   "saleValue": 30,
   "dust": 1,
+  "netProceeds": 29,
   "maxDust": 1,
   "valuePerShare": 10,
   "dustCapCoverage": 0.2,
@@ -61,7 +63,8 @@ amount = -sharesSold
 That keeps dust stateless:
 
 - `amount` remains the share/position ledger entry used by the market math.
-- User balance is credited by `saleValue`, not the originally requested credits.
+- User balance is credited by `netProceeds`, not the gross `saleValue` or the originally requested credits.
+- `saleValue` remains the gross whole-share sale value before dust is retained.
 - The transaction response reports `dust`, but dust is not persisted as a separate bet column.
 
 ## API Response
@@ -72,7 +75,8 @@ A successful sale returns:
 {
   "sharesSold": 2,
   "saleValue": 20,
-  "dust": 1
+  "dust": 1,
+  "netProceeds": 19
 }
 ```
 

--- a/backend/handlers/bets/dto/dto_test.go
+++ b/backend/handlers/bets/dto/dto_test.go
@@ -38,6 +38,7 @@ func TestSellBetDTOJSONRoundTrip(t *testing.T) {
 		SharesSold:    5,
 		SaleValue:     125,
 		Dust:          1,
+		NetProceeds:   124,
 		Outcome:       "NO",
 		TransactionAt: ts,
 	}

--- a/backend/handlers/bets/dto/sell.go
+++ b/backend/handlers/bets/dto/sell.go
@@ -16,6 +16,7 @@ type SellBetResponse struct {
 	SharesSold    int64     `json:"sharesSold"`
 	SaleValue     int64     `json:"saleValue"`
 	Dust          int64     `json:"dust"`
+	NetProceeds   int64     `json:"netProceeds"`
 	Outcome       string    `json:"outcome"`
 	TransactionAt time.Time `json:"transactionAt"`
 }
@@ -29,6 +30,7 @@ type SellQuoteResponse struct {
 	SharesSold        int64     `json:"sharesSold"`
 	SaleValue         int64     `json:"saleValue"`
 	Dust              int64     `json:"dust"`
+	NetProceeds       int64     `json:"netProceeds"`
 	MaxDust           int64     `json:"maxDust"`
 	ValuePerShare     int64     `json:"valuePerShare"`
 	DustCapCoverage   float64   `json:"dustCapCoverage"`

--- a/backend/handlers/bets/selling/sellpositionhandler.go
+++ b/backend/handlers/bets/selling/sellpositionhandler.go
@@ -148,6 +148,7 @@ func writeSellResponse(w http.ResponseWriter, result *bets.SellResult) {
 		SharesSold:    result.SharesSold,
 		SaleValue:     result.SaleValue,
 		Dust:          result.Dust,
+		NetProceeds:   result.NetProceeds,
 		Outcome:       result.Outcome,
 		TransactionAt: result.TransactionAt,
 	}
@@ -164,6 +165,7 @@ func writeSellQuoteResponse(w http.ResponseWriter, result *bets.SellQuoteResult)
 		SharesSold:        result.SharesSold,
 		SaleValue:         result.SaleValue,
 		Dust:              result.Dust,
+		NetProceeds:       result.NetProceeds,
 		MaxDust:           result.MaxDust,
 		ValuePerShare:     result.ValuePerShare,
 		DustCapCoverage:   result.DustCapCoverage,

--- a/backend/handlers/bets/selling/sellpositionhandler_test.go
+++ b/backend/handlers/bets/selling/sellpositionhandler_test.go
@@ -143,6 +143,7 @@ func TestSellPositionHandler_Success(t *testing.T) {
 		SharesSold:    3,
 		SaleValue:     60,
 		Dust:          5,
+		NetProceeds:   55,
 		Outcome:       "YES",
 		TransactionAt: time.Now(),
 	}}
@@ -171,7 +172,7 @@ func TestSellPositionHandler_Success(t *testing.T) {
 	if !resp.OK {
 		t.Fatalf("expected ok=true, got false")
 	}
-	if resp.Result.SharesSold != 3 || resp.Result.SaleValue != 60 || resp.Result.Dust != 5 {
+	if resp.Result.SharesSold != 3 || resp.Result.SaleValue != 60 || resp.Result.Dust != 5 || resp.Result.NetProceeds != 55 {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
 }
@@ -187,6 +188,7 @@ func TestSellPositionHandler_InvalidatesReadModelsAfterSuccess(t *testing.T) {
 		SharesSold:    2,
 		SaleValue:     10,
 		Dust:          1,
+		NetProceeds:   9,
 		TransactionAt: time.Now(),
 	}}
 	invalidator := &fakeReadModelInvalidator{}
@@ -219,6 +221,7 @@ func TestSellQuoteHandler_Success(t *testing.T) {
 		SharesSold:       3,
 		SaleValue:        30,
 		Dust:             2,
+		NetProceeds:      28,
 		MaxDust:          2,
 		ValuePerShare:    10,
 		DustCapCoverage:  0.3,
@@ -248,7 +251,7 @@ func TestSellQuoteHandler_Success(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if !resp.Result.Allowed || resp.Result.Dust != 2 || resp.Result.MaxDust != 2 || resp.Result.ValuePerShare != 10 {
+	if !resp.Result.Allowed || resp.Result.Dust != 2 || resp.Result.NetProceeds != 28 || resp.Result.MaxDust != 2 || resp.Result.ValuePerShare != 10 {
 		t.Fatalf("unexpected quote response: %+v", resp.Result)
 	}
 	if len(resp.Result.SuggestedAmounts) != 6 {
@@ -266,6 +269,7 @@ func TestSellQuoteHandler_RoundedDustQuoteReturnsAllowedPreview(t *testing.T) {
 		SharesSold:       3,
 		SaleValue:        30,
 		Dust:             2,
+		NetProceeds:      28,
 		MaxDust:          2,
 		ValuePerShare:    10,
 		DustCapCoverage:  0.3,
@@ -290,7 +294,7 @@ func TestSellQuoteHandler_RoundedDustQuoteReturnsAllowedPreview(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if !resp.Result.Allowed || resp.Result.DustCapExceeded || resp.Result.DustCapExceededBy != 0 || resp.Result.Dust != 2 {
+	if !resp.Result.Allowed || resp.Result.DustCapExceeded || resp.Result.DustCapExceededBy != 0 || resp.Result.Dust != 2 || resp.Result.NetProceeds != 28 {
 		t.Fatalf("unexpected rounded quote: %+v", resp.Result)
 	}
 }

--- a/backend/internal/domain/bets/bet_sell.go
+++ b/backend/internal/domain/bets/bet_sell.go
@@ -83,7 +83,7 @@ func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcom
 
 		now := s.clock.Now()
 		bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
-		if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, sale.SaleValue); err != nil {
+		if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, netSaleProceeds(sale)); err != nil {
 			return err
 		}
 
@@ -206,6 +206,14 @@ func calculateDust(requested, saleValue int64) int64 {
 		return 0
 	}
 	return dust
+}
+
+func netSaleProceeds(sale SaleQuote) int64 {
+	net := sale.SaleValue - sale.Dust
+	if net < 0 {
+		return 0
+	}
+	return net
 }
 
 func validateDustCap(dust int64, cap int64) error {

--- a/backend/internal/domain/bets/bet_support.go
+++ b/backend/internal/domain/bets/bet_support.go
@@ -114,8 +114,8 @@ type betLedger struct {
 	users TransactionRecorder
 }
 
-func (l betLedger) CreditSale(ctx context.Context, bet *boundary.Bet, saleValue int64) error {
-	if err := l.users.ApplyTransaction(ctx, bet.Username, saleValue, dusers.TransactionSale); err != nil {
+func (l betLedger) CreditSale(ctx context.Context, bet *boundary.Bet, netProceeds int64) error {
+	if err := l.users.ApplyTransaction(ctx, bet.Username, netProceeds, dusers.TransactionSale); err != nil {
 		return err
 	}
 	return l.repo.Create(ctx, bet)

--- a/backend/internal/domain/bets/models.go
+++ b/backend/internal/domain/bets/models.go
@@ -96,6 +96,7 @@ type SellResult struct {
 	SharesSold    int64
 	SaleValue     int64
 	Dust          int64
+	NetProceeds   int64
 	Outcome       string
 	TransactionAt time.Time
 }
@@ -111,6 +112,7 @@ func buildSellResult(target *SellResult, req SellRequest, outcome string, sale S
 		SharesSold:    sale.SharesToSell,
 		SaleValue:     sale.SaleValue,
 		Dust:          sale.Dust,
+		NetProceeds:   netSaleProceeds(sale),
 		Outcome:       outcome,
 		TransactionAt: transactionAt,
 	}
@@ -131,6 +133,7 @@ type SellQuoteResult struct {
 	SharesSold        int64
 	SaleValue         int64
 	Dust              int64
+	NetProceeds       int64
 	MaxDust           int64
 	ValuePerShare     int64
 	DustCapCoverage   float64
@@ -160,6 +163,7 @@ func buildSellQuoteResult(target *SellQuoteResult, req SellRequest, outcome stri
 		SharesSold:        sale.SharesToSell,
 		SaleValue:         sale.SaleValue,
 		Dust:              sale.Dust,
+		NetProceeds:       netSaleProceeds(sale),
 		MaxDust:           maxDust,
 		ValuePerShare:     sale.ValuePerShare,
 		DustCapCoverage:   dustCapCoverage(maxDust, sale.ValuePerShare),

--- a/backend/internal/domain/bets/service.go
+++ b/backend/internal/domain/bets/service.go
@@ -106,7 +106,7 @@ type BalanceGuard interface {
 
 // BetLedger encapsulates synchronous persistence and user accounting for non-placement bet flows.
 type BetLedger interface {
-	CreditSale(ctx context.Context, bet *boundary.Bet, saleValue int64) error
+	CreditSale(ctx context.Context, bet *boundary.Bet, netProceeds int64) error
 }
 
 // Clock allows time to be mocked in tests.

--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -466,7 +466,7 @@ func TestServiceSell_Succeeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Sell returned error: %v", err)
 	}
-	if res.SharesSold != 2 || res.SaleValue != 20 || res.Dust != 0 {
+	if res.SharesSold != 2 || res.SaleValue != 20 || res.Dust != 0 || res.NetProceeds != 20 {
 		t.Fatalf("unexpected sell result: %+v", res)
 	}
 	if !res.TransactionAt.Equal(now) {
@@ -484,7 +484,7 @@ func TestServiceSell_Succeeds(t *testing.T) {
 	}
 }
 
-func TestServiceSell_DustAtCapCreditsSaleValue(t *testing.T) {
+func TestServiceSell_DustAtCapCreditsNetProceeds(t *testing.T) {
 	now := serviceTestTime()
 	fixture, svc := newServiceFixture(
 		now,
@@ -498,13 +498,13 @@ func TestServiceSell_DustAtCapCreditsSaleValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Sell returned error: %v", err)
 	}
-	if res.SharesSold != 3 || res.SaleValue != 30 || res.Dust != 2 {
+	if res.SharesSold != 3 || res.SaleValue != 30 || res.Dust != 2 || res.NetProceeds != 28 {
 		t.Fatalf("unexpected sell result: %+v", res)
 	}
 	if fixture.repo.created == nil || fixture.repo.created.Amount != -3 {
 		t.Fatalf("unexpected stored sale bet: %+v", fixture.repo.created)
 	}
-	if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != 30 {
+	if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != 28 {
 		t.Fatalf("unexpected user transaction: %+v", fixture.users.calls)
 	}
 }
@@ -542,7 +542,7 @@ func TestServiceSell_RoundsDustDownToCap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Sell returned error: %v", err)
 	}
-	if result.SharesSold != 3 || result.SaleValue != 30 || result.Dust != 2 {
+	if result.SharesSold != 3 || result.SaleValue != 30 || result.Dust != 2 || result.NetProceeds != 28 {
 		t.Fatalf("unexpected rounded sale result: %+v", result)
 	}
 	if fixture.repo.created == nil || fixture.repo.created.Amount != -3 {
@@ -564,7 +564,7 @@ func TestServiceQuoteSell_AllowsDustAtCapWithoutMutatingState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("QuoteSell returned error: %v", err)
 	}
-	if !quote.Allowed || quote.SaleValue != 30 || quote.Dust != 2 || quote.MaxDust != 2 || quote.ValuePerShare != 10 {
+	if !quote.Allowed || quote.SaleValue != 30 || quote.Dust != 2 || quote.NetProceeds != 28 || quote.MaxDust != 2 || quote.ValuePerShare != 10 {
 		t.Fatalf("unexpected quote: %+v", quote)
 	}
 	if quote.DustCapCoverage != 0.3 {
@@ -595,7 +595,7 @@ func TestServiceQuoteSell_OverCapRoundsPreviewToCap(t *testing.T) {
 	if !quote.Allowed || quote.DustCapExceeded || quote.DustCapExceededBy != 0 {
 		t.Fatalf("expected rounded allowed quote, got %+v", quote)
 	}
-	if quote.SaleValue != 30 || quote.Dust != 2 || quote.MaxDust != 2 {
+	if quote.SaleValue != 30 || quote.Dust != 2 || quote.NetProceeds != 28 || quote.MaxDust != 2 {
 		t.Fatalf("unexpected over-cap quote amounts: %+v", quote)
 	}
 	for _, want := range []int64{30, 31, 32} {
@@ -747,8 +747,9 @@ func TestServiceSell_DustScenarioMatrix(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Sell returned error: %v", err)
 			}
-			if result.SharesSold != tc.wantShares || result.SaleValue != tc.wantSaleValue || result.Dust != tc.wantDust {
-				t.Fatalf("unexpected result: got %+v, want shares=%d saleValue=%d dust=%d", result, tc.wantShares, tc.wantSaleValue, tc.wantDust)
+			wantNetProceeds := tc.wantSaleValue - tc.wantDust
+			if result.SharesSold != tc.wantShares || result.SaleValue != tc.wantSaleValue || result.Dust != tc.wantDust || result.NetProceeds != wantNetProceeds {
+				t.Fatalf("unexpected result: got %+v, want shares=%d saleValue=%d dust=%d netProceeds=%d", result, tc.wantShares, tc.wantSaleValue, tc.wantDust, wantNetProceeds)
 			}
 			if fixture.repo.created == nil {
 				t.Fatal("expected stored sale bet")
@@ -756,7 +757,7 @@ func TestServiceSell_DustScenarioMatrix(t *testing.T) {
 			if fixture.repo.created.Amount != -tc.wantShares {
 				t.Fatalf("unexpected stored sale bet: %+v", fixture.repo.created)
 			}
-			if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != tc.wantSaleValue {
+			if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != wantNetProceeds {
 				t.Fatalf("unexpected user ledger calls: %+v", fixture.users.calls)
 			}
 		})
@@ -839,8 +840,9 @@ func TestServiceSell_MarketHistorySaleOrderDustScenarios(t *testing.T) {
 			if err != nil {
 				t.Fatalf("QuoteSell returned error: %v", err)
 			}
-			if !quote.Allowed || quote.RequestedCredits != tc.wantExecutableOrder || quote.SharesSold != tc.wantShares || quote.SaleValue != tc.wantSaleValue || quote.Dust != tc.wantDust {
-				t.Fatalf("unexpected quote: got %+v, want order=%d shares=%d saleValue=%d dust=%d", quote, tc.wantExecutableOrder, tc.wantShares, tc.wantSaleValue, tc.wantDust)
+			wantNetProceeds := tc.wantSaleValue - tc.wantDust
+			if !quote.Allowed || quote.RequestedCredits != tc.wantExecutableOrder || quote.SharesSold != tc.wantShares || quote.SaleValue != tc.wantSaleValue || quote.Dust != tc.wantDust || quote.NetProceeds != wantNetProceeds {
+				t.Fatalf("unexpected quote: got %+v, want order=%d shares=%d saleValue=%d dust=%d netProceeds=%d", quote, tc.wantExecutableOrder, tc.wantShares, tc.wantSaleValue, tc.wantDust, wantNetProceeds)
 			}
 			if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
 				t.Fatalf("quote should not mutate state: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
@@ -855,13 +857,13 @@ func TestServiceSell_MarketHistorySaleOrderDustScenarios(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Sell returned error: %v", err)
 			}
-			if result.SharesSold != tc.wantShares || result.SaleValue != tc.wantSaleValue || result.Dust != tc.wantDust {
-				t.Fatalf("unexpected sale result: got %+v, want shares=%d saleValue=%d dust=%d", result, tc.wantShares, tc.wantSaleValue, tc.wantDust)
+			if result.SharesSold != tc.wantShares || result.SaleValue != tc.wantSaleValue || result.Dust != tc.wantDust || result.NetProceeds != wantNetProceeds {
+				t.Fatalf("unexpected sale result: got %+v, want shares=%d saleValue=%d dust=%d netProceeds=%d", result, tc.wantShares, tc.wantSaleValue, tc.wantDust, wantNetProceeds)
 			}
 			if fixture.repo.created == nil || fixture.repo.created.Amount != -tc.wantShares || fixture.repo.created.Outcome != "YES" {
 				t.Fatalf("unexpected stored sale bet: %+v", fixture.repo.created)
 			}
-			if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != tc.wantSaleValue {
+			if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != wantNetProceeds {
 				t.Fatalf("unexpected user ledger calls: %+v", fixture.users.calls)
 			}
 		})
@@ -964,8 +966,9 @@ func TestServiceSell_ActualMixedMarketHistorySaleOrderDustScenarios(t *testing.T
 			if err != nil {
 				t.Fatalf("QuoteSell returned error: %v", err)
 			}
-			if !quote.Allowed || quote.RequestedCredits != tc.wantExecutableOrder || quote.SharesSold != tc.wantShares || quote.SaleValue != tc.wantSaleValue || quote.Dust != tc.wantDust {
-				t.Fatalf("unexpected quote: got %+v, want order=%d shares=%d saleValue=%d dust=%d", quote, tc.wantExecutableOrder, tc.wantShares, tc.wantSaleValue, tc.wantDust)
+			wantNetProceeds := tc.wantSaleValue - tc.wantDust
+			if !quote.Allowed || quote.RequestedCredits != tc.wantExecutableOrder || quote.SharesSold != tc.wantShares || quote.SaleValue != tc.wantSaleValue || quote.Dust != tc.wantDust || quote.NetProceeds != wantNetProceeds {
+				t.Fatalf("unexpected quote: got %+v, want order=%d shares=%d saleValue=%d dust=%d netProceeds=%d", quote, tc.wantExecutableOrder, tc.wantShares, tc.wantSaleValue, tc.wantDust, wantNetProceeds)
 			}
 			if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
 				t.Fatalf("quote should not mutate state: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
@@ -980,13 +983,13 @@ func TestServiceSell_ActualMixedMarketHistorySaleOrderDustScenarios(t *testing.T
 			if err != nil {
 				t.Fatalf("Sell returned error: %v", err)
 			}
-			if result.SharesSold != tc.wantShares || result.SaleValue != tc.wantSaleValue || result.Dust != tc.wantDust {
-				t.Fatalf("unexpected sale result: got %+v, want shares=%d saleValue=%d dust=%d", result, tc.wantShares, tc.wantSaleValue, tc.wantDust)
+			if result.SharesSold != tc.wantShares || result.SaleValue != tc.wantSaleValue || result.Dust != tc.wantDust || result.NetProceeds != wantNetProceeds {
+				t.Fatalf("unexpected sale result: got %+v, want shares=%d saleValue=%d dust=%d netProceeds=%d", result, tc.wantShares, tc.wantSaleValue, tc.wantDust, wantNetProceeds)
 			}
 			if fixture.repo.created == nil || fixture.repo.created.Amount != -tc.wantShares || fixture.repo.created.Outcome != "YES" {
 				t.Fatalf("unexpected stored sale bet: %+v", fixture.repo.created)
 			}
-			if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != tc.wantSaleValue {
+			if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != wantNetProceeds {
 				t.Fatalf("unexpected user ledger calls: %+v", fixture.users.calls)
 			}
 		})

--- a/frontend/src/components/layouts/trade/SellSharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.jsx
@@ -289,7 +289,8 @@ const defaultSaleAmount = (normalized) => {
 
 const buildSaleSuccessMessage = (data) => {
     const dust = Number(data?.dust) || 0;
-    const base = `Sale successful! Sold ${data.sharesSold} shares and credited ${data.saleValue} credits.`;
+    const netProceeds = Number(data?.netProceeds ?? data?.saleValue) || 0;
+    const base = `Sale successful! Sold ${data.sharesSold} shares and credited ${netProceeds} credits.`;
     if (dust <= 0) {
         return base;
     }
@@ -336,7 +337,7 @@ const SaleQuotePanel = ({ quote, quoteError, isLoading, selectedOutcome, onSelec
             </div>
             <div className="grid gap-2 sm:grid-cols-2">
                 <QuoteMetric label="Sale order" value={quote.requestedCredits} />
-                <QuoteMetric label="Credits received" value={quote.saleValue} />
+                <QuoteMetric label="Credits received" value={quote.netProceeds ?? quote.saleValue} />
                 <QuoteMetric label="Shares sold" value={quote.sharesSold} />
                 <QuoteMetric label="Dust fee" value={`${quote.dust} / ${quote.maxDust}`} />
                 <QuoteMetric label="Value per share" value={quote.valuePerShare} />


### PR DESCRIPTION
## Summary
- Credit seller wallets with net sale proceeds after subtracting retained dust
- Add explicit netProceeds fields to sell and sell quote API responses
- Update frontend sale preview/success copy to show actual credited proceeds
- Refresh OpenAPI and sell-flow documentation so saleValue is gross and netProceeds is wallet credit

## Testing
- cd backend && go test ./...
- cd frontend && npm run build

## Notes
This is intentionally stacked on feature/moderator-amendment-tabs-proposal-auto-approval because it was found while reviewing that PR. The sale ledger remains stateless: dust is not persisted as a separate column; it is computed at transaction time and withheld from the credited amount.