### PR TITLE
Add N/A neutral unwind refund feature spec

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/13/13-na-neutral-unwind-refunds.md
+++ b/README/PRODUCTION-NOTES/FEATURES/13/13-na-neutral-unwind-refunds.md
@@ -1,0 +1,129 @@
+---
+title: N/A Neutral Unwind Refunds
+document_type: feature-overview
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-07T00:00:00Z
+updated_at_display: "Sunday, June 7, 2026"
+update_reason: "Define N/A market resolution as a neutral unwind that conserves retained market value without endorsing final market probability."
+status: proposed
+---
+
+# N/A Neutral Unwind Refunds
+
+## Purpose
+
+Some markets should not resolve to `YES` or `NO`. The contract may be ambiguous, impossible to adjudicate, invalid, or otherwise not suitable for ordinary winner payout. In those cases, SocialPredict needs an `N/A` resolution path that voids the directional outcome while preserving economy integrity.
+
+`N/A` must not endorse the market-implied probability at the time the market is voided. Instead, it should unwind remaining positions using a neutral binary valuation and refund the retained market pool back to current participants.
+
+## Product Rule
+
+When a market resolves `N/A`:
+
+- The public outcome is `N/A` / `?`, not `YES`, `NO`, or `50%`.
+- The chart should show the market as voided, not as resolved to a final directional probability.
+- Refund valuation uses neutral binary probability `P = 0.5` as an accounting convention only.
+- Remaining positions are invalidated after the refund.
+- Users should no longer carry YES/NO exposure for that market in portfolio or financial views.
+- The market remains visible for audit/history unless a separate yank/obfuscation feature hides unsafe content.
+
+## Moderator/Admin Disclosure
+
+The backend currently accepts `N/A` as a resolution value, but the frontend must not expose that action without a confirmation disclosure. Any moderator/admin control that resolves a market as `N/A` must clearly explain what the action does before submission.
+
+Required disclosure points:
+
+- `N/A` voids the directional market outcome.
+- No `YES` or `NO` winner payout is made.
+- Refund valuation uses neutral `P = 0.5` as an accounting convention only.
+- `P = 0.5` is not shown as the market's final probability.
+- Remaining retained market value, including retained dust, is refunded according to the neutral unwind policy.
+- Market creation/proposal cost is not refunded.
+- Moderator work profit is not paid.
+- Prior seller proceeds are not clawed back.
+- User positions become zero effective exposure after the refund.
+- The action is irreversible and remains auditable.
+
+## Accounting Rule
+
+The refund must be derived from canonical market bet history, not cached display data.
+
+```text
+refundPool = retained market pool = net market volume + retained market dust
+sum(refunds) == refundPool
+```
+
+The refund pool includes capital still retained by the market. It does not claw back credits from users who previously sold positions and received sale proceeds.
+
+## Fee Rule
+
+| Money Source | N/A Treatment |
+| --- | --- |
+| Remaining market volume | Refund to current claim holders. |
+| Retained market dust | Refund as deterministic residual allocation. |
+| Market creation/proposal fee | Not refunded. |
+| Moderator work profit | Not paid. |
+| Prior sale proceeds | Not clawed back. |
+| Initial participation fee | Open decision; baseline should avoid refunding it unless explicitly included in retained market pool. |
+
+The market creation/proposal fee should remain non-refundable. Otherwise, market makers could be incentivized to create markets, observe low participation or bad economics, and void the market to recover their creation cost.
+
+## Neutral Valuation
+
+The neutral unwind deliberately avoids using the market's final live probability.
+
+```text
+N/A refund valuation probability = 0.5
+```
+
+This says:
+
+```text
+The platform is voiding the contract. It is not adjudicating YES/NO and is not validating the final market price.
+```
+
+That creates a possible incentive for participants to price risky or ambiguous markets closer to 50%. This is acceptable and may be beneficial: markets that appear vulnerable to `N/A` should not attract extreme directional confidence unless participants trust the contract quality.
+
+## Position Invalidation
+
+After an `N/A` refund, the market should no longer contribute live position value.
+
+Required invariant:
+
+```text
+for every user position on N/A market:
+  yesSharesOwned = 0 for display/effective portfolio purposes
+  noSharesOwned = 0 for display/effective portfolio purposes
+  positionValue = 0
+  unresolvedExposure = 0
+```
+
+The raw bet history remains untouched for audit. Position invalidation should be achieved by resolution-aware position calculation, not by deleting or rewriting bet rows.
+
+This avoids historical data loss while ensuring the user's books no longer show value in a voided market.
+
+## Divide-By-Zero Safety
+
+`N/A` can produce zero effective market volume and zero effective share value after invalidation. Every display and calculation path that reads resolved market positions must avoid divide-by-zero behavior.
+
+Required guards:
+
+- If market is resolved `N/A`, do not calculate sell quotes.
+- If market is resolved `N/A`, do not calculate live value-per-share for user sale paths.
+- If neutral unwind produces zero eligible positions, refund nothing beyond explicit residual policy.
+- If denominator is zero in charts, position tables, financials, or leaderboard views, return zero/empty state rather than dividing.
+- If `VolumeWithDust == 0`, avoid payout normalization and mark the market as void with zero effective exposure.
+
+## Acceptance Criteria
+
+- Resolving a market `N/A` does not use final market-implied probability for refunds.
+- Resolving a market `N/A` uses neutral `P = 0.5` for refund valuation only.
+- `N/A` refunds are derived from canonical chronological market bet history.
+- `N/A` refunds conserve the retained market pool, including retained dust.
+- `N/A` does not pay moderator work profit.
+- `N/A` does not refund market creation/proposal cost.
+- Prior seller proceeds are not clawed back.
+- After `N/A`, effective user positions for that market display as zero exposure/value.
+- Moderator/admin UI requires a confirmation disclosure before submitting `N/A`.
+- Tests prove no divide-by-zero paths in market detail, portfolio, financial, leaderboard, and payout/refund calculations.

--- a/README/PRODUCTION-NOTES/FEATURES/13/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/13/DESIGN.md
@@ -1,0 +1,185 @@
+---
+title: N/A Neutral Unwind Refunds Design
+document_type: feature-design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-07T00:00:00Z
+updated_at_display: "Sunday, June 7, 2026"
+update_reason: "Specify canonical-history refund derivation, neutral valuation, residual allocation, and zero-position invariants for N/A resolution."
+status: proposed
+---
+
+# N/A Neutral Unwind Refunds Design
+
+## Design Posture
+
+This feature follows the accounting and cache-boundary rules already established in the design plan and read-model notes:
+
+- Resolution/refund is transaction-critical and must not use cached display snapshots.
+- Raw market bet history remains the audit source of truth.
+- Display read models may show `N/A` state, but must not decide refund amounts.
+- The refund algorithm must conserve money and be deterministic.
+- Position invalidation should be resolution-aware derivation, not destructive historical mutation.
+
+## Domain Language
+
+| Term | Meaning |
+| --- | --- |
+| `N/A` resolution | Governance decision that the market contract should not resolve to either binary side. |
+| Neutral unwind | Refund valuation convention that treats the binary market as neutral `P = 0.5` for refund accounting only. |
+| Refund pool | Retained market value available for refund, including retained dust. |
+| Current claim holder | User with effective remaining exposure after replaying canonical bet history. |
+| Residual dust | Credits left after integer refund allocation. |
+| Position invalidation | Resolution-aware rule that voided markets no longer count as live user holdings. |
+
+## Boundary Decision
+
+`N/A` is not a third tradable outcome and not a probability.
+
+```text
+Display outcome: N/A / ?
+Refund valuation: neutral binary P = 0.5
+Trading state: closed/resolved, not tradable
+Portfolio state: zero effective exposure after refund
+```
+
+## Moderator/Admin Disclosure Boundary
+
+The current backend resolution boundary accepts `N/A`, but the frontend resolution modal only exposes ordinary binary outcomes. The frontend implementation slice must add an explicit `N/A` resolution path for authorized moderators/admins and must require a confirmation disclosure before the request is submitted.
+
+The disclosure is part of the governance boundary, not just UX copy. A moderator or admin should not be able to accidentally void a market while thinking they are selecting a third payout outcome.
+
+The disclosure must communicate:
+
+- `N/A` voids the market rather than resolving it directionally.
+- Neutral `P = 0.5` is refund accounting only.
+- No winner payout is made.
+- No moderator work profit is paid.
+- Market creation/proposal cost is not refunded.
+- Prior sale proceeds are not clawed back.
+- Remaining positions become zero effective exposure.
+- The action is irreversible and auditable.
+
+## High-Level Flow
+
+```mermaid
+flowchart TD
+    A[Admin or authorized steward confirms N/A disclosure] --> B[Load canonical market and chronological bet history]
+    B --> C[Derive current effective positions]
+    B --> D[Derive retained market dust]
+    C --> E[Neutral valuation using P = 0.5]
+    D --> F[refundPool = net volume + retained dust]
+    E --> G[Primary refund allocation]
+    F --> G
+    G --> H{Residual credits?}
+    H -->|Yes| I[Distribute residual deterministically to current claim holders]
+    H -->|No| J[No residual distribution]
+    I --> K[Apply REFUND transactions]
+    J --> K
+    K --> L[Mark market resolved N/A]
+    L --> M[Invalidate read models]
+    M --> N[Resolved N/A positions display zero value/exposure]
+```
+
+## Refund Pool
+
+The refund pool should be derived from canonical history:
+
+```text
+refundPool = GetMarketVolumeWithDust(canonicalBets)
+```
+
+This aligns with the current dust-conservation model:
+
+```text
+VolumeWithDust = plain net volume + retained market dust
+```
+
+The implementation must validate:
+
+```text
+refundPool >= 0
+sum(appliedRefunds) == refundPool
+```
+
+If either condition fails, the resolution should fail before mutating balances.
+
+## Neutral Position Valuation
+
+The algorithm should not value claims using the market's current probability. That would endorse a price produced by a market that is being voided.
+
+Instead, for refund accounting only:
+
+```text
+neutralProbability = 0.5
+```
+
+Implementation options:
+
+| Option | Notes |
+| --- | --- |
+| Reuse DBPM position path with resolution probability override | Preferred if the existing path can accept an explicit neutral resolution without corrupting normal payout behavior. |
+| Build dedicated neutral-unwind calculator | Preferred if the existing payout code is too tightly coupled to ordinary `YES`/`NO` resolution. |
+
+Either option must preserve raw bet history and keep the neutral valuation local to `N/A` refund calculation.
+
+## Residual Allocation
+
+Integer accounting can leave residual credits after neutral valuation. Residual allocation must be deterministic.
+
+Recommended baseline:
+
+1. Only current claim holders are eligible.
+2. Sort eligible users by earliest positive participation timestamp.
+3. Tie-break by username ascending.
+4. Add one credit at a time until the residual is exhausted.
+
+This does not refund dust to the exact historical dust payor. That is acceptable for the baseline because exact dust-payor attribution is not stored. The policy instead rewards users who still hold risk in the voided market, with earliest current participants receiving deterministic priority.
+
+Users who sold out completely should not receive residual dust refunds because they already exited the market and received sale proceeds.
+
+## Position Invalidation Strategy
+
+Do not write synthetic sell rows just to zero positions. Do not delete bets. Do not mutate historical bets.
+
+Instead, position/read logic should treat `resolutionResult == "N/A"` as a terminal void state:
+
+```text
+if market.isResolved && market.resolutionResult == "N/A":
+  effective YES shares = 0
+  effective NO shares = 0
+  effective value = 0
+  unresolved exposure = 0
+```
+
+Financial history may still show the refund transaction and closed market history, but active/portfolio books should not show live shares.
+
+## Critical Decisions
+
+| Decision | Uses cached/read-model data? | Reason |
+| --- | --- | --- |
+| N/A refund amount | No | Moves money and must conserve retained pool. |
+| Neutral valuation | No | Must derive from canonical market history and explicit policy. |
+| Residual dust allocation | No | Moves money and must be deterministic/auditable. |
+| Position invalidation | No for canonical position calculation; yes only for display of already-resolved state | Must not leave N/A shares on active books. |
+| Market detail display | May use read models after transaction completes | Display-only once resolved. |
+| Portfolio/financial display | May use read models after transaction completes | Must show zero effective exposure for N/A markets. |
+
+## Interactions With Existing Features
+
+| Feature | Interaction |
+| --- | --- |
+| Moderator work profits | `N/A` does not pay work profit. |
+| Market stewardship | Current steward/admin may trigger `N/A` if authorized by existing resolution policy. |
+| Read-model caching | Resolution must invalidate market, user financial, portfolio, leaderboard, and discovery snapshots. |
+| Dust accounting | Retained market dust is included in refund pool but does not affect probability. |
+| Sale dust net proceeds | Prior sale proceeds are final; `N/A` must not claw them back. |
+| Market creation/proposal cost | Not refunded. |
+| Frontend resolution UI | Existing modal exposes `YES`/`NO`; `N/A` requires an added option plus confirmation disclosure. |
+
+## Open Questions
+
+- Should initial participation fees be treated as retained server-side fees and excluded from `N/A`, or should they be voided and included in refund pool if future accounting captures them per market?
+- Should `N/A` require admin-only authority, or may current stewards resolve to `N/A` under the same policy as ordinary resolution?
+- Should the UI expose the neutral unwind formula in a market audit panel?
+- Should exact dust-payor attribution be added later if product requirements demand exact dust refunds?

--- a/README/PRODUCTION-NOTES/FEATURES/13/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/13/PLAN.md
@@ -1,0 +1,105 @@
+---
+title: N/A Neutral Unwind Refunds Plan
+document_type: feature-plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-07T00:00:00Z
+updated_at_display: "Sunday, June 7, 2026"
+update_reason: "Track implementation slices for N/A neutral unwind refunds and zero-position handling."
+status: proposed
+---
+
+# N/A Neutral Unwind Refunds Plan
+
+## Purpose
+
+This plan turns [13-na-neutral-unwind-refunds.md](./13-na-neutral-unwind-refunds.md) and [DESIGN.md](./DESIGN.md) into implementation slices.
+
+## 01. Feature Artifact And Design Alignment
+
+Checklist:
+
+- [x] Create `README/PRODUCTION-NOTES/FEATURES/13/`.
+- [x] Add feature overview.
+- [x] Add design artifact.
+- [x] Add implementation plan.
+- [x] Define `N/A` as neutral unwind, not final `50%` outcome.
+- [x] Define zero-position/effective-exposure invariant.
+- [x] Define divide-by-zero safety requirements.
+
+## 02. Refund Calculator
+
+Checklist:
+
+- [ ] Add a dedicated neutral unwind refund calculator or an explicit neutral-resolution adapter around the existing payout path.
+- [ ] Load canonical chronological bet history.
+- [ ] Derive current claim holders without using cached display snapshots.
+- [ ] Use neutral `P = 0.5` for refund valuation only.
+- [ ] Calculate `refundPool = VolumeWithDust`.
+- [ ] Allocate primary refunds.
+- [ ] Allocate residual credits deterministically to current claim holders by earliest positive participation, then username.
+- [ ] Assert `sum(refunds) == refundPool` before balance mutation.
+- [ ] Reject impossible negative refund-pool states.
+
+## 03. Resolution Transaction Path
+
+Checklist:
+
+- [ ] Replace the current raw-bet `N/A` refund path with neutral unwind refund policy.
+- [ ] Apply `REFUND` transactions from the computed allocation.
+- [ ] Mark market resolved `N/A` only after refund allocation is valid.
+- [ ] Do not pay `WORK_PROFIT` on `N/A`.
+- [ ] Do not refund market creation/proposal cost.
+- [ ] Do not claw back prior sale proceeds.
+- [ ] Invalidate affected read models after successful `N/A` resolution.
+
+## 04. Position And Display Semantics
+
+Checklist:
+
+- [ ] Confirm existing frontend resolve modal only exposes ordinary binary outcomes.
+- [ ] Add moderator/admin `N/A` resolution option where authorized by governance policy.
+- [ ] Add required confirmation disclosure before submitting `N/A`.
+- [ ] Explain neutral `P = 0.5` refund valuation without presenting it as final probability.
+- [ ] Explain no winner payout, no work-profit payout, no creation-cost refund, no sale-proceeds clawback, and zero effective positions.
+- [ ] Ensure resolved `N/A` markets report zero effective YES shares.
+- [ ] Ensure resolved `N/A` markets report zero effective NO shares.
+- [ ] Ensure resolved `N/A` markets report zero effective position value.
+- [ ] Ensure resolved `N/A` markets do not count as unresolved exposure.
+- [ ] Ensure market detail charts show an `N/A` marker rather than a final directional probability.
+- [ ] Ensure market cards show `N/A` / `?` state clearly.
+- [ ] Ensure portfolio and financial views remove live exposure but preserve historical/refund facts.
+
+## 05. Divide-By-Zero Safety
+
+Checklist:
+
+- [ ] Add guards in sell quote/sell paths for resolved `N/A` markets.
+- [ ] Add guards in market detail probability/price display when terminal probability is not directional.
+- [ ] Add guards in portfolio, financial, leaderboard, and market table calculations for zero denominators.
+- [ ] Add tests for zero-volume `N/A` market detail.
+- [ ] Add tests for zero-share `N/A` user positions.
+
+## 06. Tests
+
+Checklist:
+
+- [ ] Unit test: only buys, `N/A` refund conserves pool.
+- [ ] Unit test: buys and sells, prior sale proceeds are not clawed back.
+- [ ] Unit test: retained dust is included in refund pool.
+- [ ] Unit test: residual dust allocation is deterministic.
+- [ ] Unit test: sold-out users do not receive residual dust.
+- [ ] Unit test: `N/A` does not pay work profit.
+- [ ] Unit test: market creation/proposal cost is not refunded.
+- [ ] Integration test: Postgres `N/A` resolution leaves zero economy surplus/deficit.
+- [ ] Integration test: portfolio and financial views show zero effective exposure after `N/A`.
+- [ ] Regression test: no divide-by-zero on zero-volume or zero-position `N/A` markets.
+
+## 07. Future Decisions
+
+Checklist:
+
+- [ ] Decide whether exact dust-payor attribution is worth new durable state.
+- [ ] Decide whether initial participation fees should ever be refunded on voided markets.
+- [ ] Decide whether `N/A` should require admin-only authority.
+- [ ] Decide whether yanked/offensive markets share this refund policy or use a separate cancellation policy.

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -83,6 +83,10 @@ Current feature specs:
 6. **Temporary Load-Test Droplets** - [`FEATURES/06/06-temporary-loadtest-droplets.md`](./FEATURES/06/06-temporary-loadtest-droplets.md), [`FEATURES/06/DESIGN.md`](./FEATURES/06/DESIGN.md), [`FEATURES/06/PLAN.md`](./FEATURES/06/PLAN.md)
 7. **Market Stewardship** - [`FEATURES/07/07-market-stewardship.md`](./FEATURES/07/07-market-stewardship.md), [`FEATURES/07/DESIGN.md`](./FEATURES/07/DESIGN.md), [`FEATURES/07/PLAN.md`](./FEATURES/07/PLAN.md)
 9. **Market Taxonomy And Hierarchical Navigation** - [`FEATURES/09/09-market-taxonomy-navigation.md`](./FEATURES/09/09-market-taxonomy-navigation.md), [`FEATURES/09/DESIGN.md`](./FEATURES/09/DESIGN.md), [`FEATURES/09/PLAN.md`](./FEATURES/09/PLAN.md)
+10. **Market Description Amendments** - [`FEATURES/10/10-market-description-amendments.md`](./FEATURES/10/10-market-description-amendments.md), [`FEATURES/10/DESIGN.md`](./FEATURES/10/DESIGN.md), [`FEATURES/10/PLAN.md`](./FEATURES/10/PLAN.md)
+11. **Read Model Caching And Performance** - [`FEATURES/11/11-read-model-caching-performance.md`](./FEATURES/11/11-read-model-caching-performance.md), [`FEATURES/11/DESIGN.md`](./FEATURES/11/DESIGN.md), [`FEATURES/11/PLAN.md`](./FEATURES/11/PLAN.md)
+12. **Moderator Work Profits** - [`FEATURES/12/12-moderator-work-profits.md`](./FEATURES/12/12-moderator-work-profits.md), [`FEATURES/12/DESIGN.md`](./FEATURES/12/DESIGN.md), [`FEATURES/12/PLAN.md`](./FEATURES/12/PLAN.md)
+13. **N/A Neutral Unwind Refunds** - [`FEATURES/13/13-na-neutral-unwind-refunds.md`](./FEATURES/13/13-na-neutral-unwind-refunds.md), [`FEATURES/13/DESIGN.md`](./FEATURES/13/DESIGN.md), [`FEATURES/13/PLAN.md`](./FEATURES/13/PLAN.md)
 
 ## Implementation Priority
 


### PR DESCRIPTION
## Summary
- Add proposed FEATURE/13 for N/A neutral unwind refunds
- Define N/A as a voided-market outcome with neutral P=0.5 refund valuation, not a final 50% result
- Specify retained-pool conservation, retained dust distribution, non-refundable creation cost, no work-profit payout, and no sale-proceeds clawback
- Add position invalidation and divide-by-zero safety requirements
- Refresh the production-notes feature index through FEATURES/13

## Notes
This is documentation/design only. It is stacked on fix/sale-dust-net-proceeds because the N/A refund policy depends on the sale dust accounting model.

## Testing
- Documentation-only change; no runtime tests run.