### PR TITLE
Threshold moderator work profit payouts

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/12/12-moderator-work-profits.md
+++ b/README/PRODUCTION-NOTES/FEATURES/12/12-moderator-work-profits.md
@@ -5,7 +5,7 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-06-07T00:00:00Z
 updated_at_display: "Sunday, June 7, 2026"
-update_reason: "Define stateless moderator work-profit payout and financial reporting for resolved markets."
+update_reason: "Define thresholded moderator work-profit payout and financial reporting for resolved markets."
 status: draft
 ---
 
@@ -13,7 +13,7 @@ status: draft
 
 ## Purpose
 
-Moderators pay to create markets. If those markets attract participants, the current steward who governs and resolves the market should later receive income from the first-participation fees collected on that market. This feature treats that income as moderator work profit while preserving transaction correctness and existing canonical tables.
+Moderators pay to create markets. If those markets attract enough participants to exceed the market creation/proposal cost, the current steward who governs and resolves the market should later receive the surplus first-participation fee income. This feature treats that surplus as moderator work profit while preserving transaction correctness and existing canonical tables.
 
 ## Rule Summary
 
@@ -22,9 +22,9 @@ Moderators pay to create markets. If those markets attract participants, the cur
 - Selling out and buying back in does not create another initial entry fee for the same user on the same market.
 - Collected entry fees remain server-side until market resolution.
 - After a market resolves to `YES` or `NO`, ordinary winner payouts run first.
-- After ordinary payout, the current steward/resolver receives the derived collected entry-fee income as a `WORK_PROFIT` balance credit.
+- After ordinary payout, the current steward/resolver receives only the surplus collected entry-fee income after the market creation/proposal cost threshold has been met.
 - `N/A` refund resolutions do not pay moderator work profit in this baseline.
-- User financial display derives net work profit for resolved markets stewarded by that user. If the steward was also the creator, display subtracts the market creation/proposal fee; if the steward took over later, display does not subtract someone else's creation cost.
+- User financial display derives work profit for resolved markets stewarded by that user using the same thresholded surplus rule.
 
 ## Stateless Accounting
 
@@ -33,25 +33,25 @@ This feature does not add new database columns or tables. Work-profit income is 
 ```text
 uniquePositiveParticipants = count(distinct username where market_id = M and bet.amount > 0)
 marketFeeIncome = uniquePositiveParticipants * initialBetFee
-marketCreationFee = market.proposalCost if steward is creator, otherwise 0
-netWorkProfit = marketFeeIncome - marketCreationFee
+marketCreationThreshold = market.proposalCost or configured createMarketCost fallback
+workProfit = max(marketFeeIncome - marketCreationThreshold, 0)
 ```
 
-Resolution-time payout credits only `marketFeeIncome`; the creation fee has already been deducted from the original creator when the market was created. Financial display subtracts the creation fee only when the work-profit beneficiary is also the market creator.
+Resolution-time payout credits only surplus `workProfit`. The creation fee has already been deducted from the original creator when the market was created and is not paid back out as work profit. The first participant fees effectively satisfy the market's creation-cost threshold; only fees above that threshold become steward work income.
 
 ## Boundary Notes
 
 - Payout decisions use canonical bet history, not cached/read-model snapshots.
 - Work-profit display may appear in user financial read models, but those read models remain display-only.
-- System metrics should treat participation fees on resolved `YES`/`NO` markets as redistributed steward work income, not retained system fees, to avoid double-counting the same money.
+- System metrics should treat only the paid surplus on resolved `YES`/`NO` markets as redistributed steward work income. Threshold participation fees that do not become work profit remain retained participation fees.
 - The payout goes to the current steward who governs resolution. A reassigned steward receives the work income; the original creator does not receive it unless they remain steward.
 - Future historical policy changes may require durable per-market fee policy capture. The current implementation intentionally uses existing state and current economics config to avoid adding new state for this baseline.
 
 ## Acceptance Criteria
 
 - Resolving a non-`N/A` market pays ordinary winners first.
-- Resolving a non-`N/A` market then credits the current steward/resolver for one initial fee per unique positive-bet participant.
+- Resolving a non-`N/A` market then credits the current steward/resolver only for participation-fee surplus above the market creation/proposal cost threshold.
 - Resolving `N/A` refunds participant bet amounts and does not credit work profit.
-- User financials show `workProfits` for resolved markets stewarded by that user, subtracting market creation/proposal cost only when that user was also the creator.
+- User financials show thresholded `workProfits` for resolved markets stewarded by that user.
 - Tests prove repeated participation by the same user is counted once.
 - Tests prove sale/negative bet rows do not create extra work-profit income.

--- a/README/PRODUCTION-NOTES/FEATURES/12/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/12/DESIGN.md
@@ -5,7 +5,7 @@ domain: features
 author: Patrick Delaney
 updated_at: 2026-06-07T00:00:00Z
 updated_at_display: "Sunday, June 7, 2026"
-update_reason: "Specify domain boundaries, payout timing, and stateless derivation for moderator work profits."
+update_reason: "Specify domain boundaries, payout timing, and thresholded stateless derivation for moderator work profits."
 status: draft
 ---
 
@@ -27,8 +27,8 @@ This design follows the canonical design plan's boundary posture:
 | Market creator | Immutable user who created the market and paid the proposal/creation cost. |
 | Steward | Current operational owner who can govern the market; not necessarily the creator. |
 | Initial entry fee | Existing first-positive-bet fee charged once per user per market. |
-| Work income | Gross entry-fee income credited to the current steward/resolver after normal resolution payout. |
-| Work profit | Display-only net value: work income minus the market creation/proposal cost only when the steward was also the creator. |
+| Work income | Surplus entry-fee income credited to the current steward/resolver after normal resolution payout. |
+| Work profit | Thresholded surplus value: unique participant fees minus the market creation/proposal cost, floored at zero. |
 
 ## Payout Timing
 
@@ -39,9 +39,12 @@ flowchart TD
   B -->|YES or NO| D[Resolve market state]
   D --> E[Pay winning participant positions]
   E --> F[Derive unique positive-bet participants]
-  F --> G[Credit steward WORK_PROFIT income]
-  C --> H[No work-profit payout]
-  G --> I[Financial display derives net work profit]
+  F --> G[Subtract market creation-cost threshold]
+  G --> H{Surplus above threshold?}
+  H -->|Yes| I[Credit steward WORK_PROFIT surplus]
+  H -->|No| J[No WORK_PROFIT payout]
+  C --> J
+  I --> K[Financial display derives thresholded work profit]
 ```
 
 ## Derivation
@@ -52,25 +55,29 @@ Work income is derived from canonical market bet history at resolution time:
 - Ignore sell rows and zero-value rows.
 - Ignore repeated buy rows from the same user.
 - Multiply unique participant count by `InitialBetFee`.
+- Subtract the market creation/proposal cost threshold.
+- Floor the result at zero.
 
 Financial display separately computes net work profit:
 
 ```text
 workProfits = sum(resolved stewarded markets) {
-  uniquePositiveParticipants * InitialBetFee - creationCostIfStewardIsCreator
+  max(uniquePositiveParticipants * InitialBetFee - marketCreationThreshold, 0)
 }
 ```
 
 If a legacy market has no stored proposal cost, display logic falls back to the current `CreateMarketCost` config.
+
+The threshold applies to the market, not only to the creator. If stewardship is reassigned, the new steward can earn work profit, but only after the market's participant fees exceed the creation-cost threshold.
 
 ## Critical Decisions
 
 | Decision | Uses cached/read-model data? | Reason |
 | --- | --- | --- |
 | Winner payout | No | Must use canonical market state and payout positions. |
-| Work-profit payout | No | Must use canonical bet history at resolution time. |
+| Work-profit payout | No | Must use canonical bet history and market creation-cost threshold at resolution time. |
 | Balance mutation | No | User balance writes are transaction truth. |
-| Retained participation-fee metric | No | Resolved `YES`/`NO` market fees are redistributed as work income and should not be double-counted as retained system fees. |
+| Retained participation-fee metric | No | Only surplus above threshold is redistributed as work income; threshold fees remain retained participation fees. |
 | User financial display | May use read models | Display-only summary can be stale, but must be marked as such. |
 
 ## Out Of Scope

--- a/README/PRODUCTION-NOTES/FEATURES/12/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/12/PLAN.md
@@ -33,6 +33,7 @@ Checklist:
 - [x] Wire `InitialBetFee` into the market service config.
 - [x] Derive unique positive-bet participants from canonical bet history.
 - [x] Credit work income after ordinary winner payout.
+- [x] Pay only the surplus above the market creation/proposal cost threshold.
 - [x] Skip work-profit payout for `N/A` refund resolution.
 - [x] Add service tests for payout ordering and unique participant counting.
 
@@ -43,6 +44,7 @@ Checklist:
 - [x] Derive user `workProfits` from resolved markets stewarded by that user.
 - [x] Use stored `ProposalCost` as the market creation fee when available.
 - [x] Fall back to configured `CreateMarketCost` for legacy rows with no proposal cost.
+- [x] Apply the market creation/proposal cost threshold regardless of whether the current steward is the original creator.
 - [x] Include work profits in direct financial calculations.
 - [x] Include work profits in user financial read-model refresh.
 - [x] Update retained participation-fee system metric semantics to avoid double-counting paid-out steward work income.

--- a/backend/internal/domain/analytics/financials.go
+++ b/backend/internal/domain/analytics/financials.go
@@ -52,10 +52,7 @@ func (s *Service) computeUserWorkProfits(ctx context.Context, username string) (
 		if err != nil {
 			return 0, err
 		}
-		creationCost := int64(0)
-		if market.CreatorUsername == username {
-			creationCost = creationCostForWorkProfit(market.ProposalCost, s.config.CreateMarketCost)
-		}
+		creationCost := creationCostForWorkProfit(market.ProposalCost, s.config.CreateMarketCost)
 		total += stewardMarketWorkProfit(bets, s.config.InitialBetFee, creationCost)
 	}
 
@@ -63,7 +60,11 @@ func (s *Service) computeUserWorkProfits(ctx context.Context, username string) (
 }
 
 func stewardMarketWorkProfit(bets []boundary.Bet, initialBetFee int64, creationCost int64) int64 {
-	return participationFeeIncome(bets, initialBetFee) - creationCost
+	income := participationFeeIncome(bets, initialBetFee) - creationCost
+	if income < 0 {
+		return 0
+	}
+	return income
 }
 
 func participationFeeIncome(bets []boundary.Bet, initialBetFee int64) int64 {

--- a/backend/internal/domain/analytics/financialsnapshot_test.go
+++ b/backend/internal/domain/analytics/financialsnapshot_test.go
@@ -205,7 +205,7 @@ func TestComputeUserFinancials_DerivesModeratorWorkProfitsFromResolvedStewardedM
 
 	stewardSnapshot := requireFinancialSnapshot(t, svc, steward)
 
-	expectedWorkProfits := int64(14)
+	expectedWorkProfits := int64(4)
 	if stewardSnapshot.WorkProfits != expectedWorkProfits {
 		t.Fatalf("steward work profits = %d, want %d", stewardSnapshot.WorkProfits, expectedWorkProfits)
 	}
@@ -253,5 +253,46 @@ func TestComputeUserFinancials_SubtractsCreationCostWhenCreatorRemainsSteward(t 
 	expectedWorkProfits := int64(4)
 	if snapshot.WorkProfits != expectedWorkProfits {
 		t.Fatalf("creator-steward work profits = %d, want %d", snapshot.WorkProfits, expectedWorkProfits)
+	}
+}
+
+func TestComputeUserFinancials_WorkProfitsRemainZeroBelowCreationCostThreshold(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	creator := modelstesting.GenerateUser("threshold_creator", 500)
+	steward := modelstesting.GenerateUser("threshold_steward", 500)
+	alice := modelstesting.GenerateUser("threshold_alice", 500)
+	bob := modelstesting.GenerateUser("threshold_bob", 500)
+	for _, user := range []models.User{creator, steward, alice, bob} {
+		if err := db.Create(&user).Error; err != nil {
+			t.Fatalf("create user %s: %v", user.Username, err)
+		}
+	}
+
+	market := modelstesting.GenerateMarket(3, creator.Username)
+	market.IsResolved = true
+	market.ResolutionResult = "YES"
+	market.ProposalCost = 10
+	market.StewardUsername = steward.Username
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+
+	bets := []models.Bet{
+		modelstesting.GenerateBet(100, "YES", alice.Username, uint(market.ID), 0),
+		modelstesting.GenerateBet(50, "NO", bob.Username, uint(market.ID), time.Minute),
+	}
+	for _, bet := range bets {
+		if err := db.Create(&bet).Error; err != nil {
+			t.Fatalf("create bet: %v", err)
+		}
+	}
+
+	econ := modelstesting.GenerateEconomicConfig()
+	econ.Economics.Betting.BetFees.InitialBetFee = 3
+	svc := newAnalyticsService(t, db, econ)
+
+	snapshot := requireFinancialSnapshot(t, svc, steward)
+	if snapshot.WorkProfits != 0 {
+		t.Fatalf("steward work profits below threshold = %d, want 0", snapshot.WorkProfits)
 	}
 }

--- a/backend/internal/domain/analytics/models.go
+++ b/backend/internal/domain/analytics/models.go
@@ -19,6 +19,7 @@ type MarketRecord struct {
 	CreatedAt        time.Time
 	IsResolved       bool
 	ResolutionResult string
+	ProposalCost     int64
 }
 
 // WorkProfitMarketRecord captures the resolved market fields needed to derive

--- a/backend/internal/domain/analytics/repository.go
+++ b/backend/internal/domain/analytics/repository.go
@@ -104,7 +104,7 @@ func (r *GormRepository) ListMarkets(ctx context.Context) ([]MarketRecord, error
 	}
 	var markets []analyticsMarketRow
 	if err := db.Table("markets").
-		Select("id", "created_at", "is_resolved", "resolution_result").
+		Select("id", "created_at", "is_resolved", "resolution_result", "proposal_cost").
 		Find(&markets).Error; err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (r *GormRepository) listMarketsByIDs(db *gorm.DB, marketIDs []uint) ([]Mark
 	}
 	var markets []analyticsMarketRow
 	if err := db.Table("markets").
-		Select("id", "created_at", "is_resolved", "resolution_result").
+		Select("id", "created_at", "is_resolved", "resolution_result", "proposal_cost").
 		Where("id IN ?", marketIDs).
 		Find(&markets).Error; err != nil {
 		return nil, err
@@ -315,6 +315,7 @@ type analyticsMarketRow struct {
 	CreatedAt        time.Time
 	IsResolved       bool
 	ResolutionResult string
+	ProposalCost     int64
 }
 
 type analyticsWorkProfitMarketRow struct {
@@ -355,6 +356,7 @@ func mapMarkets(dbMarkets []analyticsMarketRow) []MarketRecord {
 			CreatedAt:        market.CreatedAt,
 			IsResolved:       market.IsResolved,
 			ResolutionResult: market.ResolutionResult,
+			ProposalCost:     market.ProposalCost,
 		}
 	}
 	return markets

--- a/backend/internal/domain/analytics/system_metrics.go
+++ b/backend/internal/domain/analytics/system_metrics.go
@@ -117,33 +117,55 @@ func (c DefaultFeeCalculator) CalculateParticipationFees(ctx context.Context, re
 		return 0, err
 	}
 
-	type userMarket struct {
+	marketByID := make(map[uint]MarketRecord, len(markets))
+	for _, market := range markets {
+		marketByID[market.ID] = market
+	}
+
+	feesByMarket := make(map[uint]int64)
+	seen := make(map[struct {
 		marketID uint
 		username string
-	}
-
-	paidOutMarket := make(map[uint]bool, len(markets))
-	for _, market := range markets {
-		if market.IsResolved && market.ResolutionResult != "N/A" {
-			paidOutMarket[market.ID] = true
-		}
-	}
-
-	seen := make(map[userMarket]bool)
-	var participationFees int64
+	}]bool)
 
 	for _, b := range betsOrdered {
-		if b.Amount <= 0 || paidOutMarket[b.MarketID] {
+		if b.Amount <= 0 {
 			continue
 		}
-		key := userMarket{marketID: b.MarketID, username: b.Username}
+		key := struct {
+			marketID uint
+			username string
+		}{marketID: b.MarketID, username: b.Username}
 		if !seen[key] {
-			participationFees += config.InitialBetFee
+			feesByMarket[b.MarketID] += config.InitialBetFee
 			seen[key] = true
 		}
 	}
 
+	var participationFees int64
+	for marketID, feeIncome := range feesByMarket {
+		market := marketByID[marketID]
+		if market.IsResolved && market.ResolutionResult != "N/A" {
+			participationFees += retainedParticipationFeesAfterWorkProfit(feeIncome, creationCostForWorkProfit(market.ProposalCost, config.CreateMarketCost))
+			continue
+		}
+		participationFees += feeIncome
+	}
+
 	return participationFees, nil
+}
+
+func retainedParticipationFeesAfterWorkProfit(feeIncome int64, creationCost int64) int64 {
+	if feeIncome <= 0 {
+		return 0
+	}
+	if creationCost <= 0 {
+		return 0
+	}
+	if feeIncome < creationCost {
+		return feeIncome
+	}
+	return creationCost
 }
 
 // DefaultMetricsAssembler builds the SystemMetrics DTO from calculator outputs.
@@ -164,7 +186,7 @@ func (a DefaultMetricsAssembler) Assemble(debt *DebtStats, volume *MarketVolumeS
 			UnusedDebt:         NewInt64Metric(debt.UnusedDebt, "Σ(maxDebtPerUser - max(0, -balance))", "Remaining borrowing capacity available to users"),
 			ActiveBetVolume:    NewInt64Metric(volume.ActiveBetVolume, "Σ(unresolved_market_volumes)", "Total value of bets currently active in unresolved markets (excludes fees and subsidies)"),
 			MarketCreationFees: NewInt64Metric(volume.MarketCreationFees, "number_of_markets × creation_fee_per_market", "Fees collected from users creating new markets"),
-			ParticipationFees:  NewInt64Metric(participationFees, "Σ(unpaid_first_bet_per_user_per_market × participation_fee)", "Retained fees collected from first-time participation before eligible resolved markets redistribute them as steward work profit"),
+			ParticipationFees:  NewInt64Metric(participationFees, "Σ(retained_first_bet_per_user_per_market × participation_fee)", "Retained fees collected from first-time participation; resolved markets only redistribute surplus above the market creation-cost threshold as steward work profit"),
 			BonusesPaid:        NewInt64Metric(bonusesPaid, "", "System bonuses paid to users and realized profits currently held in user balances"),
 			TotalUtilized:      NewInt64Metric(totalUtilized, "unusedDebt + activeBetVolume + marketCreationFees + participationFees + bonusesPaid", "Total debt capacity that has been utilized across all categories"),
 		},

--- a/backend/internal/domain/analytics/systemmetrics_test.go
+++ b/backend/internal/domain/analytics/systemmetrics_test.go
@@ -106,9 +106,10 @@ func TestComputeSystemMetrics_WithData(t *testing.T) {
 	}
 }
 
-func TestComputeSystemMetrics_ParticipationFeesExcludeResolvedWorkProfitMarkets(t *testing.T) {
+func TestComputeSystemMetrics_ParticipationFeesRetainResolvedCreationCostThreshold(t *testing.T) {
 	db := modelstesting.NewFakeDB(t)
 	econ := modelstesting.GenerateEconomicConfig()
+	econ.Economics.MarketIncentives.CreateMarketCost = 10
 	econ.Economics.Betting.BetFees.InitialBetFee = 5
 
 	creator := modelstesting.GenerateUser("creator", 0)
@@ -137,6 +138,52 @@ func TestComputeSystemMetrics_ParticipationFeesExcludeResolvedWorkProfitMarkets(
 		modelstesting.GenerateBet(10, "YES", participant.Username, uint(activeMarket.ID), 0),
 		modelstesting.GenerateBet(10, "YES", participant.Username, uint(resolvedWorkProfitMarket.ID), 0),
 		modelstesting.GenerateBet(10, "YES", participant.Username, uint(resolvedNAMarket.ID), 0),
+	}
+	for _, bet := range bets {
+		if err := db.Create(&bet).Error; err != nil {
+			t.Fatalf("create bet: %v", err)
+		}
+	}
+
+	svc := newAnalyticsService(t, db, econ)
+	metrics := requireSystemMetrics(t, svc)
+
+	expectedRetainedFees := int64(15)
+	if got := requireMetricInt64(t, metrics.MoneyUtilized.ParticipationFees); got != expectedRetainedFees {
+		t.Fatalf("retained participation fees = %d, want %d", got, expectedRetainedFees)
+	}
+}
+
+func TestComputeSystemMetrics_ParticipationFeesExcludeOnlyPaidWorkProfitSurplus(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	econ := modelstesting.GenerateEconomicConfig()
+	econ.Economics.MarketIncentives.CreateMarketCost = 10
+	econ.Economics.Betting.BetFees.InitialBetFee = 5
+
+	creator := modelstesting.GenerateUser("surplus_creator", 0)
+	for _, user := range []models.User{
+		creator,
+		modelstesting.GenerateUser("surplus_alice", 0),
+		modelstesting.GenerateUser("surplus_bob", 0),
+		modelstesting.GenerateUser("surplus_carol", 0),
+	} {
+		if err := db.Create(&user).Error; err != nil {
+			t.Fatalf("create user %s: %v", user.Username, err)
+		}
+	}
+
+	market := modelstesting.GenerateMarket(14, creator.Username)
+	market.IsResolved = true
+	market.ResolutionResult = "YES"
+	market.ProposalCost = 10
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+
+	bets := []models.Bet{
+		modelstesting.GenerateBet(10, "YES", "surplus_alice", uint(market.ID), 0),
+		modelstesting.GenerateBet(10, "YES", "surplus_bob", uint(market.ID), 0),
+		modelstesting.GenerateBet(10, "YES", "surplus_carol", uint(market.ID), 0),
 	}
 	for _, bet := range bets {
 		if err := db.Create(&bet).Error; err != nil {

--- a/backend/internal/domain/markets/market_resolution.go
+++ b/backend/internal/domain/markets/market_resolution.go
@@ -47,7 +47,7 @@ func (s *Service) applyModeratorWorkProfit(ctx context.Context, market *Market, 
 		return nil
 	}
 
-	income, err := s.calculateModeratorWorkFeeIncome(ctx, market.ID)
+	income, err := s.calculateModeratorWorkProfitIncome(ctx, market)
 	if err != nil {
 		return err
 	}
@@ -58,12 +58,15 @@ func (s *Service) applyModeratorWorkProfit(ctx context.Context, market *Market, 
 	return s.userService.ApplyTransaction(ctx, stewardUsername, income, users.TransactionWorkProfit)
 }
 
-func (s *Service) calculateModeratorWorkFeeIncome(ctx context.Context, marketID int64) (int64, error) {
-	bets, err := s.repo.ListBetsForMarket(ctx, marketID)
+func (s *Service) calculateModeratorWorkProfitIncome(ctx context.Context, market *Market) (int64, error) {
+	if market == nil {
+		return 0, nil
+	}
+	bets, err := s.repo.ListBetsForMarket(ctx, market.ID)
 	if err != nil {
 		return 0, err
 	}
-	return ModeratorWorkFeeIncome(bets, s.config.InitialBetFee), nil
+	return ModeratorWorkProfitIncome(bets, s.config.InitialBetFee, marketCreationCostForWorkProfit(market.ProposalCost, s.config.CreateMarketCost)), nil
 }
 
 // ModeratorWorkFeeIncome derives the first-participation fee income for a
@@ -83,4 +86,22 @@ func ModeratorWorkFeeIncome(bets []*Bet, initialBetFee int64) int64 {
 	}
 
 	return int64(len(participants)) * initialBetFee
+}
+
+// ModeratorWorkProfitIncome returns the work-profit payout after the market's
+// creation cost threshold has been met. The first participation fees offset the
+// market creation subsidy; only surplus fee income is paid to the steward.
+func ModeratorWorkProfitIncome(bets []*Bet, initialBetFee int64, creationCost int64) int64 {
+	income := ModeratorWorkFeeIncome(bets, initialBetFee) - creationCost
+	if income < 0 {
+		return 0
+	}
+	return income
+}
+
+func marketCreationCostForWorkProfit(proposalCost int64, fallbackCreateMarketCost int64) int64 {
+	if proposalCost > 0 {
+		return proposalCost
+	}
+	return fallbackCreateMarketCost
 }

--- a/backend/internal/domain/markets/service_resolve_test.go
+++ b/backend/internal/domain/markets/service_resolve_test.go
@@ -358,11 +358,55 @@ func TestResolveMarketPaysWinners(t *testing.T) {
 	}
 }
 
-func TestResolveMarketPaysStewardWorkProfitAfterWinnerPayouts(t *testing.T) {
+func TestResolveMarketSkipsStewardWorkProfitUntilCreationCostThresholdIsMet(t *testing.T) {
 	market := &markets.Market{
 		ID:              42,
 		CreatorUsername: "creator",
 		StewardUsername: "backup",
+		ProposalCost:    10,
+		Status:          "active",
+	}
+	repo := newResolveRepo(
+		withResolveRepoMarket(market),
+		withResolveRepoResolve(func(context.Context, int64, string) error {
+			market.Status = "resolved"
+			return nil
+		}),
+		withResolveRepoPayouts([]*markets.PayoutPosition{
+			{Username: "winner", Value: 120},
+			{Username: "loser", Value: 0},
+		}),
+		withResolveRepoBets([]*markets.Bet{
+			{Username: "alice", Amount: 100},
+			{Username: "alice", Amount: -20},
+			{Username: "bob", Amount: 50},
+			{Username: "bob", Amount: 10},
+			{Username: "creator", Amount: 0},
+		}),
+	)
+	userSvc := newResolveUserService()
+	service := markets.NewService(repo, userSvc, newNopClock(marketsTestTime()), markets.Config{InitialBetFee: 3})
+
+	if err := service.ResolveMarket(context.Background(), 42, "YES", "backup"); err != nil {
+		t.Fatalf("ResolveMarket returned error: %v", err)
+	}
+
+	if len(userSvc.applied) != 1 {
+		t.Fatalf("expected winner payout only below work-profit threshold, got %d: %+v", len(userSvc.applied), userSvc.applied)
+	}
+
+	winnerCall := userSvc.applied[0]
+	if winnerCall.username != "winner" || winnerCall.amount != 120 || winnerCall.txType != users.TransactionWin {
+		t.Fatalf("unexpected winner payout %+v", winnerCall)
+	}
+}
+
+func TestResolveMarketPaysStewardWorkProfitSurplusAfterCreationCostThreshold(t *testing.T) {
+	market := &markets.Market{
+		ID:              42,
+		CreatorUsername: "creator",
+		StewardUsername: "backup",
+		ProposalCost:    5,
 		Status:          "active",
 	}
 	repo := newResolveRepo(
@@ -391,7 +435,7 @@ func TestResolveMarketPaysStewardWorkProfitAfterWinnerPayouts(t *testing.T) {
 	}
 
 	if len(userSvc.applied) != 2 {
-		t.Fatalf("expected winner payout and work-profit payout, got %d: %+v", len(userSvc.applied), userSvc.applied)
+		t.Fatalf("expected winner payout and work-profit surplus payout, got %d: %+v", len(userSvc.applied), userSvc.applied)
 	}
 
 	winnerCall := userSvc.applied[0]
@@ -400,7 +444,7 @@ func TestResolveMarketPaysStewardWorkProfitAfterWinnerPayouts(t *testing.T) {
 	}
 
 	workProfitCall := userSvc.applied[1]
-	if workProfitCall.username != "backup" || workProfitCall.amount != 6 || workProfitCall.txType != users.TransactionWorkProfit {
+	if workProfitCall.username != "backup" || workProfitCall.amount != 1 || workProfitCall.txType != users.TransactionWorkProfit {
 		t.Fatalf("unexpected work-profit payout %+v", workProfitCall)
 	}
 }


### PR DESCRIPTION
## Summary
- Change moderator work-profit payouts to pay only surplus participant fees above the market creation/proposal cost threshold
- Apply the threshold to the market regardless of whether the current steward is the original creator
- Keep creation/proposal fees separate from market trading volume, while using the stored proposal cost as the work-profit threshold
- Update user financial `workProfits` to match actual thresholded payout semantics
- Update system metrics so retained participation fees keep threshold fees and exclude only paid work-profit surplus
- Refresh FEATURE/12 docs and tests for the corrected policy

## Accounting Notes
The market creation/proposal fee is not stored as a bet row and is not part of `GetMarketVolume` or `VolumeWithDust`. It is deducted from the creator and stored on the market as `ProposalCost`. This PR treats that stored cost as the threshold that must be exceeded by first-participation fees before any steward receives `WORK_PROFIT`.

Formula:

```text
workProfit = max(uniquePositiveParticipants * InitialBetFee - marketCreationThreshold, 0)
```

## Testing
- `cd backend && go test ./internal/domain/markets ./internal/domain/analytics`
- `cd backend && go test ./...`
