### PR TITLE
Add GORM query scoping efficiency plan and bet indexes

### DIFF
--- a/README/PRODUCTION-NOTES/FEATURES/22/22-gorm-query-scoping-efficiency.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/22-gorm-query-scoping-efficiency.md
@@ -1,0 +1,269 @@
+---
+title: Market Bet-History Query Boundaries And Replay Efficiency
+document_type: feature-overview
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-23T00:00:00Z
+updated_at_display: "Tuesday, June 23, 2026"
+update_reason: "Align the query-efficiency spec with the SocialPredict design-plan postures: domain language, evolutionary architecture, clean boundaries, and transaction-safe optimization."
+status: proposed
+---
+
+# Market Bet-History Query Boundaries And Replay Efficiency
+
+GORM is the current persistence mechanism this feature audits. The domain subject is broader: which market, user, participant, and system-wide facts each use case is allowed to read, and how much canonical bet history it should ask Postgres to return.
+
+## Purpose
+
+SocialPredict market math often depends on chronological bet history. That is correct for transaction-time order math, sale math, probability history, resolution, refunds, and auditability. It does not mean every display or analytics path should repeatedly materialize broad tables or more rows than it needs.
+
+For this feature, **chronological bet history** means the authoritative bet event stream ordered deterministically by:
+
+```text
+placed_at ASC, id ASC
+```
+
+Any optimized replay input must preserve that event order unless a separate domain decision names a different authoritative sequence.
+
+As the platform grows to many markets and many bets, inefficient GORM reads can become a dominant cost. The most important rule is:
+
+```text
+When a calculation is for one market, the repository query should fetch only that market's rows unless the caller explicitly asks for a system-wide aggregate.
+```
+
+This feature starts a repository/query audit and implementation plan for tightening bet-history reads, adding the right database indexes, and using display read models where exact transaction-time state is not required.
+
+## Design-Plan Alignment
+
+This feature follows the design posture captured in `spec-socialpredict-tasks/lib/design/design-plan.json`:
+
+- **Domain-first language:** optimization work must preserve the canonical meaning of bets, market volume, probability, participant fees, work profits, dust, and payouts.
+- **Evolutionary architecture:** start with measurement, scoped repository methods, projections, and indexes before introducing broader caching or SQL rewrites.
+- **Clean architecture:** handlers and domain services should ask for use-case-shaped data through repository interfaces; GORM, SQL, indexes, and projection structs are persistence details.
+- **Policy over mechanism:** transaction paths use canonical fresh state; display paths may use projections, aggregates, or snapshots only when their freshness contract is explicit.
+- **Migration discipline:** index/schema changes use timestamped Go migrations and focused tests where practical.
+
+## Ubiquitous Language
+
+| Term | Meaning in this feature | Avoid confusing with |
+| --- | --- | --- |
+| Bet event | One canonical row in the market event stream used for replay and audit. | Visible bet-table row. |
+| Buy exposure | A positive amount row that can indicate first participation and increased market exposure. | Sale proceeds, refunds, or zero/negative rows. |
+| Sell exposure | A negative amount row produced by a sale path. | First participation for fee/work-profit policy. |
+| Participant identifier | The stable identity used for participation counting, currently `username`. | Display name, email, or mutable profile fields. |
+| Canonical bet history | The append-only source rows needed to reconstruct market math and audit financial changes. | Display snapshots or cached widgets. |
+| Market replay | Reconstructing probability, positions, payouts, dust, or refund state from the ordered bet event stream. | Aggregated platform statistics. |
+| Market-scoped read | A repository query whose SQL predicate limits rows to the relevant `market_id` or explicit market-ID set. | Loading all bets and filtering in Go. |
+| Projection row | A narrow data shape containing only fields needed by a use case. | Full GORM model hydration. |
+| First participation | The first positive buy exposure for a participant in a market under the current fee/work-profit policy. | Repeated buys, sells, refunds, or cancelled-market payout state. |
+| Active volume | Display/accounting volume whose exact semantics must be specified by the caller: gross buy volume, net exposure, or snapshot total including dust. | Assuming `SUM(amount)` always means the same thing. |
+| Aggregate SQL | Database-side count/sum/grouping that returns a reduced result. | Reimplementing WPAM/DBPM math in SQL. |
+| Read model snapshot | Durable display-oriented data with a freshness contract. | Authoritative transaction state. |
+| Transaction-critical path | Buy, sell, quote execution, dust, refund, resolution, payout, and balance mutation paths. | Public/read-only display paths. |
+| System aggregate | A platform-wide metric that is global by definition and must be named/documented as such. | Accidental table-wide scan. |
+
+## Current Grounding
+
+A quick audit shows that some important paths are already market-scoped:
+
+- `markets.GormRepository.ListBetsForMarket` uses `WHERE market_id = ?`.
+- `analytics.GormRepository.ListBetsForMarket` uses `WHERE market_id = ?`.
+- market bet history, market volume, probability projection, market leaderboard, market overview, and resolution paths call market-scoped bet loaders.
+- user financial positions already narrow from a user's bets to `market_id IN ?` for only the relevant markets.
+
+The remaining performance concern is not simply "every market path loads the whole bets table." The more precise concern is:
+
+- some analytics/system paths are intentionally global and may need aggregate SQL or read-model snapshots rather than row-by-row replay;
+- some display pagination paths still load the full market history before slicing a page;
+- some probability/chart paths may require full market history but can read a narrower column projection;
+- some repository methods may fetch more columns than a calculation needs, for example `Select("bets.*")` when only amount/outcome/time are required;
+- some routes may issue multiple related queries that can be consolidated into one purpose-built query or read-model refresh;
+- indexes may not yet match the most common market-scoped and user-scoped read patterns;
+- future GORM additions need tests or guardrails to prevent accidental table-wide reads in per-market code.
+
+## Prior PR #352 Finding
+
+PR #352 explored using a raw SQL query to count first-time market participation by grouping `bets` on `(market_id, username)`. The direction was correct: platform-wide aggregate questions should often be answered by SQL aggregates instead of loading every row and counting in Go.
+
+The improved version should be more precise:
+
+- GORM can express multi-column grouping with `Group("market_id, username")`; raw SQL is optional, not required just because there are two group columns.
+- If the caller only needs a count, the database should return a count, not all grouped pairs for Go to count.
+- The query should count only positive first participation rows when matching the current fee/work-profit policy.
+- For Postgres, a raw query may still be appropriate when it is clearer or faster, for example `COUNT(*) FROM (SELECT 1 FROM bets WHERE amount > 0 GROUP BY market_id, username)`.
+- The repository method should be named for business intent, such as `CountUniquePositiveParticipantsByMarket` or `CountPlatformFirstParticipations`, rather than exposing generic raw bet grouping.
+
+This gives us the useful part of PR #352 without assuming raw SQL is always faster than GORM. GORM-generated SQL and raw SQL both execute inside Postgres; the optimization comes from pushing aggregation/filtering into the database and supporting it with the right indexes.
+
+## Column Projection And Query Consolidation
+
+Row filtering is only one part of query efficiency. Column projection matters too.
+
+For example, a market-scoped query can still be wasteful if it uses:
+
+```go
+Select("bets.*")
+```
+
+when the caller only needs a narrow event stream:
+
+```text
+id, username, market_id, amount, outcome, placed_at, created_at
+```
+
+Some use cases need even less:
+
+| Use case | Likely needed columns |
+| --- | --- |
+| WPAM probability replay | `id`, `amount`, `outcome`, `placed_at` |
+| DBPM/user position calculation | `id`, `username`, `market_id`, `amount`, `outcome`, `placed_at` |
+| Market volume | `amount` |
+| First participation fees | `market_id`, `username`, `amount` |
+| Recent bet table | `username`, `amount`, `outcome`, `placed_at`, plus probability source |
+| User-has-bet check | no row materialization; use `COUNT`, `EXISTS`, or equivalent |
+
+The goal is to define purpose-specific row structs and repository methods so each path receives the smallest correct row shape.
+
+Query consolidation is the related rule: avoid issuing several broad queries when one narrower query or one read-model refresh can produce the needed display payload. This is especially relevant for stats, leaderboards, and market-card widgets.
+
+## Query Classes
+
+| Query class | Examples | Required behavior |
+| --- | --- | --- |
+| Transaction-critical market query | buy, sell, sale quote execution, resolution, refund, payout, work-profit payout, dust calculation | Use canonical state, scoped by market/user as tightly as correctness allows. Do not use stale display snapshots. |
+| Market display query | market bet table, positions, leaderboard, chart, volume widget | Prefer market-scoped query or read model. Avoid full platform bet scans. |
+| User display query | portfolio, user financials, user positions | Start from username and then load only affected market IDs. |
+| System aggregate query | system metrics, global leaderboard, platform totals | May be global by definition, but should use aggregate SQL or durable read models rather than repeatedly replaying all bets on every request. |
+| Admin review/search query | market review, stewardship, tags, user queue | Use filters, search predicates, limit/offset, and supporting indexes. |
+
+## Domain Invariants
+
+- A per-market use case must not perform a platform-wide bet scan unless the method name and documentation explicitly justify why it is global.
+- Transaction-critical paths must not depend on stale display snapshots, cached leaderboard rows, or asynchronously refreshed read models.
+- SQL may reduce rows, filter rows, order rows, count rows, and sum simple values; it must not silently become a second WPAM/DBPM implementation.
+- Repository interfaces should express business intent such as first positive participation, market replay, or user-in-market existence, not generic table access.
+- Any new index or durable read-model storage must be introduced through the established migration convention.
+- Performance work must not change market economics, payout math, dust handling, participant-fee rules, or moderator work-profit policy without a separate feature decision.
+- Display snapshots must expose freshness metadata, for example `generated_at`, `as_of_event_id`, or an equivalent field that lets callers and UI copy distinguish cached display state from authoritative transaction state.
+
+## Architecture Drivers
+
+- Scale `bets` reads as the number of markets and bet events grows.
+- Preserve correctness and auditability for WPAM, DBPM, resolution, refund, dust, balance, and work-profit calculations.
+- Improve changeability by moving from generic table reads toward intent-specific repository contracts.
+- Prefer operationally simple improvements before Redis, materialized views, or SQL math rewrites.
+- Keep migration risk visible through additive timestamped migrations, duplicate-index inspection, and tests.
+- Require performance evidence before introducing broader read-model or caching infrastructure.
+
+## Candidate Metrics For SQL Aggregation
+
+The stats page and other display-only dashboards should push simple reductions into Postgres where possible. Go should keep domain math that depends on WPAM/DBPM semantics, transaction state, or audited chronological replay.
+
+| Metric or display area | Good Postgres aggregation candidate? | Suggested SQL/GORM shape | Keep out of Postgres |
+| --- | --- | --- | --- |
+| Number of users | Yes | `COUNT(*) FROM users` | none |
+| Number of markets | Yes | `COUNT(*) FROM markets`, optionally grouped by lifecycle/resolution state | none |
+| Active market volume | Yes, when the volume meaning is explicit | `SUM(amount)` for a defined net-exposure metric, a gross-buy aggregate, or market accounting snapshot | final transaction settlement logic; ambiguous volume labels |
+| Market creation fees | Yes | `COUNT(markets) * createMarketCost` or `SUM(proposal_cost)` when stored | fee-policy decisions that depend on historical config until policy capture exists |
+| First participation fees | Yes | grouped distinct positive `(market_id, username)` counts | work-profit payout execution still needs canonical transaction path |
+| Global leaderboard | Partially | pre-aggregate candidate rows/counts, or read-model snapshot | final DBPM/WPAM profitability semantics unless proven equivalent |
+| Top/active markets | Yes | filtered/sorted/paginated market rows plus snapshot columns | live transaction probability math |
+| Current probability per market | Prefer snapshot | read from market accounting/probability snapshot | recomputing WPAM in SQL |
+| User financial summaries | Partially | user-scoped bets and affected market IDs only, or user financial snapshot | final position valuation math if it depends on DBPM/WPAM replay |
+
+Rule of thumb:
+
+```text
+SQL reduces data.
+Go applies domain math.
+Snapshots serve repeated display reads.
+Transaction paths stay canonical and fresh.
+```
+
+## DBPM/WPAM Boundary
+
+DBPM and WPAM can benefit from narrower inputs, but their math should remain in Go unless a separate math-optimization feature proves an equivalent SQL implementation.
+
+Safe optimizations:
+
+- fetch only one market's chronological event stream;
+- fetch only columns needed by the probability/position calculator;
+- order rows in SQL by `placed_at ASC, id ASC`;
+- add indexes that support that ordered market replay;
+- use display snapshots for charts/cards/leaderboards when freshness policy allows.
+
+Unsafe without proof:
+
+- grouping bets by user/outcome before WPAM/DBPM replay;
+- collapsing chronological events when intermediate probability changes matter;
+- using cached display snapshots for buy, sell, resolve, refund, or dust execution.
+
+## Product/Engineering Rule
+
+For any route or service method named for a single market, a table-wide bet scan is a bug unless explicitly justified in the code and docs.
+
+Examples of acceptable single-market query shape:
+
+```sql
+SELECT id, username, market_id, amount, outcome, placed_at, created_at
+FROM bets
+WHERE market_id = $1
+ORDER BY placed_at ASC, id ASC;
+```
+
+Examples of suspect single-market query shape:
+
+```sql
+SELECT * FROM bets ORDER BY placed_at ASC;
+```
+
+```go
+db.Find(&bets)
+// then filter market IDs in Go
+```
+
+## Database Index Direction
+
+The first implementation should verify and add missing indexes for the observed access patterns.
+
+Recommended baseline indexes:
+
+| Table | Index | Why |
+| --- | --- | --- |
+| `bets` | `(market_id, placed_at, id)` | Chronological market replay, charts, resolution, per-market display. |
+| `bets` | `(market_id, username, placed_at, id)` | First participation checks, user-in-market checks, sale/position paths. |
+| `bets` | `(username, market_id, placed_at, id)` | User portfolio/financial paths that start from a username. |
+| `markets` | `(lifecycle_status, created_at)` | Admin/public lifecycle queues and status lists. |
+| `market_tag_assignments` | `(tag_slug, market_id)` or equivalent actual schema columns | Topic pages and tag-filtered discovery. |
+
+Index names and exact columns should be verified against current models and migrations before implementation.
+
+## Relationship To Read Model Caching
+
+This feature complements Feature 11, Read Model Caching And Performance.
+
+- Transaction paths still use canonical tables.
+- Display paths can use snapshots/read models when freshness is acceptable.
+- If a display route uses raw bets, the repository should still scope the query tightly.
+- System/global displays should prefer aggregate read models or aggregate SQL over full replay at request time.
+
+## Acceptance Criteria
+
+- Audit all production GORM reads against the query classes above.
+- Identify every route/service that reads `bets` and mark it as transaction-critical, market display, user display, or system aggregate.
+- Identify every caller that depends on canonical chronological replay and record why projection/aggregation is safe or unsafe.
+- Define edge cases for first participation: repeated buys, sells after buy, refunds, cancelled/N/A markets, zero/negative rows, and participant identity changes.
+- Identify over-wide column projections such as `Select("bets.*")` or full model loads where a narrow row struct is sufficient.
+- Identify related query groups that can be consolidated into a single aggregate query or read-model refresh.
+- Add missing indexes through timestamped migrations.
+- Add tests proving per-market repository reads include `WHERE market_id = ?` behavior and exclude other market rows.
+- Add tests proving narrowed projections still provide all required WPAM/DBPM inputs.
+- Add domain-equivalence tests proving optimized/reduced query inputs produce identical WPAM, DBPM, resolution, refund, and dust outcomes for representative replay histories.
+- Add at least one guardrail test proving transaction paths do not call display snapshot/read-model repositories for authoritative execution.
+- Replace any per-market table-wide bet scans with scoped repository methods.
+- Replace or defer global row replay paths with aggregate SQL/read-model snapshots where appropriate.
+- Document intentionally global queries so future reviewers can distinguish valid aggregate work from accidental broad scans.
+
+## Numbering And Retargeting Note
+
+This PR was originally authored while `FEATURES/22` was available. If this branch is retargeted to the current `main`, confirm the feature number before merge because newer grouped-market feature docs may already occupy this slot.

--- a/README/PRODUCTION-NOTES/FEATURES/22/22-gorm-query-scoping-efficiency.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/22-gorm-query-scoping-efficiency.md
@@ -3,10 +3,10 @@ title: Market Bet-History Query Boundaries And Replay Efficiency
 document_type: feature-overview
 domain: features
 author: Patrick Delaney
-updated_at: 2026-06-23T00:00:00Z
-updated_at_display: "Tuesday, June 23, 2026"
-update_reason: "Align the query-efficiency spec with the SocialPredict design-plan postures: domain language, evolutionary architecture, clean boundaries, and transaction-safe optimization."
-status: proposed
+updated_at: 2026-06-25T00:00:00Z
+updated_at_display: "Thursday, June 25, 2026"
+update_reason: "Start implementation with deterministic market bet replay ordering, composite bet indexes, and scoped-read adapter tests."
+status: in_progress
 ---
 
 # Market Bet-History Query Boundaries And Replay Efficiency
@@ -32,6 +32,14 @@ When a calculation is for one market, the repository query should fetch only tha
 ```
 
 This feature starts a repository/query audit and implementation plan for tightening bet-history reads, adding the right database indexes, and using display read models where exact transaction-time state is not required.
+
+## Implementation Slice 1
+
+The first implementation slice keeps market math unchanged and improves the persistence adapter boundary:
+
+- canonical per-market bet replay now orders by `placed_at ASC, id ASC` where market history is loaded for market, analytics, sale, and user-position paths;
+- a timestamped migration adds composite indexes for market chronology, market/user existence checks, and user/market chronological reads;
+- repository tests seed unrelated market rows between same-timestamp target rows to prove scoped reads exclude cross-market rows and preserve deterministic tie ordering.
 
 ## Design-Plan Alignment
 

--- a/README/PRODUCTION-NOTES/FEATURES/22/22-gorm-query-scoping-efficiency.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/22-gorm-query-scoping-efficiency.md
@@ -40,6 +40,9 @@ The first implementation slice keeps market math unchanged and improves the pers
 - canonical per-market bet replay now orders by `placed_at ASC, id ASC` where market history is loaded for market, analytics, sale, and user-position paths;
 - a timestamped migration adds composite indexes for market chronology, market/user existence checks, and user/market chronological reads;
 - repository tests seed unrelated market rows between same-timestamp target rows to prove scoped reads exclude cross-market rows and preserve deterministic tie ordering.
+- user bet-history display now uses a narrower projection and deterministic reverse chronological ordering;
+- grouped work-profit hydration now loads child market IDs in one bulk query instead of one query per group;
+- `QUERY_AUDIT.md` records the repository-wide regex pass, actions taken, and follow-up candidates.
 
 ## Design-Plan Alignment
 

--- a/README/PRODUCTION-NOTES/FEATURES/22/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/DESIGN.md
@@ -1,0 +1,380 @@
+---
+title: Market Bet-History Query Boundaries And Replay Efficiency Design
+document_type: feature-design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-23T00:00:00Z
+updated_at_display: "Tuesday, June 23, 2026"
+update_reason: "Align repository/query optimization design with domain-first language, evolutionary architecture, clean dependency boundaries, and transaction-safe read-model rules."
+status: proposed
+---
+
+# Market Bet-History Query Boundaries And Replay Efficiency Design
+
+## Design Posture
+
+The design goal is not to avoid canonical bet history. The design goal is to avoid asking Postgres for more canonical history than the caller needs.
+
+This follows existing SocialPredict boundaries:
+
+- transaction math must remain canonical and non-stale
+- display/read models may be cached or snapshotted
+- repositories own database access details
+- domain services should ask for intent-specific data rather than loading tables and filtering in Go
+
+## Policy Versus Mechanism
+
+Policies this feature must preserve:
+
+- market replay uses canonical chronological bet history in deterministic order;
+- transaction-critical paths use fresh authoritative state;
+- single-market use cases must not request platform-wide bet history;
+- display snapshots must declare freshness and must not drive execution;
+- SQL aggregation must not redefine WPAM, DBPM, dust, payout, refund, or work-profit rules.
+
+Mechanisms this feature may change:
+
+- GORM chain shape;
+- raw SQL where clearer;
+- projection DTOs;
+- composite indexes;
+- CTE/window-query experiments;
+- read-model refresh and invalidation strategy;
+- query-plan and logger-based verification.
+
+## Design-Plan Compatibility
+
+This design intentionally maps the external design-plan postures into a narrow backend performance feature:
+
+| Design posture | Applied here |
+| --- | --- |
+| Evans/domain-first | Preserve SocialPredict accounting language; optimize access to domain facts without redefining the facts. |
+| Fowler/evolutionary | Prefer audit, measurement, scoped methods, indexes, and reversible projection changes before bigger caching or SQL-math rewrites. |
+| Martin/clean architecture | Keep use-case policy in domain services and persistence mechanics in repository adapters. Repository interfaces express intent; GORM does not define the domain. |
+
+The design is not a general database-performance campaign. It is specifically about aligning query scope with domain use cases while keeping transaction math authoritative.
+
+## Bounded Contexts And Ownership
+
+| Boundary | Owns | Must not own |
+| --- | --- | --- |
+| Prediction Market Core | canonical bet history, WPAM/DBPM policy, sale/dust/resolution/refund correctness | GORM query mechanics, index names, display freshness policy |
+| Transaction Use Cases | authoritative buy/sell/quote/resolve/refund/payout flows | stale read-model data, async snapshots, UI pagination shortcuts |
+| Display Read Models | cached/snapshotted market cards, charts, leaderboards, stats where freshness is acceptable | order execution, balance mutation, payout decisions |
+| Repository Interfaces | use-case-shaped data access contracts | generic table dumps or framework types leaking inward |
+| GORM/Postgres Adapters | SQL predicates, indexes, projections, aggregate queries, transaction mechanics | business policy decisions or alternative market-math semantics |
+
+The desired dependency direction is:
+
+```text
+handlers -> domain/application service -> repository interface -> GORM/Postgres adapter
+```
+
+Use-case/application packages own repository ports. GORM repositories are outer adapters implementing those ports.
+
+Domain and use-case code must not import:
+
+- `gorm`;
+- SQL builders or concrete query helpers;
+- migration packages;
+- concrete repository packages;
+- ORM row types unless they have been intentionally promoted into domain entities.
+
+The adapter can use projection structs, raw SQL, or GORM chains as implementation details.
+
+## Repository Boundary
+
+Repository methods should expose intent, not generic table access.
+
+Preferred methods:
+
+```go
+ListChronologicalBetEventsForMarket(ctx, marketID)
+ListRecentVisibleBetRowsForMarket(ctx, marketID, page)
+LoadPositionReplayInputs(ctx, username, marketIDs)
+CountFirstPositiveParticipationsByMarket(ctx, marketIDs)
+UserHasBet(ctx, marketID, username)
+```
+
+Avoid new generic methods like:
+
+```go
+ListBets(ctx)
+AllBets(ctx)
+```
+
+Those names hide whether the caller truly needs a system-wide read.
+
+When a global read is legitimate, the method name should say so:
+
+```go
+ComputeGlobalParticipationCounts(ctx)
+LoadSystemMetricSnapshot(ctx)
+ListGlobalLeaderboardCandidates(ctx, page)
+```
+
+This gives reviewers a language-level way to distinguish intentional platform-wide aggregation from accidental broad scans.
+
+When reasons to change differ, prefer narrow ports instead of one broad `BetRepository`:
+
+| Port/interface | Reason to change |
+| --- | --- |
+| `MarketReplayReader` | WPAM/DBPM/resolution/refund replay input requirements. |
+| `MarketDisplayReader` | visible bet rows, display pagination, chart/read-model behavior. |
+| `UserPositionReader` | user-scoped portfolio and position inputs. |
+| `PlatformAggregateReader` | system metrics, global leaderboard candidates, participation aggregates. |
+
+These can share one concrete GORM adapter internally, but the inner contracts should stay use-case-shaped.
+
+## Per-Market Calculations
+
+Per-market calculations may need every bet for that market. That is acceptable. They should not need every bet for every market.
+
+Examples:
+
+- market probability history
+- market detail chart
+- market resolution payout
+- N/A refund calculation
+- market-level leaderboard
+- market volume/dust display
+
+Required repository behavior:
+
+```text
+market_id predicate is applied in SQL
+chronological ordering is done in SQL
+only needed columns are selected where practical
+```
+
+## Column Projection
+
+Every repository method should choose the narrowest correct projection for its caller.
+
+| Caller type | Preferred projection |
+| --- | --- |
+| WPAM replay | chronological amount/outcome/time rows; include `id` for deterministic tie-breaks |
+| DBPM positions | username, market, amount, outcome, time rows; include `id` where ordering matters |
+| Volume/dust display | amount rows or aggregate volume snapshot |
+| First participation fee counts | market/user positive participation rows or SQL aggregate counts |
+| Recent bet table | visible row fields plus display probability source |
+| Existence checks | `EXISTS`/`COUNT`; do not materialize bet rows |
+
+Full model reads remain acceptable where the caller truly needs the whole model, but they should not be the default for high-frequency or high-volume paths.
+
+Projection-row rules:
+
+- use simple scalar DTOs;
+- include deterministic ordering fields such as `id` and `placed_at` where replay order matters;
+- avoid GORM hooks, lifecycle methods, or business methods on projection rows;
+- avoid framework-specific types crossing inward;
+- name display DTOs distinctly from transaction replay inputs;
+- do not return `models.Bet` to WPAM/DBPM unless it is intentionally treated as a domain entity rather than an ORM row.
+
+## Query Consolidation
+
+Some display endpoints may currently assemble a page by calling several repositories that each perform their own table scan or replay. The implementation audit should identify those call chains and decide whether one of these is better:
+
+- one aggregate SQL query;
+- one scoped query returning a compact DTO;
+- one read-model refresh that stores the display payload;
+- one explicit transaction-safe repository call for canonical execution paths.
+
+Consolidation should not merge unrelated domain decisions. It should only reduce redundant database work for one coherent display or metric payload.
+
+## Critical Decisions Versus Mechanisms
+
+| Concern | Critical policy decision? | Mechanism choice? | Rule |
+| --- | --- | --- | --- |
+| Whether transaction paths use canonical fresh state | Yes | No | Must not be changed by this feature. |
+| Whether a display widget may use a stale snapshot | Yes | Partly | Requires an explicit freshness contract and UI/API behavior. |
+| Whether a query uses GORM chains or raw SQL | No | Yes | Choose the clearer/testable adapter implementation. |
+| Which indexes support common predicates | No | Yes | Add through migrations and verify with tests or query plans. |
+| Whether WPAM/DBPM math moves into SQL | Yes | No for this feature | Out of scope unless a separate equivalence feature proves it. |
+| Whether global metrics are cached hourly/minutely | Yes | Partly | Belongs with read-model/cache policy, not hidden inside repository code. |
+
+## Pagination Caveat
+
+The market bet table can show a paginated page of rows, but the current implementation may still need full market history to attach probability-after-bet values without creating a second math path.
+
+Implementation options:
+
+| Option | Tradeoff | Migration cost | Operational burden | Reversibility | When to choose |
+| --- | --- | --- | --- | --- | --- |
+| Keep full market-scoped history for bet table | Correct and simple, but expensive for very large single markets. | Low | Low | High | First slice and moderate market history sizes. |
+| Add probability-history read model | Faster display; must remain display-only and invalidated after transactions. | Medium | Medium | Medium | After profiling proves full market replay dominates display latency. |
+| Use window/CTE query for recent rows plus probability snapshot | More complex; may be useful after profiling. | Medium/high | Medium | Medium | When recent visible rows are hot but full probability history is already snapshotted. |
+
+The first implementation should focus on avoiding platform-wide scans and adding indexes. Later slices can optimize very large single-market history display.
+
+## Global Aggregates
+
+Some queries are global by definition. Examples:
+
+- system financial metrics
+- global leaderboard
+- platform participation fees
+
+These should not be confused with accidental broad scans. However, they are still risky as the platform grows.
+
+Preferred future shapes:
+
+- aggregate SQL for counts/sums where possible
+- durable read-model snapshots refreshed asynchronously or after mutations
+- paginated/ranked materialized views for leaderboards
+- explicit repository method names that include `Global`, `Aggregate`, or `Snapshot`
+
+Tradeoff notes:
+
+| Shape | Benefit | Cost | Use when |
+| --- | --- | --- | --- |
+| Aggregate SQL | Reduces row materialization and app CPU. | Couples repository adapter to Postgres query shape. | Metric is a count/sum/group and does not require chronological market math. |
+| Durable read-model snapshot | Stable under repeated reads and restart-inspectable. | Needs refresh/invalidation ownership and migration/storage. | Display route is hot and can tolerate explicit staleness. |
+| Materialized/ranked view | Efficient for leaderboards and rankings. | More operational complexity and Postgres-specific behavior. | Repeated global ranking pressure is measured. |
+
+For first-participation fee accounting, prefer pushing the distinct `(market_id, username)` grouping into SQL rather than materializing all `bets` rows. A repository method could return either a platform total or per-market counts depending on the caller:
+
+```sql
+SELECT market_id, COUNT(*) AS participant_count
+FROM (
+  SELECT market_id, username
+  FROM bets
+  WHERE amount > 0
+  GROUP BY market_id, username
+) first_participations
+GROUP BY market_id;
+```
+
+This is the refined version of the idea explored in PR #352: aggregate in the database, but return only the aggregate shape the domain needs.
+
+## Evolution Path
+
+The implementation should proceed in reversible slices:
+
+1. **Inventory and classify** current GORM reads and callers.
+2. **Add tests around existing scoped behavior** before changing queries.
+3. **Add missing indexes** using timestamped migrations.
+4. **Introduce projection methods** behind existing repository interfaces where call sites can stay stable.
+5. **Move simple global counts/sums to aggregate SQL** only where domain semantics are not chronology-sensitive.
+6. **Defer probability-history/read-model rewrites** until profiling proves hot single-market history is the bottleneck.
+
+Each slice should be independently reviewable and should not require a frontend or market-math rewrite.
+
+Fallback rules:
+
+- Keep old repository methods while introducing projection methods until call sites are migrated and tested.
+- Index migrations should inspect for duplicates first and should consider write-path cost and lock behavior.
+- If a projection or aggregate changes behavior, revert to the older full canonical input and keep the failed optimization as evidence.
+
+## SQL Versus Go Math Boundary
+
+Postgres should reduce and shape data. Go should preserve SocialPredict's domain math.
+
+| Work | Belongs in Postgres? | Belongs in Go? | Notes |
+| --- | --- | --- | --- |
+| Filtering a market's bets | Yes | No | `WHERE market_id = ?` should happen in SQL. |
+| Selecting only needed bet columns | Yes | No | Use projection row structs. |
+| Counting users/markets | Yes | No | Pure aggregate. |
+| Counting first positive market participants | Yes | Usually no | Aggregate in SQL; apply policy thresholds in Go if clearer. |
+| Summing plain active volume | Yes | Maybe | SQL or read-model snapshot is appropriate for display. |
+| WPAM chronological probability replay | No, unless separately proven | Yes | Chronology-sensitive domain math. |
+| DBPM position valuation | No, unless separately proven | Yes | Keep audited math path in Go. |
+| Sale order execution/dust calculation | No stale aggregate | Yes | Transaction path must use canonical current state. |
+| Chart/card display probability | Snapshot preferred | Maybe | Display can use read models; transaction paths cannot. |
+
+This boundary prevents the optimization work from accidentally creating a second market-math implementation inside SQL.
+
+## Candidate Function/Metric Audit Seeds
+
+Initial candidates to inspect during implementation:
+
+| Function/path | Owner boundary | Current shape to verify | Candidate optimization |
+| --- | --- | --- | --- |
+| `markets.GormRepository.ListBetsForMarket` | Prediction Market Core / Persistence Adapter | market-scoped, currently full bet model projection | narrow projection for callers that do not need full `models.Bet` |
+| `analytics.GormRepository.ListBetsForMarket` | Analytics Read Model / Persistence Adapter | market-scoped, already selected columns | verify ordering includes deterministic `id`; add index support |
+| `markets.Service.GetMarketBetsPage` | Market Display Read Model | market-scoped full history, then in-memory page | keep correctness; later use probability snapshot plus recent-row projection |
+| `analytics.Service.ComputeSystemMetrics` | Platform Aggregate | global metrics assembled from users/markets/bets | aggregate SQL/read-model snapshot for counts, active volume, participation fees |
+| `analytics.Service.ComputeGlobalLeaderboardSnapshot` | Platform Aggregate / Display Read Model | all users, all markets, per-market bet loads | cached leaderboard snapshot / pre-aggregated candidate rows |
+| user financial summary paths | Participant Account / User Display | user-scoped then affected market IDs | ensure narrow projections and use user financial read model for display |
+| `bets.GormRepository.UserHasBet` | Betting/Position Ledger | count with `market_id`/`username` predicate | consider `EXISTS` and supporting composite index |
+
+## ADR Candidates
+
+- ADR: Transaction paths must use canonical bet history and never stale display snapshots.
+- ADR: Repository methods are named by use case/intent rather than table access.
+- ADR: Postgres may aggregate and project data, but WPAM/DBPM policy remains in Go unless separately proven equivalent.
+- ADR: High-volume display paths prefer read models or aggregate SQL when freshness and domain rules allow it.
+- ADR: Index additions follow timestamped migration convention and are backed by focused tests.
+
+## Query Audit Output
+
+The implementation audit should produce a table like:
+
+| Path | Current query shape | Scope | Risk | Proposed change |
+| --- | --- | --- | --- | --- |
+| `GetMarketBetsPage` | `ListBetsForMarket` then in-memory page | market-scoped | single hot market history can grow large | keep scoped baseline; consider probability read model later |
+| `ComputeSystemMetrics` | `ListMarkets` plus per-market bet loads and global ordered bets for fees | global | expensive at platform scale | aggregate SQL/read-model snapshot |
+| `ComputeGlobalLeaderboardSnapshot` | all users, all markets, per-market bet loads | global | expensive at platform scale | cached leaderboard snapshot / aggregate strategy |
+
+## Migration Boundary
+
+Indexes must be added through the existing timestamped migration convention. The implementation should inspect current migrations first to avoid duplicate indexes.
+
+Migration convention:
+
+- file name: readable `YYYYMMDD_HHMMSS_description.go`;
+- registration ID: compact timestamp format already used by `backend/migration`;
+- behavior: additive/backward-compatible where practical;
+- tests: package-local migration tests for created indexes/default behavior where practical;
+- evidence: note duplicate-index inspection and expected lock/write-path impact in the PR.
+
+## Testing Boundary
+
+Tests should verify behavior first and query shape where necessary:
+
+- seed bets for multiple markets
+- call per-market repository method
+- assert rows from other markets are excluded
+- assert ordering by `placed_at`, then `id` when needed
+- for Postgres integration tests, optionally use `EXPLAIN` to verify indexes are eligible after indexes exist
+- add a fake repository or call-counter test proving transaction services do not route through display snapshot repositories for execution
+- add projection tests that fail if a required WPAM/DBPM input is accidentally removed from the row shape
+- add aggregate tests that seed multiple markets/users and prove returned counts/sums match business-intent names
+- add pure WPAM/DBPM tests with in-memory event DTOs to prove reduced inputs are equivalent
+- add use-case tests with fake repository ports to verify dependency direction
+- add adapter contract tests with multiple markets/users to prove SQL-scoped behavior
+- add migration/index existence tests where the migration framework supports it
+- add import-guard tests or static checks preventing `gorm` imports from entering domain/use-case packages
+- for high-risk methods, use query capture, GORM dry-run, or logger assertions to prove the generated SQL carries the required scope predicate
+
+Result-only tests are not sufficient for query-scope proof because an implementation could load all rows and filter in Go while returning the correct answer.
+
+## Read-Model Freshness Rules
+
+Any display snapshot or read model introduced by this feature must document:
+
+- owner;
+- refresh trigger;
+- invalidation after buy, sell, resolve, refund, or equivalent mutation;
+- max acceptable staleness;
+- freshness field exposed to callers, such as `generated_at` or `as_of_event_id`;
+- explicit prohibition from transaction-critical execution paths.
+
+## Risks And Open Questions
+
+| Risk or ambiguity | Why it matters | Resolution path |
+| --- | --- | --- |
+| Feature number conflicts with newer docs on `main` | This branch was authored before later grouped-market feature docs occupied adjacent numbers. | Renumber before retargeting to current `main` if needed. |
+| Narrow projections accidentally omit fields used by chronology-sensitive math | Could change probability, positions, dust, or payout behavior. | Projection tests must cover WPAM/DBPM required inputs and deterministic ordering. |
+| Aggregate SQL creates a hidden second interpretation of market economics | Could make stats disagree with transaction truth. | Keep SQL to counts/sums/grouping; apply domain policy in Go unless separately proven. |
+| Index additions improve reads but slow writes | Betting is write-heavy during hot events. | Measure write-path impact and keep indexes tied to demonstrated access patterns. |
+| In-memory pagination remains expensive for very large single markets | Market-scoped is necessary but may not be sufficient at high event volumes. | Defer probability-history read model or recent-row strategy until profiling justifies it. |
+| Display read models leak into transaction paths | Could make orders, balances, payouts, refunds, or dust depend on stale state. | Use repository naming, fake-port tests, and import/call guards. |
+
+## Non-Goals
+
+- Do not rewrite market math.
+- Do not put stale snapshots on transaction paths.
+- Do not remove canonical bet-history replay where correctness requires it.
+- Do not implement Redis just to hide inefficient SQL.
+- Do not introduce framework/database types into domain policy to make a query easier.

--- a/README/PRODUCTION-NOTES/FEATURES/22/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/PLAN.md
@@ -3,10 +3,10 @@ title: Market Bet-History Query Boundaries And Replay Efficiency Plan
 document_type: feature-plan
 domain: features
 author: Patrick Delaney
-updated_at: 2026-06-23T00:00:00Z
-updated_at_display: "Tuesday, June 23, 2026"
-update_reason: "Align implementation slices with design-plan review: domain-term classification, narrow repository ports, migration evidence, and query-scope proof."
-status: proposed
+updated_at: 2026-06-25T00:00:00Z
+updated_at_display: "Thursday, June 25, 2026"
+update_reason: "Start implementation with deterministic market bet replay ordering, composite bet indexes, and scoped-read adapter tests."
+status: in_progress
 ---
 
 # Market Bet-History Query Boundaries And Replay Efficiency Plan
@@ -51,13 +51,20 @@ Checklist:
 
 Checklist:
 
-- [ ] Inspect existing timestamped migrations for bet/market/tag indexes.
-- [ ] Confirm index naming and duplicate-index behavior before adding migrations.
-- [ ] Add missing timestamped migrations for market bet chronology.
-- [ ] Add missing timestamped migrations for market+user and user+market bet lookups.
+- [x] Inspect existing timestamped migrations for bet/market/tag indexes.
+- [x] Confirm index naming and duplicate-index behavior before adding migrations.
+- [x] Add missing timestamped migrations for market bet chronology.
+- [x] Add missing timestamped migrations for market+user and user+market bet lookups.
 - [ ] Add missing timestamped migrations for lifecycle/status/tag discovery if absent.
-- [ ] Add migration tests or Postgres verification where practical.
-- [ ] Record write-path/storage/lock-risk notes for each new composite index.
+- [x] Add migration tests or Postgres verification where practical.
+- [x] Record write-path/storage/lock-risk notes for each new composite index.
+
+Implementation note:
+
+- Added `idx_bets_market_id_placed_at_id` for canonical per-market replay reads ordered by `placed_at ASC, id ASC`.
+- Added `idx_bets_market_id_username` for first-participation and market/user existence checks.
+- Added `idx_bets_username_market_id_placed_at_id` for user-scoped position/portfolio reads that identify affected markets and then replay those markets.
+- These indexes trade additional bet-insert write/storage cost for scoped read performance. They do not add business state or alter transaction math.
 
 ## 05. Repository Refactor
 
@@ -70,14 +77,19 @@ Checklist:
 - [ ] Ensure projection rows are scalar DTOs with no GORM hooks/business methods.
 - [ ] Ensure projection rows include deterministic ordering fields where needed.
 - [ ] Keep framework-specific types and concrete repository packages out of domain/use-case packages.
-- [ ] Ensure per-market methods include SQL `market_id` predicates.
+- [x] Ensure per-market methods include SQL `market_id` predicates.
 - [ ] Ensure high-volume reads select only needed columns.
 - [ ] Ensure user methods begin from `username` where appropriate.
 - [ ] Avoid adding generic `ListBets`/`AllBets` methods without explicit global naming.
-- [ ] Add tests that seed multiple markets and prove per-market reads exclude unrelated rows.
+- [x] Add tests that seed multiple markets and prove per-market reads exclude unrelated rows.
 - [ ] Add adapter-level query-capture, dry-run, or logger assertions for high-risk methods so correct results cannot hide broad SQL.
-- [ ] Add ordering tests for chronological market replay.
+- [x] Add ordering tests for chronological market replay.
 - [ ] Add tests proving narrow projections still satisfy WPAM/DBPM calculator inputs.
+
+Implementation note:
+
+- Updated market, analytics, sell-transaction, and user-position bet-history readers to use deterministic `placed_at ASC, id ASC` ordering.
+- Added repository tests that seed unrelated market rows between same-timestamp target rows, then verify only the requested market's rows are returned and ties are ordered by ID.
 
 ## 06. Display Path Optimization
 
@@ -98,14 +110,14 @@ Checklist:
 Checklist:
 
 - [ ] Run backend unit tests.
-- [ ] Run targeted repository tests.
+- [x] Run targeted repository tests.
 - [ ] Run Postgres integration tests for index-heavy paths when `POSTGRES_TEST_DSN` is available.
 - [ ] Capture before/after query counts or query plans for at least one high-risk route.
 - [ ] Capture before/after row count and column projection evidence for at least one hot market replay path.
 - [ ] Run pure WPAM/DBPM tests with in-memory event DTOs for reduced replay inputs.
 - [ ] Run use-case tests with fake repository ports.
 - [ ] Run adapter contract tests with multiple markets/users.
-- [ ] Run migration/index existence tests where practical.
+- [x] Run migration/index existence tests where practical.
 - [ ] Run import-guard/static checks preventing `gorm` imports from domain/use-case packages if such a guard exists or can be added cheaply.
 - [ ] Prove optimized/reduced query inputs produce identical WPAM, DBPM, resolution, refund, and dust results for representative replay histories.
 

--- a/README/PRODUCTION-NOTES/FEATURES/22/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/PLAN.md
@@ -24,15 +24,15 @@ Checklist:
 
 Checklist:
 
-- [ ] Define the domain term represented by each `bets` read: replay event stream, visible bet row, participation aggregate, position input, audit record, or display snapshot.
-- [ ] Inventory every production GORM read of `bets`.
-- [ ] Classify each read as transaction-critical, market display, user display, system aggregate, or admin/search.
-- [ ] Assign an owner boundary to each read: Prediction Market Core, Betting/Position Ledger, Participant Account, Analytics/Read Model, Admin/Search, or Persistence Adapter.
-- [ ] Document whether each query is already SQL-scoped, scoped through `IN`, or broad/global by design.
-- [ ] Identify accidental table-wide reads in per-market or per-user paths.
-- [ ] Identify over-wide projections such as `Select("bets.*")`, plain full-model `Find`, or unused model fields.
+- [x] Define the domain term represented by each `bets` read: replay event stream, visible bet row, participation aggregate, position input, audit record, or display snapshot.
+- [x] Inventory every production GORM read of `bets`.
+- [x] Classify each read as transaction-critical, market display, user display, system aggregate, or admin/search.
+- [x] Assign an owner boundary to each read: Prediction Market Core, Betting/Position Ledger, Participant Account, Analytics/Read Model, Admin/Search, or Persistence Adapter.
+- [x] Document whether each query is already SQL-scoped, scoped through `IN`, or broad/global by design.
+- [x] Identify accidental table-wide reads in per-market or per-user paths.
+- [x] Identify over-wide projections such as `Select("bets.*")`, plain full-model `Find`, or unused model fields.
 - [ ] Identify display paths that page in memory after loading full market history.
-- [ ] Identify related query groups that can be consolidated into one aggregate query, scoped DTO query, or read-model refresh.
+- [x] Identify related query groups that can be consolidated into one aggregate query, scoped DTO query, or read-model refresh.
 - [ ] Identify global paths that should move to aggregate SQL or read-model snapshots.
 - [ ] Revisit the PR #352 first-time participation query idea and convert it into aggregate repository methods rather than row materialization.
 - [ ] Document first-participation edge cases: repeated buys, sells after buy, refunds, cancelled/N/A markets, zero/negative rows, and participant identity changes.
@@ -64,6 +64,7 @@ Implementation note:
 - Added `idx_bets_market_id_placed_at_id` for canonical per-market replay reads ordered by `placed_at ASC, id ASC`.
 - Added `idx_bets_market_id_username` for first-participation and market/user existence checks.
 - Added `idx_bets_username_market_id_placed_at_id` for user-scoped position/portfolio reads that identify affected markets and then replay those markets.
+- Added `idx_bets_username_placed_at_id` for user bet-history display ordered by `placed_at DESC, id DESC`.
 - These indexes trade additional bet-insert write/storage cost for scoped read performance. They do not add business state or alter transaction math.
 
 ## 05. Repository Refactor
@@ -79,7 +80,7 @@ Checklist:
 - [ ] Keep framework-specific types and concrete repository packages out of domain/use-case packages.
 - [x] Ensure per-market methods include SQL `market_id` predicates.
 - [ ] Ensure high-volume reads select only needed columns.
-- [ ] Ensure user methods begin from `username` where appropriate.
+- [x] Ensure user methods begin from `username` where appropriate.
 - [ ] Avoid adding generic `ListBets`/`AllBets` methods without explicit global naming.
 - [x] Add tests that seed multiple markets and prove per-market reads exclude unrelated rows.
 - [ ] Add adapter-level query-capture, dry-run, or logger assertions for high-risk methods so correct results cannot hide broad SQL.
@@ -90,6 +91,8 @@ Implementation note:
 
 - Updated market, analytics, sell-transaction, and user-position bet-history readers to use deterministic `placed_at ASC, id ASC` ordering.
 - Added repository tests that seed unrelated market rows between same-timestamp target rows, then verify only the requested market's rows are returned and ties are ordered by ID.
+- Updated user bet-history display to select only `market_id` and `placed_at` with deterministic reverse chronological ordering.
+- Collapsed grouped work-profit member hydration from one query per group into one `WHERE group_id IN ?` query.
 
 ## 06. Display Path Optimization
 

--- a/README/PRODUCTION-NOTES/FEATURES/22/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/PLAN.md
@@ -1,0 +1,120 @@
+---
+title: Market Bet-History Query Boundaries And Replay Efficiency Plan
+document_type: feature-plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-23T00:00:00Z
+updated_at_display: "Tuesday, June 23, 2026"
+update_reason: "Align implementation slices with design-plan review: domain-term classification, narrow repository ports, migration evidence, and query-scope proof."
+status: proposed
+---
+
+# Market Bet-History Query Boundaries And Replay Efficiency Plan
+
+## 01. Feature Spec
+
+Checklist:
+
+- [x] Create feature overview.
+- [x] Create design document.
+- [x] Create implementation plan.
+- [x] Ground the spec in a first-pass code audit.
+
+## 02. Query Audit
+
+Checklist:
+
+- [ ] Define the domain term represented by each `bets` read: replay event stream, visible bet row, participation aggregate, position input, audit record, or display snapshot.
+- [ ] Inventory every production GORM read of `bets`.
+- [ ] Classify each read as transaction-critical, market display, user display, system aggregate, or admin/search.
+- [ ] Assign an owner boundary to each read: Prediction Market Core, Betting/Position Ledger, Participant Account, Analytics/Read Model, Admin/Search, or Persistence Adapter.
+- [ ] Document whether each query is already SQL-scoped, scoped through `IN`, or broad/global by design.
+- [ ] Identify accidental table-wide reads in per-market or per-user paths.
+- [ ] Identify over-wide projections such as `Select("bets.*")`, plain full-model `Find`, or unused model fields.
+- [ ] Identify display paths that page in memory after loading full market history.
+- [ ] Identify related query groups that can be consolidated into one aggregate query, scoped DTO query, or read-model refresh.
+- [ ] Identify global paths that should move to aggregate SQL or read-model snapshots.
+- [ ] Revisit the PR #352 first-time participation query idea and convert it into aggregate repository methods rather than row materialization.
+- [ ] Document first-participation edge cases: repeated buys, sells after buy, refunds, cancelled/N/A markets, zero/negative rows, and participant identity changes.
+
+## 03. Baseline Evidence
+
+Checklist:
+
+- [ ] Capture current query count for at least one high-risk market route.
+- [ ] Capture rows loaded and columns selected for at least one hot-market replay path.
+- [ ] Capture current latency or p95 behavior for a representative display route where available.
+- [ ] Record whether the bottleneck is platform-wide scanning, large single-market replay, over-wide projection, missing index, or repeated call-chain work.
+- [ ] Commit or link the query-audit table in PR notes.
+
+## 04. Index Migration
+
+Checklist:
+
+- [ ] Inspect existing timestamped migrations for bet/market/tag indexes.
+- [ ] Confirm index naming and duplicate-index behavior before adding migrations.
+- [ ] Add missing timestamped migrations for market bet chronology.
+- [ ] Add missing timestamped migrations for market+user and user+market bet lookups.
+- [ ] Add missing timestamped migrations for lifecycle/status/tag discovery if absent.
+- [ ] Add migration tests or Postgres verification where practical.
+- [ ] Record write-path/storage/lock-risk notes for each new composite index.
+
+## 05. Repository Refactor
+
+Checklist:
+
+- [ ] Add or standardize narrow use-case repository ports, not one broad `BetRepository` for unrelated reasons to change.
+- [ ] Split ports where appropriate: `MarketReplayReader`, `MarketDisplayReader`, `UserPositionReader`, and `PlatformAggregateReader`.
+- [ ] Add aggregate methods for unique positive participants by market/platform where system metrics or work-profit reporting need them.
+- [ ] Add purpose-specific row structs for narrow bet projections.
+- [ ] Ensure projection rows are scalar DTOs with no GORM hooks/business methods.
+- [ ] Ensure projection rows include deterministic ordering fields where needed.
+- [ ] Keep framework-specific types and concrete repository packages out of domain/use-case packages.
+- [ ] Ensure per-market methods include SQL `market_id` predicates.
+- [ ] Ensure high-volume reads select only needed columns.
+- [ ] Ensure user methods begin from `username` where appropriate.
+- [ ] Avoid adding generic `ListBets`/`AllBets` methods without explicit global naming.
+- [ ] Add tests that seed multiple markets and prove per-market reads exclude unrelated rows.
+- [ ] Add adapter-level query-capture, dry-run, or logger assertions for high-risk methods so correct results cannot hide broad SQL.
+- [ ] Add ordering tests for chronological market replay.
+- [ ] Add tests proving narrow projections still satisfy WPAM/DBPM calculator inputs.
+
+## 06. Display Path Optimization
+
+Checklist:
+
+- [ ] Keep transaction paths canonical and non-cached.
+- [ ] Keep market bet table market-scoped even when full history is needed for probability display.
+- [ ] Keep WPAM/DBPM math in Go unless a separate math-equivalence feature proves another implementation.
+- [ ] Consider a probability-history display read model only after profiling proves very large single-market bet-table pressure.
+- [ ] If a display read model is introduced, document owner, refresh trigger, invalidation triggers, max staleness, and exposed freshness metadata.
+- [ ] Add guardrail tests proving display read models are not used by buy, sell, quote execution, resolve, refund, dust, payout, or balance mutation paths.
+- [ ] Move system metrics and global leaderboard toward aggregate/read-model paths from Feature 11.
+- [ ] Document intentionally global queries.
+- [ ] Add entry criteria for future read models: measured p95 latency, rows loaded per request, repeated global replay, or single-market history size beyond an agreed threshold.
+
+## 07. Verification
+
+Checklist:
+
+- [ ] Run backend unit tests.
+- [ ] Run targeted repository tests.
+- [ ] Run Postgres integration tests for index-heavy paths when `POSTGRES_TEST_DSN` is available.
+- [ ] Capture before/after query counts or query plans for at least one high-risk route.
+- [ ] Capture before/after row count and column projection evidence for at least one hot market replay path.
+- [ ] Run pure WPAM/DBPM tests with in-memory event DTOs for reduced replay inputs.
+- [ ] Run use-case tests with fake repository ports.
+- [ ] Run adapter contract tests with multiple markets/users.
+- [ ] Run migration/index existence tests where practical.
+- [ ] Run import-guard/static checks preventing `gorm` imports from domain/use-case packages if such a guard exists or can be added cheaply.
+- [ ] Prove optimized/reduced query inputs produce identical WPAM, DBPM, resolution, refund, and dust results for representative replay histories.
+
+## 08. Rollout And Fallback
+
+Checklist:
+
+- [ ] Introduce projection/aggregate methods alongside old methods before deleting broad methods.
+- [ ] Migrate the highest-risk call sites first.
+- [ ] Leave a simple fallback path to the previous canonical full-input method until behavior and performance evidence are captured.
+- [ ] Retire broad methods only after callers are migrated and tests prove no semantic drift.
+- [ ] If a query optimization changes economic behavior, revert it and open a separate math-equivalence feature rather than silently accepting the change.

--- a/README/PRODUCTION-NOTES/FEATURES/22/QUERY_AUDIT.md
+++ b/README/PRODUCTION-NOTES/FEATURES/22/QUERY_AUDIT.md
@@ -1,0 +1,63 @@
+---
+title: GORM Query Scope Regex Audit
+document_type: feature-audit
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-25T00:00:00Z
+updated_at_display: "Thursday, June 25, 2026"
+update_reason: "Record repository-wide regex audit findings for GORM query scoping and first implementation actions."
+status: in_progress
+---
+
+# GORM Query Scope Regex Audit
+
+This audit records the repository-wide regex pass used for Feature 22. The goal is not to replace profiling. The goal is to catch obvious broad reads, missing predicates, unstable ordering, over-wide projections, and N+1 hydration patterns before deeper performance work.
+
+## Search Commands
+
+```bash
+rg -n '\.Find\(&|\.First\(&|\.Last\(&|\.Take\(&|\.Scan\(&|\.Count\(&|\.Raw\(|\.Exec\(|\.Joins\(|\.Preload\(|\.Model\(&|\.Table\(' backend/internal backend/handlers backend/server backend/seed backend/migration backend/models -g '*.go'
+rg -n 'models\.Bet|Table\("bets"\)|Model\(&models\.Bet|\[\]models\.Bet|Find\(&bets|Where\("market_id|Where\("username' backend -g '*.go'
+rg -n '\.Find\(&|\.First\(&|\.Scan\(&|\.Count\(&|\.Raw\(|\.Table\("bets"\)|Model\(&models\.Bet|\[\]models\.Bet' backend/internal backend/handlers backend/cmd backend/seed backend/server -g '*.go' -g '!*_test.go'
+```
+
+## Findings
+
+| Area | Query shape found | Risk | Action in PR #745 | Remaining action |
+| --- | --- | --- | --- | --- |
+| Market replay reads | `WHERE market_id = ?` with chronological replay in market, analytics, sale, and user-position adapters. | Correctly scoped, but timestamp ties could replay differently. | Added `placed_at ASC, id ASC`. Added `idx_bets_market_id_placed_at_id`. Added scoped-read tests. | Consider narrower replay projections for transaction adapters only after math-equivalence tests. |
+| User bet history display | `WHERE username = ? ORDER BY placed_at DESC` hydrating full `models.Bet`. | Over-wide projection and no stable tie order. | Added `Select("market_id", "placed_at")`, `ORDER BY placed_at DESC, id DESC`, and `idx_bets_username_placed_at_id`. Expanded repository test. | If profile history grows large, add pagination at the repository/domain port. |
+| User financial positions | Starts from `WHERE username = ?`, then loads only affected `market_id IN ?`. | Good scope; still replays full affected markets to preserve canonical position math. | Existing `idx_bets_username_market_id_placed_at_id` and `idx_bets_market_id_placed_at_id` support the two-phase read. | Do not shortcut transaction or position math without equivalence tests. |
+| User-has-bet / first participation checks | `WHERE market_id = ? AND username = ? COUNT`. | Correctly scoped; needs composite index. | Added `idx_bets_market_id_username`. | A later aggregate method can count first positive participants without materializing rows. |
+| Global analytics bet reads | `ListBetsOrdered` intentionally scans all bets for platform-wide metrics/leaderboards. | Legitimate global read, but expensive as platform grows. | Documented as intentionally global. Existing deterministic order already includes `market_id, placed_at, id`. | Move more global metrics to read-model snapshots or SQL aggregates under Feature 11/22 continuation. |
+| Market group work-profit hydration | Groups were loaded, then members were queried once per group. | N+1 query pattern for grouped market financial metrics. | Collapsed to one `WHERE group_id IN ?` member query. Existing `idx_market_group_members_group_order` supports it. Added repository test. | None for this slice. |
+| Market discovery `/markets` and `/markets/topic/:slug` | Loads matching markets, hydrates group/tag data, groups in Go, then paginates grouped rows. | Correct grouped pagination semantics, but can materialize too many rows for broad discovery pages. | Documented as the largest remaining scaling candidate. | Build a backend grouped discovery read model or SQL grouped-row query before high-volume production use. |
+| Admin market review | Raw grouped page key query with `COUNT`, `LIMIT`, `OFFSET`, then hydrates selected keys. | Good server-side pagination shape; search uses `LOWER(... LIKE)` across text. | No code change needed in this slice. | Consider trigram/full-text search only if admin search latency becomes visible. |
+| Description amendment review | Raw grouped page key query with `COUNT`, `LIMIT`, `OFFSET`, then hydrates selected keys. | Good server-side pagination shape; text search may grow. | No code change needed in this slice. | Same search-index caveat as admin review. |
+| Answer addition review | GORM count + limited page query with optional group join. | Acceptable scoped admin/moderator queue. | Existing model indexes cover group/status and status/created. | Consider additional reviewer/steward indexes only after queue latency appears. |
+| CMS/settings/read-model lookups | Slug/key lookups on small singleton/config tables. | Low volume and already scoped. | No change. | None. |
+| Dev bootstrap/load-test seed commands | Utility queries by username/title/tag. | Not production request path. | No change. | None. |
+| Tests/migrations | Broad GORM calls in test setup and migration plumbing. | Not production path. | Excluded from production-action list. | None. |
+
+## Current Conclusion
+
+The original concern that GORM might load the full `bets` table before applying `Where("market_id = ?")` is not accurate for these adapter calls. GORM generates SQL predicates and Postgres/SQLite apply those predicates in the database.
+
+The useful optimizations from this pass are therefore more specific:
+
+- keep per-market replay reads SQL-scoped;
+- make replay ordering deterministic with `id` tie-breaks;
+- add composite indexes that match the actual predicates and ordering;
+- select fewer columns on display-only paths;
+- remove obvious N+1 hydration where the result is still the same domain record;
+- document intentionally global analytics reads rather than pretending every global scan is a bug.
+
+## Follow-Up Candidates
+
+| Candidate | Why not in this slice? | Entry criterion |
+| --- | --- | --- |
+| Grouped discovery SQL/read-model pagination | More invasive; must preserve grouped-market row semantics, tag filtering, and topic search. | `/markets` or `/markets/topic/:slug` p95/row materialization becomes a measured bottleneck. |
+| Probability-history display read model | Changes display freshness path and needs invalidation/freshness metadata. | Single-market bet history grows enough that chart rendering repeatedly replays too many rows. |
+| SQL aggregate first-participation counts | Safe if carefully named, but must match fee/work-profit policy around positive participation and grouped children. | System metrics or work-profit reporting shows global bet replay pressure. |
+| Full-text/trigram search indexes | Deployment-specific Postgres feature choice. | Search latency is measured as a user/admin bottleneck. |
+| Additional lifecycle/status/created indexes | Could help discovery/admin queues but adds write/storage cost. | Query plan or p95 shows status/time filters are scanning too much. |

--- a/README/PRODUCTION-NOTES/FEATURES/23/23-external-market-movement-sale-lock.md
+++ b/README/PRODUCTION-NOTES/FEATURES/23/23-external-market-movement-sale-lock.md
@@ -1,0 +1,139 @@
+---
+title: External Market Movement Sale Lock
+document_type: feature-overview
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-25T00:00:00Z
+updated_at_display: "Thursday, June 25, 2026"
+update_reason: "Document the economic sale lock that prevents self-created market movement from becoming immediately extractable value."
+status: in_progress
+---
+
+# External Market Movement Sale Lock
+
+## Purpose
+
+SocialPredict market math should not allow a user to create mark-to-market value with their own bet and then immediately extract that value through a sale.
+
+This feature defines the economic lock as:
+
+```text
+A bet lot cannot realize gained value until another user places a later qualifying bet on the same market.
+```
+
+The key policy change is the phrase **another user**.
+
+A later bet from the same user must not unlock that user's earlier bet lot. A self-top-up such as:
+
+```text
+Alice buys YES for 50.
+Alice buys YES for 1.
+Alice tries to sell the original 50.
+```
+
+must remain locked because no external participant has entered after Alice's original 50-credit bet.
+
+## Math Grounding
+
+The prediction-market math already documents the intended anti-self-dealing posture: share value should not reward a user simply for moving the market themselves. Gained value should require later market movement by other participants.
+
+This feature turns that posture into an explicit sale policy.
+
+## Ubiquitous Language
+
+| Term | Meaning |
+| --- | --- |
+| Economic lock | A transaction-time sale restriction that prevents self-created appreciation from being extracted. |
+| Bet lot | One positive buy exposure row for a user, market, and outcome. |
+| Seasoned lot | A buy lot that has been followed by a qualifying later bet from a different user. |
+| Unseasoned lot | A buy lot that has not yet been followed by a qualifying later bet from a different user. |
+| Qualifying later bet | A later positive buy exposure on the same market by a different user. |
+| Self-top-up | A small later buy by the same user that attempts to unlock a larger earlier buy. |
+| Sellable shares | Shares attributable to seasoned lots. |
+| Locked shares | Shares attributable to unseasoned lots. |
+
+## Rule
+
+The first implementation keeps the rule intentionally narrow:
+
+```text
+A positive buy lot becomes sell-eligible only after a later positive buy on the same market by a different user.
+```
+
+The following must not unlock a lot:
+
+- a later bet by the same user;
+- a sale row;
+- a refund row;
+- a system/admin accounting row;
+- a zero or negative amount row;
+- activity on a different child market in a grouped market.
+
+For multiple-choice binary markets, the lock applies independently to each child binary market. A bet on one answer does not unlock lots on another answer.
+
+## Implementation Slice 1
+
+The first landed slice enforces a position-level version of the lock in the backend sale path:
+
+- sale quotes now return `allowed=false` when the seller's latest positive buy for that outcome has not been followed by a later positive bet from another user on the same market;
+- sale execution rechecks the same rule inside the sell transaction and returns `POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT` before mutating balances or writing the sale row;
+- same-user self-top-ups do not unlock the position;
+- a later positive bet from another user unlocks the position;
+- quote responses expose `positionLocked`, `sellableShares`, `lockedShares`, and `lockReason`;
+- the frontend sale Terms panel displays locked quotes distinctly.
+
+This first slice is deliberately stricter than full lot-level partial unlocking: if the seller's latest same-outcome positive buy is unseasoned, the sale is blocked. A later slice can allow partial sale of older seasoned lots once the UI and sale order model can clearly select or cap lot-level exposure.
+
+## Non-Goals
+
+This feature does not change:
+
+- WPAM or DBPM probability math;
+- dust accounting;
+- market resolution payout math;
+- N/A refund policy;
+- moderator work-profit policy;
+- read-model/cache behavior;
+- database concurrency locking.
+
+This is not a database lock. It is an economic sale-eligibility rule.
+
+## Expected User-Facing Behavior
+
+If a user attempts to sell only locked shares, the backend should reject the sale with a clear reason such as:
+
+```text
+POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT
+```
+
+The frontend sale quote should distinguish:
+
+```text
+Total shares
+Sellable shares
+Locked shares
+```
+
+The UI copy should explain that locked shares become sellable after another user places a later bet on the same market.
+
+## Core Examples
+
+| Scenario | Expected result |
+| --- | --- |
+| Alice buys YES 50, then Alice buys YES 1, then Alice sells | Sale remains locked. Same-user top-up does not season the first lot. |
+| Alice buys YES 50, then Bob buys YES 1, then Alice sells | Sale can proceed against Alice's seasoned YES lot. |
+| Alice buys YES 50, then Bob buys NO 1, then Alice sells | Sale can proceed under the initial simple rule because an external participant entered the same market. |
+| Alice buys YES on child market A, then Bob buys YES on child market B | Alice's child market A lot remains locked. Grouped-market children are independent binary markets. |
+
+## Open Decision
+
+The first version treats any later positive buy by another user on the same market as a qualifying event.
+
+A stricter future version could require favorable external movement before profitable sale extraction, for example:
+
+```text
+YES lots unlock profitable sale value only after another user moves YES further upward.
+NO lots unlock profitable sale value only after another user moves NO further upward.
+```
+
+That stricter rule may be more philosophically precise, but it is more complex and should not be the first implementation unless tests show the simpler same-market external-entry rule is insufficient.

--- a/README/PRODUCTION-NOTES/FEATURES/23/DESIGN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/23/DESIGN.md
@@ -1,0 +1,156 @@
+---
+title: External Market Movement Sale Lock Design
+document_type: feature-design
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-25T00:00:00Z
+updated_at_display: "Thursday, June 25, 2026"
+update_reason: "Define the transaction-time sale seasoning rule and design boundaries for external market movement locks."
+status: in_progress
+---
+
+# External Market Movement Sale Lock Design
+
+## Design Posture
+
+The sale lock is a transaction-time economic invariant:
+
+```text
+A user cannot extract appreciation created only by that user's own bet history.
+```
+
+The design should be conservative, auditable, and stateless where possible. It should derive sell eligibility from canonical bet history rather than adding mutable per-lot state unless profiling later proves that replay cost is too high.
+
+## Boundary
+
+This feature belongs to the betting/sale transaction path.
+
+It must be enforced in backend domain/application code, not only in the frontend. The frontend may preview locked versus sellable shares, but the backend remains authoritative.
+
+## Dependency Direction
+
+Preferred dependency direction:
+
+```text
+handler -> bet sale service -> sale lock evaluator -> repository interface -> GORM/Postgres adapter
+```
+
+The sale lock evaluator should receive ordered market bet events or a purpose-specific projection. It should not know about GORM.
+
+## Canonical Input
+
+The lock evaluator needs canonical chronological buy/sell event context for one market:
+
+```text
+market_id
+bet_id
+username
+outcome
+amount
+placed_at
+```
+
+The authoritative order should match the existing market replay order:
+
+```text
+placed_at ASC, id ASC
+```
+
+## Policy
+
+A buy lot is sellable only if it has been seasoned by a qualifying later bet.
+
+A qualifying later bet is:
+
+```text
+same market
+AND amount > 0
+AND later in canonical order
+AND username != original_lot.username
+```
+
+Non-qualifying rows:
+
+- same-user buys;
+- sell rows;
+- refunds;
+- zero rows;
+- administrative accounting rows;
+- rows from a different child market in a grouped market.
+
+## Stateless Derivation
+
+The first implementation should derive lot seasoning from bet history during quote/sale execution.
+
+High-level derivation:
+
+```text
+1. Replay market events in canonical order.
+2. Track positive buy lots by user/outcome.
+3. When a positive buy from user B appears, season prior unseasoned lots on that market owned by users other than B.
+4. During sale calculation, expose only the seller's seasoned shares as sellable.
+5. Reject or cap sale orders that exceed sellable shares.
+```
+
+This keeps the rule auditable and avoids adding new state that can drift from canonical history.
+
+## Sale Behavior
+
+Implementation options:
+
+| Option | Behavior | First-version recommendation |
+| --- | --- | --- |
+| Reject oversize sale | If requested sale exceeds sellable shares, return a lock error. | Yes, simplest and clearest. |
+| Auto-cap sale | Execute only the sellable portion and leave locked shares. | No, surprising unless UI explicitly opts in. |
+| Sell at basis only | Allow unseasoned shares to be sold only without appreciation. | No, adds another math path. |
+
+The initial behavior should reject sales that require locked shares.
+
+The first implementation rejects the full sale when the seller's latest same-outcome positive buy is still unseasoned. This prevents the self-top-up exploit without introducing lot-selection UI or partial-sale auto-capping.
+
+## Quote Behavior
+
+Sale quotes should include enough information to explain the result:
+
+```text
+total_shares
+sellable_shares
+locked_shares
+requested_sale_amount
+max_sellable_amount
+lock_reason
+```
+
+If the requested sale is blocked, the quote should say that another user must place a later bet on the same market before those shares can be sold.
+
+## Grouped Markets
+
+Multiple-choice binary markets are groups of independent binary child markets.
+
+The sale lock applies to the child market where the bet was placed. A user buying answer A does not season another user's answer B lots unless those answers share the same child market, which they do not.
+
+## Design-Plan Alignment
+
+This design follows the SocialPredict design posture:
+
+| Principle | Application |
+| --- | --- |
+| Domain-first language | Use explicit terms such as lot, seasoned, unseasoned, qualifying later bet, and sellable shares. |
+| Clean architecture | Keep lock policy in sale/domain code; keep GORM and SQL as adapter details. |
+| Transaction safety | Enforce the rule during backend quote/sale execution using canonical fresh history. |
+| Evolutionary design | Start with stateless replay and targeted tests before adding durable per-lot state or caches. |
+| Auditability | Make every unlock decision derivable from the market bet stream. |
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Existing users expect all shares to be sellable. | Surface locked/sellable shares in quote UI and return a clear backend error. |
+| Sale math becomes harder to reason about. | Keep lock eligibility separate from WPAM/DBPM valuation. |
+| Performance cost on large hot markets. | Use market-scoped chronological projections and indexes from Feature 22. |
+| Partial frontend-only enforcement. | Add backend tests proving the exploit fails even without frontend help. |
+| Ambiguous external movement policy. | First version uses any later positive buy by another user on the same market. Record stricter favorable-movement policy as future work. |
+
+## Future Work
+
+A later feature can evaluate whether profitable sale unlocks should require favorable external price movement rather than any external same-market buy. That would better match the philosophy that profit should require another participant moving the market further in the seller's favor, but it introduces additional edge cases around loss-taking exits and probability history.

--- a/README/PRODUCTION-NOTES/FEATURES/23/PLAN.md
+++ b/README/PRODUCTION-NOTES/FEATURES/23/PLAN.md
@@ -1,0 +1,104 @@
+---
+title: External Market Movement Sale Lock Plan
+document_type: feature-plan
+domain: features
+author: Patrick Delaney
+updated_at: 2026-06-25T00:00:00Z
+updated_at_display: "Thursday, June 25, 2026"
+update_reason: "Plan implementation and tests for requiring another user's later bet before sale value can be extracted."
+status: in_progress
+---
+
+# External Market Movement Sale Lock Plan
+
+## 01. Feature Spec
+
+Checklist:
+
+- [x] Document the lock as an economic sale rule, not a database lock.
+- [x] Define the key policy: another user's later bet is required.
+- [x] Define self-top-up as the exploit case to block.
+- [x] Define same-market and grouped-market child boundaries.
+- [x] Record the stricter favorable-movement rule as future work.
+
+## 02. Code Audit
+
+Checklist:
+
+- [x] Locate every backend sell and sale-quote entrypoint.
+- [x] Confirm whether any existing sale lock is implemented or only implied by position math.
+- [x] Identify the canonical market bet-history reader used by sale execution.
+- [x] Confirm canonical ordering is `placed_at ASC, id ASC`.
+- [x] Identify whether sale rows and refund rows are distinguishable from positive buy exposure rows.
+- [x] Confirm grouped child markets use independent market IDs for sale math.
+- [ ] Document any frontend-only sale restrictions that need backend enforcement.
+
+## 03. Domain Model
+
+Checklist:
+
+- [x] Add domain language for seasoned and locked sale exposure.
+- [x] Add a sale-lock evaluator that consumes ordered market bet events.
+- [x] Keep the evaluator free of GORM and HTTP dependencies.
+- [x] Return a structured result with sellable shares, locked shares, and lock reason.
+- [x] Decide whether the first version rejects oversize sale orders or caps them. Current recommendation: reject.
+
+## 04. Backend Implementation
+
+Checklist:
+
+- [x] Wire sale quote through the lock evaluator.
+- [x] Wire sale execution through the same lock evaluator.
+- [x] Ensure sale execution rechecks lock eligibility inside the transaction.
+- [x] Reject sale orders that require locked shares.
+- [x] Add a stable error code such as `POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT`.
+- [x] Ensure same-user later buys do not season earlier lots.
+- [x] Ensure later positive buys by another user season prior lots on the same market.
+- [x] Ensure sell rows do not season prior lots.
+- [x] Ensure grouped-market answer children are isolated by child market ID.
+
+## 05. Frontend Implementation
+
+Checklist:
+
+- [x] Display sellable and locked shares in sale terms/quote UI.
+- [x] Explain that locked shares require a later bet from another user on the same market.
+- [x] Show backend lock errors clearly.
+- [ ] Avoid promising that a quote is guaranteed if high trade volume changes market state before submission.
+- [ ] Keep the backend as authoritative; frontend checks are advisory.
+
+## 06. Tests
+
+Checklist:
+
+- [x] Alice buys YES 50, Alice buys YES 1, Alice tries to sell: blocked.
+- [x] Alice buys YES 50, Bob buys YES or NO 1, Alice sells: allowed under the initial same-market external-entry rule.
+- [x] Alice buys YES 50, Bob buys NO 1, Alice sells: allowed under the initial same-market external-entry rule.
+- [ ] Alice buys YES 50, Alice sells negative/sale row exists after it: still blocked unless another user bought.
+- [ ] Alice buys YES on grouped child A, Bob buys YES on grouped child B: Alice child A sale remains blocked.
+- [ ] Multiple same-timestamp rows use `placed_at ASC, id ASC` ordering.
+- [x] Sale quote and sale execution return consistent sellable/locked results.
+- [x] Execution rechecks inside transaction so a stale quote cannot bypass the lock.
+- [x] Existing dust tests still pass.
+- [x] Existing payout/resolution tests still pass.
+
+## 07. Verification
+
+Checklist:
+
+- [x] Run targeted backend tests for sale lock scenarios.
+- [x] Run full backend tests.
+- [x] Run frontend build if sale quote UI changes.
+- [ ] Run schemathesis/kin if API response contracts change.
+- [ ] Add or update OpenAPI response schemas if sale quote/error payload changes.
+- [ ] Manually verify the exploit case in local dev with two test users.
+
+## 08. Rollout
+
+Checklist:
+
+- [ ] Keep the first version behind normal sale path behavior, not a separate opt-in route.
+- [ ] Document the new error and UI language in release notes.
+- [ ] Watch support/admin reports for users seeing locked shares after deployment.
+- [ ] Consider a migration-free rollout because the first version is stateless.
+- [ ] Revisit stricter favorable-movement unlocking only after the basic external-user lock is stable.

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -95,6 +95,7 @@ Current feature specs:
 19. **Grouped Market N/A And Documentation Alignment** - [`FEATURES/19/19-grouped-market-na-and-doc-alignment.md`](./FEATURES/19/19-grouped-market-na-and-doc-alignment.md), [`FEATURES/19/DESIGN.md`](./FEATURES/19/DESIGN.md), [`FEATURES/19/PLAN.md`](./FEATURES/19/PLAN.md)
 20. **Analytics Repository Boundary** - [`FEATURES/20/20-analytics-repository-boundary.md`](./FEATURES/20/20-analytics-repository-boundary.md), [`FEATURES/20/DESIGN.md`](./FEATURES/20/DESIGN.md), [`FEATURES/20/PLAN.md`](./FEATURES/20/PLAN.md)
 21. **Container Security Scanning** - [`FEATURES/21/21-container-security-scanning.md`](./FEATURES/21/21-container-security-scanning.md), [`FEATURES/21/DESIGN.md`](./FEATURES/21/DESIGN.md), [`FEATURES/21/PLAN.md`](./FEATURES/21/PLAN.md)
+22. **GORM Query Scoping And Market Bet-History Efficiency** - [`FEATURES/22/22-gorm-query-scoping-efficiency.md`](./FEATURES/22/22-gorm-query-scoping-efficiency.md), [`FEATURES/22/DESIGN.md`](./FEATURES/22/DESIGN.md), [`FEATURES/22/PLAN.md`](./FEATURES/22/PLAN.md)
 
 ## Implementation Priority
 

--- a/README/PRODUCTION-NOTES/README.md
+++ b/README/PRODUCTION-NOTES/README.md
@@ -95,7 +95,7 @@ Current feature specs:
 19. **Grouped Market N/A And Documentation Alignment** - [`FEATURES/19/19-grouped-market-na-and-doc-alignment.md`](./FEATURES/19/19-grouped-market-na-and-doc-alignment.md), [`FEATURES/19/DESIGN.md`](./FEATURES/19/DESIGN.md), [`FEATURES/19/PLAN.md`](./FEATURES/19/PLAN.md)
 20. **Analytics Repository Boundary** - [`FEATURES/20/20-analytics-repository-boundary.md`](./FEATURES/20/20-analytics-repository-boundary.md), [`FEATURES/20/DESIGN.md`](./FEATURES/20/DESIGN.md), [`FEATURES/20/PLAN.md`](./FEATURES/20/PLAN.md)
 21. **Container Security Scanning** - [`FEATURES/21/21-container-security-scanning.md`](./FEATURES/21/21-container-security-scanning.md), [`FEATURES/21/DESIGN.md`](./FEATURES/21/DESIGN.md), [`FEATURES/21/PLAN.md`](./FEATURES/21/PLAN.md)
-22. **GORM Query Scoping And Market Bet-History Efficiency** - [`FEATURES/22/22-gorm-query-scoping-efficiency.md`](./FEATURES/22/22-gorm-query-scoping-efficiency.md), [`FEATURES/22/DESIGN.md`](./FEATURES/22/DESIGN.md), [`FEATURES/22/PLAN.md`](./FEATURES/22/PLAN.md)
+22. **GORM Query Scoping And Market Bet-History Efficiency** - [`FEATURES/22/22-gorm-query-scoping-efficiency.md`](./FEATURES/22/22-gorm-query-scoping-efficiency.md), [`FEATURES/22/DESIGN.md`](./FEATURES/22/DESIGN.md), [`FEATURES/22/PLAN.md`](./FEATURES/22/PLAN.md), [`FEATURES/22/QUERY_AUDIT.md`](./FEATURES/22/QUERY_AUDIT.md)
 
 ## Implementation Priority
 

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -62,6 +62,7 @@ x-route-family-migration-matrix:
     - INSUFFICIENT_BALANCE
     - NO_POSITION
     - INSUFFICIENT_SHARES
+    - POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT
     - DUST_CAP_EXCEEDED
     - INTERNAL_ERROR
   plain_text_error_response_state: migration_state_not_target_contract
@@ -5571,7 +5572,7 @@ components:
         - INVALID_STATE: the requested transition is not valid for the resource's current lifecycle state.
         - MARKET_GROUP_CHILD_UNPUBLISHED: grouped-market resolution was blocked because one answer child is not published yet.
         - VALIDATION_FAILED: syntactically valid input that fails route or business validation.
-        - MARKET_CLOSED, INSUFFICIENT_BALANCE, NO_POSITION, INSUFFICIENT_SHARES, and DUST_CAP_EXCEEDED: shared market and bet rule failures.
+        - MARKET_CLOSED, INSUFFICIENT_BALANCE, NO_POSITION, INSUFFICIENT_SHARES, POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT, and DUST_CAP_EXCEEDED: shared market and bet rule failures.
         - INTERNAL_ERROR: unexpected server-side failure.
       properties:
         ok:
@@ -5598,6 +5599,7 @@ components:
             - INSUFFICIENT_BALANCE
             - NO_POSITION
             - INSUFFICIENT_SHARES
+            - POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT
             - DUST_CAP_EXCEEDED
             - INTERNAL_ERROR
           example: VALIDATION_FAILED
@@ -7144,6 +7146,20 @@ components:
         allowed:
           type: boolean
           description: Whether POST /v0/sell would be allowed after sale-order rounding.
+        positionLocked:
+          type: boolean
+          description: Whether the sale is blocked because the seller's latest positive buy has not been followed by another user's later positive bet on the same market.
+        lockReason:
+          type: string
+          description: Human-readable explanation when positionLocked is true.
+        sellableShares:
+          type: integer
+          format: int64
+          description: Shares currently sellable under the external market movement lock.
+        lockedShares:
+          type: integer
+          format: int64
+          description: Shares currently locked until another user places a later positive bet on the same market.
         suggestedAmounts:
           type: array
           items:

--- a/backend/handlers/bets/dto/sell.go
+++ b/backend/handlers/bets/dto/sell.go
@@ -35,6 +35,10 @@ type SellQuoteResponse struct {
 	ValuePerShare     int64     `json:"valuePerShare"`
 	DustCapCoverage   float64   `json:"dustCapCoverage"`
 	Allowed           bool      `json:"allowed"`
+	PositionLocked    bool      `json:"positionLocked"`
+	LockReason        string    `json:"lockReason,omitempty"`
+	SellableShares    int64     `json:"sellableShares"`
+	LockedShares      int64     `json:"lockedShares"`
 	SuggestedAmounts  []int64   `json:"suggestedAmounts"`
 	Message           string    `json:"message"`
 	QuotedAt          time.Time `json:"quotedAt"`

--- a/backend/handlers/bets/selling/sellpositionhandler.go
+++ b/backend/handlers/bets/selling/sellpositionhandler.go
@@ -134,6 +134,16 @@ func handleSellError(w http.ResponseWriter, err error) {
 		_ = handlers.WriteFailure(w, http.StatusUnprocessableEntity, handlers.ReasonNoPosition)
 	case errors.Is(err, bets.ErrInsufficientShares):
 		_ = handlers.WriteFailure(w, http.StatusUnprocessableEntity, handlers.ReasonInsufficientShares)
+	case errors.Is(err, bets.ErrPositionLocked):
+		_ = handlers.WriteFailureWithDetails(
+			w,
+			http.StatusConflict,
+			handlers.ReasonPositionLocked,
+			"Sale is locked until another user places a later bet on this market.",
+			map[string]any{
+				"hint": "Wait for external market activity before selling this position.",
+			},
+		)
 	case errors.Is(err, dmarkets.ErrMarketNotFound):
 		_ = handlers.WriteFailure(w, http.StatusNotFound, handlers.ReasonMarketNotFound)
 	default:
@@ -170,6 +180,10 @@ func writeSellQuoteResponse(w http.ResponseWriter, result *bets.SellQuoteResult)
 		ValuePerShare:     result.ValuePerShare,
 		DustCapCoverage:   result.DustCapCoverage,
 		Allowed:           result.Allowed,
+		PositionLocked:    result.PositionLocked,
+		LockReason:        result.LockReason,
+		SellableShares:    result.SellableShares,
+		LockedShares:      result.LockedShares,
 		SuggestedAmounts:  result.SuggestedAmounts,
 		Message:           result.Message,
 		QuotedAt:          result.QuotedAt,

--- a/backend/handlers/envelope.go
+++ b/backend/handlers/envelope.go
@@ -28,6 +28,7 @@ const (
 	ReasonInsufficientBalance FailureReason = "INSUFFICIENT_BALANCE"
 	ReasonNoPosition          FailureReason = "NO_POSITION"
 	ReasonInsufficientShares  FailureReason = "INSUFFICIENT_SHARES"
+	ReasonPositionLocked      FailureReason = "POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT"
 	ReasonDustCapExceeded     FailureReason = "DUST_CAP_EXCEEDED"
 	ReasonInternalError       FailureReason = "INTERNAL_ERROR"
 )
@@ -51,6 +52,7 @@ var publicFailureReasons = []FailureReason{
 	ReasonInsufficientBalance,
 	ReasonNoPosition,
 	ReasonInsufficientShares,
+	ReasonPositionLocked,
 	ReasonDustCapExceeded,
 	ReasonInternalError,
 }

--- a/backend/internal/domain/bets/bet_sell.go
+++ b/backend/internal/domain/bets/bet_sell.go
@@ -52,13 +52,21 @@ func (s *Service) QuoteSell(ctx context.Context, req SellRequest) (*SellQuoteRes
 		return nil, err
 	}
 
+	lock, err := evaluateSaleLock(ctx, s.markets, req, outcome, sharesOwned)
+	if err != nil {
+		return nil, err
+	}
+
 	allowed := true
 	if err := validateDustCap(sale.Dust, s.config.MaxDustPerSale); err != nil {
 		allowed = false
 	}
+	if lock.Locked {
+		allowed = false
+	}
 
 	suggested := suggestSaleAmounts(sale, sharesOwned, s.config.MaxDustPerSale)
-	return new(SellQuoteResult).Build(req, outcome, sale, s.config.MaxDustPerSale, allowed, suggested, s.clock.Now()), nil
+	return new(SellQuoteResult).Build(req, outcome, sale, s.config.MaxDustPerSale, allowed, lock, suggested, s.clock.Now()), nil
 }
 
 func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcome string) (*SellResult, error) {
@@ -71,6 +79,12 @@ func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcom
 		sharesOwned, position, err := loadUserSharesFrom(txCtx, markets, req, outcome)
 		if err != nil {
 			return err
+		}
+
+		if lock, err := evaluateSaleLock(txCtx, markets, req, outcome, sharesOwned); err != nil {
+			return err
+		} else if lock.Locked {
+			return ErrPositionLocked
 		}
 
 		sale, err := s.saleCalculator.Calculate(position, sharesOwned, req.Amount)
@@ -94,6 +108,64 @@ func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcom
 		return nil, err
 	}
 	return result, nil
+}
+
+type saleLockResult struct {
+	Locked         bool
+	Reason         string
+	SellableShares int64
+	LockedShares   int64
+}
+
+func unlockedSaleLock(sharesOwned int64) saleLockResult {
+	return saleLockResult{SellableShares: sharesOwned}
+}
+
+func lockedSaleLock(sharesOwned int64) saleLockResult {
+	return saleLockResult{
+		Locked:         true,
+		Reason:         ErrPositionLocked.Message(),
+		SellableShares: 0,
+		LockedShares:   sharesOwned,
+	}
+}
+
+func evaluateSaleLock(ctx context.Context, markets MarketBetReader, req SellRequest, outcome string, sharesOwned int64) (saleLockResult, error) {
+	if sharesOwned <= 0 {
+		return unlockedSaleLock(0), nil
+	}
+	history, err := markets.ListBetsForMarket(ctx, int64(req.MarketID))
+	if err != nil {
+		return saleLockResult{}, err
+	}
+	if positionLockedAwaitingExternalBet(history, req.Username, outcome) {
+		return lockedSaleLock(sharesOwned), nil
+	}
+	return unlockedSaleLock(sharesOwned), nil
+}
+
+func positionLockedAwaitingExternalBet(history []*dmarkets.Bet, username string, outcome string) bool {
+	lastUserBuyIndex := -1
+	for i, bet := range history {
+		if bet == nil {
+			continue
+		}
+		if bet.Username == username && bet.Outcome == outcome && bet.Amount > 0 {
+			lastUserBuyIndex = i
+		}
+	}
+	if lastUserBuyIndex < 0 {
+		return false
+	}
+	for _, bet := range history[lastUserBuyIndex+1:] {
+		if bet == nil {
+			continue
+		}
+		if bet.Amount > 0 && bet.Username != username {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Service) loadUserShares(ctx context.Context, req SellRequest, outcome string) (int64, *dmarkets.UserPosition, error) {
@@ -250,7 +322,10 @@ func dustCapCoverage(maxDust int64, valuePerShare int64) float64 {
 	return math.Round(coverage*10000) / 10000
 }
 
-func sellQuoteMessage(allowed bool, dust int64, maxDust int64) string {
+func sellQuoteMessage(allowed bool, dust int64, maxDust int64, lock saleLockResult) string {
+	if lock.Locked {
+		return "This Sale Order is locked until another user places a later bet on this market."
+	}
 	if allowed {
 		if dust == 0 {
 			return "This sale can be submitted with no dust fee."

--- a/backend/internal/domain/bets/errors.go
+++ b/backend/internal/domain/bets/errors.go
@@ -48,6 +48,8 @@ var (
 	ErrNoPosition BetError = newDomainError("no position found for the given market and outcome")
 	// ErrInsufficientShares indicates the user cannot sell the requested credits.
 	ErrInsufficientShares BetError = newDomainError("not enough shares to satisfy requested sale")
+	// ErrPositionLocked indicates the position cannot be sold until external market movement occurs.
+	ErrPositionLocked BetError = newDomainError("position is locked until another user places a later bet on this market")
 )
 
 // ErrDustCapExceeded is returned when a sell transaction would generate dust above the configured cap.

--- a/backend/internal/domain/bets/models.go
+++ b/backend/internal/domain/bets/models.go
@@ -138,6 +138,10 @@ type SellQuoteResult struct {
 	ValuePerShare     int64
 	DustCapCoverage   float64
 	Allowed           bool
+	PositionLocked    bool
+	LockReason        string
+	SellableShares    int64
+	LockedShares      int64
 	SuggestedAmounts  []int64
 	Message           string
 	QuotedAt          time.Time
@@ -145,7 +149,7 @@ type SellQuoteResult struct {
 	DustCapExceededBy int64
 }
 
-func buildSellQuoteResult(target *SellQuoteResult, req SellRequest, outcome string, sale SaleQuote, maxDust int64, allowed bool, suggested []int64, quotedAt time.Time) *SellQuoteResult {
+func buildSellQuoteResult(target *SellQuoteResult, req SellRequest, outcome string, sale SaleQuote, maxDust int64, allowed bool, lock saleLockResult, suggested []int64, quotedAt time.Time) *SellQuoteResult {
 	if target == nil {
 		target = &SellQuoteResult{}
 	}
@@ -168,8 +172,12 @@ func buildSellQuoteResult(target *SellQuoteResult, req SellRequest, outcome stri
 		ValuePerShare:     sale.ValuePerShare,
 		DustCapCoverage:   dustCapCoverage(maxDust, sale.ValuePerShare),
 		Allowed:           allowed,
+		PositionLocked:    lock.Locked,
+		LockReason:        lock.Reason,
+		SellableShares:    lock.SellableShares,
+		LockedShares:      lock.LockedShares,
 		SuggestedAmounts:  suggested,
-		Message:           sellQuoteMessage(allowed, sale.Dust, maxDust),
+		Message:           sellQuoteMessage(allowed, sale.Dust, maxDust, lock),
 		QuotedAt:          quotedAt,
 		DustCapExceeded:   exceededBy > 0,
 		DustCapExceededBy: exceededBy,
@@ -177,6 +185,6 @@ func buildSellQuoteResult(target *SellQuoteResult, req SellRequest, outcome stri
 	return target
 }
 
-func (r *SellQuoteResult) Build(req SellRequest, outcome string, sale SaleQuote, maxDust int64, allowed bool, suggested []int64, quotedAt time.Time) *SellQuoteResult {
-	return buildSellQuoteResult(r, req, outcome, sale, maxDust, allowed, suggested, quotedAt)
+func (r *SellQuoteResult) Build(req SellRequest, outcome string, sale SaleQuote, maxDust int64, allowed bool, lock saleLockResult, suggested []int64, quotedAt time.Time) *SellQuoteResult {
+	return buildSellQuoteResult(r, req, outcome, sale, maxDust, allowed, lock, suggested, quotedAt)
 }

--- a/backend/internal/domain/bets/service.go
+++ b/backend/internal/domain/bets/service.go
@@ -51,10 +51,16 @@ type PositionReader interface {
 	GetUserPositionInMarket(ctx context.Context, marketID int64, username string) (*dmarkets.UserPosition, error)
 }
 
+// MarketBetReader exposes canonical market bet history for sale-lock checks.
+type MarketBetReader interface {
+	ListBetsForMarket(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error)
+}
+
 // MarketService exposes the subset of market operations required by bets.
 type MarketService interface {
 	MarketReader
 	PositionReader
+	MarketBetReader
 }
 
 // MarketGate ensures market openness before betting operations.

--- a/backend/internal/domain/bets/service_helpers_test.go
+++ b/backend/internal/domain/bets/service_helpers_test.go
@@ -21,6 +21,7 @@ var errUnexpectedHelperCall = errors.New("unexpected call")
 type stubMarketService struct {
 	marketGetter   stubMarketGetter
 	positionGetter stubPositionGetter
+	betGetter      stubMarketBetGetter
 }
 
 func newStubMarketService(opts ...func(*stubMarketService)) stubMarketService {
@@ -32,6 +33,11 @@ func newStubMarketService(opts ...func(*stubMarketService)) stubMarketService {
 		},
 		positionGetter: stubPositionGetter{
 			getUserPositionInMarketFn: func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
+				return nil, errUnexpectedHelperCall
+			},
+		},
+		betGetter: stubMarketBetGetter{
+			listBetsForMarketFn: func(context.Context, int64) ([]*dmarkets.Bet, error) {
 				return nil, errUnexpectedHelperCall
 			},
 		},
@@ -66,8 +72,16 @@ type stubPositionGetter struct {
 	getUserPositionInMarketFn func(ctx context.Context, marketID int64, username string) (*dmarkets.UserPosition, error)
 }
 
+type stubMarketBetGetter struct {
+	listBetsForMarketFn func(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error)
+}
+
 func (s stubMarketService) GetUserPositionInMarket(ctx context.Context, marketID int64, username string) (*dmarkets.UserPosition, error) {
 	return s.positionGetter.GetUserPositionInMarket(ctx, marketID, username)
+}
+
+func (s stubMarketService) ListBetsForMarket(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error) {
+	return s.betGetter.ListBetsForMarket(ctx, marketID)
 }
 
 func (s stubMarketGetter) GetMarket(ctx context.Context, id int64) (*dmarkets.Market, error) {
@@ -82,6 +96,13 @@ func (s stubPositionGetter) GetUserPositionInMarket(ctx context.Context, marketI
 		return nil, errUnexpectedHelperCall
 	}
 	return s.getUserPositionInMarketFn(ctx, marketID, username)
+}
+
+func (s stubMarketBetGetter) ListBetsForMarket(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error) {
+	if s.listBetsForMarketFn == nil {
+		return nil, errUnexpectedHelperCall
+	}
+	return s.listBetsForMarketFn(ctx, marketID)
 }
 
 type gateClock struct {

--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -116,6 +116,7 @@ func (f fakeBetHistoryReader) UserHasBet(ctx context.Context, marketID uint, use
 type fakeMarkets struct {
 	reader    fakeMarketReader
 	positions fakePositionReader
+	history   fakeMarketBetReader
 }
 
 func newFakeMarkets(opts ...func(*fakeMarkets)) *fakeMarkets {
@@ -128,6 +129,11 @@ func newFakeMarkets(opts ...func(*fakeMarkets)) *fakeMarkets {
 		positions: fakePositionReader{
 			getUserPositionInMarketFunc: func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
 				return nil, errUnexpectedServiceCall
+			},
+		},
+		history: fakeMarketBetReader{
+			listBetsForMarketFunc: func(context.Context, int64) ([]*dmarkets.Bet, error) {
+				return defaultUnlockedSaleHistory(), nil
 			},
 		},
 	}
@@ -149,6 +155,12 @@ func withFakePosition(fn func(ctx context.Context, marketID int64, username stri
 	}
 }
 
+func withFakeMarketBets(fn func(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error)) func(*fakeMarkets) {
+	return func(markets *fakeMarkets) {
+		markets.history.listBetsForMarketFunc = fn
+	}
+}
+
 type fakeMarketReader struct {
 	getMarketFunc func(ctx context.Context, id int64) (*dmarkets.Market, error)
 }
@@ -165,6 +177,10 @@ func (f *fakeMarkets) GetUserPositionInMarket(ctx context.Context, marketID int6
 	return f.positions.GetUserPositionInMarket(ctx, marketID, username)
 }
 
+func (f *fakeMarkets) ListBetsForMarket(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error) {
+	return f.history.ListBetsForMarket(ctx, marketID)
+}
+
 func (f fakeMarketReader) GetMarket(ctx context.Context, id int64) (*dmarkets.Market, error) {
 	if f.getMarketFunc == nil {
 		return nil, errUnexpectedServiceCall
@@ -177,6 +193,17 @@ func (f fakePositionReader) GetUserPositionInMarket(ctx context.Context, marketI
 		return nil, errUnexpectedServiceCall
 	}
 	return f.getUserPositionInMarketFunc(ctx, marketID, username)
+}
+
+type fakeMarketBetReader struct {
+	listBetsForMarketFunc func(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error)
+}
+
+func (f fakeMarketBetReader) ListBetsForMarket(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error) {
+	if f.listBetsForMarketFunc == nil {
+		return nil, errUnexpectedServiceCall
+	}
+	return f.listBetsForMarketFunc(ctx, marketID)
 }
 
 type applyCall struct {
@@ -295,13 +322,50 @@ func withFixturePosition(position *dmarkets.UserPosition) serviceFixtureOption {
 			f.markets = newFakeMarkets()
 		}
 		current := f.markets.reader.getMarketFunc
+		history := f.markets.history.listBetsForMarketFunc
 		f.markets = newFakeMarkets(
 			withFakeMarket(current),
 			withFakePosition(func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
 				return position, nil
 			}),
+			withFakeMarketBets(history),
 		)
 	}
+}
+
+func withFixtureHistory(history []boundary.Bet) serviceFixtureOption {
+	return func(f *serviceFixture) {
+		if f.markets == nil {
+			f.markets = newFakeMarkets()
+		}
+		f.markets.history.listBetsForMarketFunc = func(context.Context, int64) ([]*dmarkets.Bet, error) {
+			return boundaryBetsToMarketBets(history), nil
+		}
+	}
+}
+
+func defaultUnlockedSaleHistory() []*dmarkets.Bet {
+	now := serviceTestTime()
+	return []*dmarkets.Bet{
+		{Username: "alice", MarketID: 1, Amount: 10, Outcome: "YES", PlacedAt: now.Add(-2 * time.Hour), CreatedAt: now.Add(-2 * time.Hour)},
+		{Username: "bob", MarketID: 1, Amount: 1, Outcome: "NO", PlacedAt: now.Add(-1 * time.Hour), CreatedAt: now.Add(-1 * time.Hour)},
+	}
+}
+
+func boundaryBetsToMarketBets(history []boundary.Bet) []*dmarkets.Bet {
+	result := make([]*dmarkets.Bet, len(history))
+	for i := range history {
+		result[i] = &dmarkets.Bet{
+			ID:        history[i].ID,
+			Username:  history[i].Username,
+			MarketID:  history[i].MarketID,
+			Amount:    history[i].Amount,
+			Outcome:   history[i].Outcome,
+			PlacedAt:  history[i].PlacedAt,
+			CreatedAt: history[i].CreatedAt,
+		}
+	}
+	return result
 }
 
 func withFixtureUser(user *dusers.User) serviceFixtureOption {
@@ -770,6 +834,7 @@ func TestServiceSell_MarketHistorySaleOrderDustScenarios(t *testing.T) {
 		{Username: "alice", MarketID: 1, Amount: 70, Outcome: "YES", PlacedAt: now.Add(-4 * time.Hour)},
 		{Username: "bob", MarketID: 1, Amount: 40, Outcome: "NO", PlacedAt: now.Add(-3 * time.Hour)},
 		{Username: "alice", MarketID: 1, Amount: 30, Outcome: "YES", PlacedAt: now.Add(-2 * time.Hour)},
+		{Username: "carol", MarketID: 1, Amount: 1, Outcome: "NO", PlacedAt: now.Add(-90 * time.Minute)},
 		{Username: "bob", MarketID: 1, Amount: -1, Outcome: "NO", PlacedAt: now.Add(-1 * time.Hour)},
 	}
 
@@ -828,6 +893,7 @@ func TestServiceSell_MarketHistorySaleOrderDustScenarios(t *testing.T) {
 				withFixtureMaxDust(tc.maxDust),
 				withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
 				withFixturePosition(position),
+				withFixtureHistory(priorHistory),
 				withFixtureUser(&dusers.User{Username: "alice"}),
 			)
 
@@ -865,6 +931,106 @@ func TestServiceSell_MarketHistorySaleOrderDustScenarios(t *testing.T) {
 			}
 			if len(fixture.users.calls) != 1 || fixture.users.calls[0].transaction != dusers.TransactionSale || fixture.users.calls[0].amount != wantNetProceeds {
 				t.Fatalf("unexpected user ledger calls: %+v", fixture.users.calls)
+			}
+		})
+	}
+}
+
+func TestServiceSell_PositionRemainsLockedAfterSelfTopUp(t *testing.T) {
+	now := serviceTestTime()
+	history := []boundary.Bet{
+		{Username: "alice", MarketID: 1, Amount: 50, Outcome: "YES", PlacedAt: now.Add(-2 * time.Hour), CreatedAt: now.Add(-2 * time.Hour)},
+		{Username: "alice", MarketID: 1, Amount: 1, Outcome: "YES", PlacedAt: now.Add(-1 * time.Hour), CreatedAt: now.Add(-1 * time.Hour)},
+	}
+	fixture, svc := newServiceFixture(
+		now,
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(&dmarkets.UserPosition{
+			Username:       "alice",
+			MarketID:       1,
+			YesSharesOwned: 5,
+			Value:          50,
+		}),
+		withFixtureHistory(history),
+		withFixtureUser(&dusers.User{Username: "alice"}),
+	)
+
+	quote, err := svc.QuoteSell(context.Background(), bets.SellRequest{
+		Username: "alice",
+		MarketID: 1,
+		Amount:   10,
+		Outcome:  "YES",
+	})
+	if err != nil {
+		t.Fatalf("QuoteSell returned error: %v", err)
+	}
+	if quote.Allowed || !quote.PositionLocked || quote.SellableShares != 0 || quote.LockedShares != 5 {
+		t.Fatalf("expected locked quote with all shares locked, got %+v", quote)
+	}
+
+	_, err = svc.Sell(context.Background(), bets.SellRequest{
+		Username: "alice",
+		MarketID: 1,
+		Amount:   10,
+		Outcome:  "YES",
+	})
+	if !errors.Is(err, bets.ErrPositionLocked) {
+		t.Fatalf("expected ErrPositionLocked, got %v", err)
+	}
+	if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
+		t.Fatalf("locked sale must not mutate state: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
+	}
+}
+
+func TestServiceSell_PositionUnlocksAfterAnotherUserBet(t *testing.T) {
+	now := serviceTestTime()
+	for _, bobOutcome := range []string{"YES", "NO"} {
+		t.Run("bob_"+bobOutcome+"_unlocks", func(t *testing.T) {
+			history := []boundary.Bet{
+				{Username: "alice", MarketID: 1, Amount: 50, Outcome: "YES", PlacedAt: now.Add(-3 * time.Hour), CreatedAt: now.Add(-3 * time.Hour)},
+				{Username: "alice", MarketID: 1, Amount: 1, Outcome: "YES", PlacedAt: now.Add(-2 * time.Hour), CreatedAt: now.Add(-2 * time.Hour)},
+				{Username: "bob", MarketID: 1, Amount: 1, Outcome: bobOutcome, PlacedAt: now.Add(-1 * time.Hour), CreatedAt: now.Add(-1 * time.Hour)},
+			}
+			fixture, svc := newServiceFixture(
+				now,
+				withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+				withFixturePosition(&dmarkets.UserPosition{
+					Username:       "alice",
+					MarketID:       1,
+					YesSharesOwned: 5,
+					Value:          50,
+				}),
+				withFixtureHistory(history),
+				withFixtureUser(&dusers.User{Username: "alice"}),
+			)
+
+			quote, err := svc.QuoteSell(context.Background(), bets.SellRequest{
+				Username: "alice",
+				MarketID: 1,
+				Amount:   10,
+				Outcome:  "YES",
+			})
+			if err != nil {
+				t.Fatalf("QuoteSell returned error: %v", err)
+			}
+			if !quote.Allowed || quote.PositionLocked || quote.SellableShares != 5 || quote.LockedShares != 0 {
+				t.Fatalf("expected unlocked quote, got %+v", quote)
+			}
+
+			result, err := svc.Sell(context.Background(), bets.SellRequest{
+				Username: "alice",
+				MarketID: 1,
+				Amount:   10,
+				Outcome:  "YES",
+			})
+			if err != nil {
+				t.Fatalf("Sell returned error: %v", err)
+			}
+			if result.SharesSold != 1 || result.NetProceeds != 10 {
+				t.Fatalf("unexpected sale result: %+v", result)
+			}
+			if fixture.repo.created == nil || fixture.repo.created.Amount != -1 {
+				t.Fatalf("expected stored sale bet for one share, got %+v", fixture.repo.created)
 			}
 		})
 	}
@@ -954,6 +1120,7 @@ func TestServiceSell_ActualMixedMarketHistorySaleOrderDustScenarios(t *testing.T
 					TotalSpent:       position.TotalSpent,
 					TotalSpentInPlay: position.TotalSpentInPlay,
 				}),
+				withFixtureHistory(history),
 				withFixtureUser(&dusers.User{Username: "alice"}),
 			)
 

--- a/backend/internal/domain/markets/market_bets.go
+++ b/backend/internal/domain/markets/market_bets.go
@@ -26,6 +26,14 @@ func (s *Service) GetMarketBetsPage(ctx context.Context, marketID int64, p Page)
 	return paginateBetDisplayInfos(infos, p), nil
 }
 
+// ListBetsForMarket returns canonical market bet history for transaction-policy callers.
+func (s *Service) ListBetsForMarket(ctx context.Context, marketID int64) ([]*Bet, error) {
+	if marketID <= 0 {
+		return nil, ErrInvalidInput
+	}
+	return s.repo.ListBetsForMarket(ctx, marketID)
+}
+
 func (s *Service) getMarketBetDisplayInfos(ctx context.Context, marketID int64) ([]*BetDisplayInfo, error) {
 	if marketID <= 0 {
 		return nil, ErrInvalidInput

--- a/backend/internal/repository/analytics/bet_queries_test.go
+++ b/backend/internal/repository/analytics/bet_queries_test.go
@@ -1,0 +1,80 @@
+package analytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestGormRepositoryListBetsForMarketScopesAndOrdersReplayRows(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("creator", 1000)
+	bettor := modelstesting.GenerateUser("bettor", 1000)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator: %v", err)
+	}
+	if err := db.Create(&bettor).Error; err != nil {
+		t.Fatalf("seed bettor: %v", err)
+	}
+
+	market := modelstesting.GenerateMarket(1001, creator.Username)
+	otherMarket := modelstesting.GenerateMarket(1002, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("seed market: %v", err)
+	}
+	if err := db.Create(&otherMarket).Error; err != nil {
+		t.Fatalf("seed unrelated market: %v", err)
+	}
+
+	placedAt := time.Now().UTC().Truncate(time.Second)
+	first := models.Bet{
+		Username: "bettor",
+		MarketID: uint(market.ID),
+		Amount:   7,
+		Outcome:  "YES",
+		PlacedAt: placedAt,
+	}
+	unrelated := models.Bet{
+		Username: "bettor",
+		MarketID: uint(otherMarket.ID),
+		Amount:   999,
+		Outcome:  "NO",
+		PlacedAt: placedAt,
+	}
+	second := models.Bet{
+		Username: "bettor",
+		MarketID: uint(market.ID),
+		Amount:   9,
+		Outcome:  "NO",
+		PlacedAt: placedAt,
+	}
+	for _, bet := range []*models.Bet{&first, &unrelated, &second} {
+		if err := db.Create(bet).Error; err != nil {
+			t.Fatalf("seed bet: %v", err)
+		}
+	}
+
+	bets, err := repo.ListBetsForMarket(ctx, uint(market.ID))
+	if err != nil {
+		t.Fatalf("ListBetsForMarket returned error: %v", err)
+	}
+
+	if len(bets) != 2 {
+		t.Fatalf("expected 2 scoped bets, got %d: %+v", len(bets), bets)
+	}
+	if bets[0].MarketID != uint(market.ID) || bets[1].MarketID != uint(market.ID) {
+		t.Fatalf("expected only market %d rows, got %+v", market.ID, bets)
+	}
+	if bets[0].Amount != 7 || bets[1].Amount != 9 {
+		t.Fatalf("expected target market rows in insertion-id tie order, got %+v", bets)
+	}
+	if bets[0].ID >= bets[1].ID {
+		t.Fatalf("expected stable id tie-break ordering, got first id %d second id %d", bets[0].ID, bets[1].ID)
+	}
+}

--- a/backend/internal/repository/analytics/bet_queries_test.go
+++ b/backend/internal/repository/analytics/bet_queries_test.go
@@ -78,3 +78,74 @@ func TestGormRepositoryListBetsForMarketScopesAndOrdersReplayRows(t *testing.T) 
 		t.Fatalf("expected stable id tie-break ordering, got first id %d second id %d", bets[0].ID, bets[1].ID)
 	}
 }
+
+func TestGormRepositoryListMarketGroupFeeRecordsHydratesMembersInBulkOrder(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	repo := NewGormRepository(db)
+	ctx := context.Background()
+
+	groups := []models.MarketGroup{
+		{
+			ID:                 2001,
+			QuestionTitle:      "Group One",
+			Description:        "First group",
+			GroupType:          "MULTIPLE_CHOICE_BINARY",
+			ProbabilityPolicy:  "INDEPENDENT_BINARY",
+			ResolutionPolicy:   "ONLY_ONE_YES",
+			LifecycleStatus:    "published",
+			ProposalCost:       10,
+			CreatorUsername:    "creator",
+			ResolutionDateTime: time.Now().Add(24 * time.Hour),
+		},
+		{
+			ID:                 2002,
+			QuestionTitle:      "Group Two",
+			Description:        "Second group",
+			GroupType:          "MULTIPLE_CHOICE_BINARY",
+			ProbabilityPolicy:  "INDEPENDENT_BINARY",
+			ResolutionPolicy:   "ONLY_ONE_YES",
+			LifecycleStatus:    "resolved",
+			ProposalCost:       10,
+			CreatorUsername:    "creator",
+			StewardUsername:    "steward",
+			ResolutionDateTime: time.Now().Add(24 * time.Hour),
+		},
+	}
+	for i := range groups {
+		if err := db.Create(&groups[i]).Error; err != nil {
+			t.Fatalf("create group: %v", err)
+		}
+	}
+
+	members := []models.MarketGroupMember{
+		{GroupID: 2001, MarketID: 3002, AnswerLabel: "B", DisplayOrder: 2},
+		{GroupID: 2001, MarketID: 3001, AnswerLabel: "A", DisplayOrder: 1},
+		{GroupID: 2002, MarketID: 4001, AnswerLabel: "Only", DisplayOrder: 1},
+	}
+	for i := range members {
+		if err := db.Create(&members[i]).Error; err != nil {
+			t.Fatalf("create member: %v", err)
+		}
+	}
+
+	records, err := repo.ListMarketGroupFeeRecords(ctx)
+	if err != nil {
+		t.Fatalf("ListMarketGroupFeeRecords returned error: %v", err)
+	}
+
+	byID := make(map[uint]WorkProfitMarketGroupRecord, len(records))
+	for _, record := range records {
+		byID[record.ID] = record
+	}
+	first := byID[2001]
+	second := byID[2002]
+	if got := first.MemberMarketIDs; len(got) != 2 || got[0] != 3001 || got[1] != 3002 {
+		t.Fatalf("expected first group members ordered by display order, got %+v", got)
+	}
+	if got := second.MemberMarketIDs; len(got) != 1 || got[0] != 4001 {
+		t.Fatalf("expected second group member, got %+v", got)
+	}
+	if second.StewardUsername != "steward" {
+		t.Fatalf("expected explicit steward to be preserved, got %q", second.StewardUsername)
+	}
+}

--- a/backend/internal/repository/analytics/repository.go
+++ b/backend/internal/repository/analytics/repository.go
@@ -120,7 +120,7 @@ func (r *GormRepository) ListBetsForMarket(ctx context.Context, marketID uint) (
 	if err := db.Table("bets").
 		Select("id, username, market_id, amount, outcome, placed_at, created_at").
 		Where("market_id = ?", marketID).
-		Order("placed_at ASC").
+		Order("placed_at ASC, id ASC").
 		Find(&bets).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/analytics/repository.go
+++ b/backend/internal/repository/analytics/repository.go
@@ -269,17 +269,33 @@ func (r *GormRepository) hydrateWorkProfitMarketGroups(ctx context.Context, grou
 		return nil, err
 	}
 	records := mapWorkProfitMarketGroups(groups)
-	for index := range records {
-		var members []analyticsMarketGroupMemberRow
-		if err := db.Table("market_group_members").
-			Select("market_id").
-			Where("group_id = ?", records[index].ID).
-			Order("display_order ASC, id ASC").
-			Find(&members).Error; err != nil {
-			return nil, err
-		}
-		records[index].MemberMarketIDs = mapMarketGroupMemberIDs(members)
+	if len(records) == 0 {
+		return records, nil
 	}
+
+	groupIDs := make([]uint, 0, len(records))
+	recordIndexByGroupID := make(map[uint]int, len(records))
+	for index, record := range records {
+		groupIDs = append(groupIDs, record.ID)
+		recordIndexByGroupID[record.ID] = index
+	}
+
+	var members []analyticsMarketGroupMemberRow
+	if err := db.Table("market_group_members").
+		Select("group_id, market_id").
+		Where("group_id IN ?", groupIDs).
+		Order("group_id ASC, display_order ASC, id ASC").
+		Find(&members).Error; err != nil {
+		return nil, err
+	}
+	for _, member := range members {
+		index, ok := recordIndexByGroupID[member.GroupID]
+		if !ok || member.MarketID == 0 {
+			continue
+		}
+		records[index].MemberMarketIDs = append(records[index].MemberMarketIDs, member.MarketID)
+	}
+
 	return records, nil
 }
 
@@ -422,6 +438,7 @@ type analyticsWorkProfitMarketGroupRow struct {
 }
 
 type analyticsMarketGroupMemberRow struct {
+	GroupID  uint
 	MarketID uint
 }
 
@@ -495,17 +512,6 @@ func mapWorkProfitMarketGroups(dbGroups []analyticsWorkProfitMarketGroupRow) []W
 		}
 	}
 	return groups
-}
-
-func mapMarketGroupMemberIDs(members []analyticsMarketGroupMemberRow) []uint {
-	ids := make([]uint, 0, len(members))
-	for _, member := range members {
-		if member.MarketID == 0 {
-			continue
-		}
-		ids = append(ids, member.MarketID)
-	}
-	return ids
 }
 
 func mapBets(dbBets []analyticsBetRow) []boundary.Bet {

--- a/backend/internal/repository/bets/sell_transaction.go
+++ b/backend/internal/repository/bets/sell_transaction.go
@@ -71,6 +71,26 @@ func (r sellMarketRepository) GetUserPositionInMarket(ctx context.Context, marke
 	}, nil
 }
 
+func (r sellMarketRepository) ListBetsForMarket(ctx context.Context, marketID int64) ([]*dmarkets.Bet, error) {
+	_, bets, err := r.loadMarketData(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*dmarkets.Bet, len(bets))
+	for i := range bets {
+		result[i] = &dmarkets.Bet{
+			ID:        bets[i].ID,
+			Username:  bets[i].Username,
+			MarketID:  bets[i].MarketID,
+			Amount:    bets[i].Amount,
+			Outcome:   bets[i].Outcome,
+			PlacedAt:  bets[i].PlacedAt,
+			CreatedAt: bets[i].CreatedAt,
+		}
+	}
+	return result, nil
+}
+
 func (r sellMarketRepository) loadMarketData(ctx context.Context, marketID int64) (positionsmath.MarketSnapshot, []boundary.Bet, error) {
 	var market models.Market
 	marketQuery := r.db.WithContext(ctx)

--- a/backend/internal/repository/bets/sell_transaction.go
+++ b/backend/internal/repository/bets/sell_transaction.go
@@ -89,7 +89,7 @@ func (r sellMarketRepository) loadMarketData(ctx context.Context, marketID int64
 		Model(&models.Bet{}).
 		Select("bets.*").
 		Where("market_id = ?", marketID).
-		Order("placed_at ASC")
+		Order("placed_at ASC, id ASC")
 	if r.db.Dialector.Name() == "postgres" {
 		betsQuery = betsQuery.Clauses(clause.Locking{Strength: "UPDATE"})
 	}

--- a/backend/internal/repository/markets/repository.go
+++ b/backend/internal/repository/markets/repository.go
@@ -554,7 +554,7 @@ func (r *GormRepository) ListBetsForMarket(ctx context.Context, marketID int64) 
 		Model(&models.Bet{}).
 		Select("bets.*").
 		Where("market_id = ?", marketID).
-		Order("placed_at ASC").
+		Order("placed_at ASC, id ASC").
 		Find(&bets).Error; err != nil {
 		return nil, err
 	}
@@ -610,7 +610,7 @@ func (r *GormRepository) loadMarketData(ctx context.Context, marketID int64) (po
 		Model(&models.Bet{}).
 		Select("bets.*").
 		Where("market_id = ?", marketID).
-		Order("placed_at ASC").
+		Order("placed_at ASC, id ASC").
 		Find(&bets).Error; err != nil {
 		return positionsmath.MarketSnapshot{}, nil, err
 	}

--- a/backend/internal/repository/markets/repository_test.go
+++ b/backend/internal/repository/markets/repository_test.go
@@ -101,23 +101,38 @@ func TestGormRepositoryListBetsForMarket(t *testing.T) {
 	if err := db.Create(&market).Error; err != nil {
 		t.Fatalf("seed market: %v", err)
 	}
+	otherMarket := modelstesting.GenerateMarket(201, creator.Username)
+	if err := db.Create(&otherMarket).Error; err != nil {
+		t.Fatalf("seed unrelated market: %v", err)
+	}
 
+	placedAt := time.Now().UTC().Truncate(time.Second)
 	first := models.Bet{
 		Username: "bettor",
 		MarketID: uint(market.ID),
 		Amount:   10,
 		Outcome:  "YES",
-		PlacedAt: time.Now().Add(-2 * time.Minute),
+		PlacedAt: placedAt,
+	}
+	unrelated := models.Bet{
+		Username: "bettor",
+		MarketID: uint(otherMarket.ID),
+		Amount:   99,
+		Outcome:  "YES",
+		PlacedAt: placedAt,
 	}
 	second := models.Bet{
 		Username: "bettor",
 		MarketID: uint(market.ID),
 		Amount:   15,
 		Outcome:  "NO",
-		PlacedAt: time.Now().Add(-1 * time.Minute),
+		PlacedAt: placedAt,
 	}
 	if err := db.Create(&first).Error; err != nil {
 		t.Fatalf("insert first bet: %v", err)
+	}
+	if err := db.Create(&unrelated).Error; err != nil {
+		t.Fatalf("insert unrelated bet: %v", err)
 	}
 	if err := db.Create(&second).Error; err != nil {
 		t.Fatalf("insert second bet: %v", err)
@@ -134,8 +149,14 @@ func TestGormRepositoryListBetsForMarket(t *testing.T) {
 	if bets[0].Username != "bettor" || bets[0].Amount != 10 || bets[0].Outcome != "YES" {
 		t.Fatalf("unexpected first bet: %+v", bets[0])
 	}
-	if !bets[0].PlacedAt.Before(bets[1].PlacedAt) {
-		t.Fatalf("bets not ordered ascending by PlacedAt")
+	if bets[1].Username != "bettor" || bets[1].Amount != 15 || bets[1].Outcome != "NO" {
+		t.Fatalf("unexpected second bet: %+v", bets[1])
+	}
+	if bets[0].MarketID != uint(market.ID) || bets[1].MarketID != uint(market.ID) {
+		t.Fatalf("expected only bets for market %d, got %+v", market.ID, bets)
+	}
+	if bets[0].ID >= bets[1].ID {
+		t.Fatalf("expected stable id tie-break ordering, got first id %d second id %d", bets[0].ID, bets[1].ID)
 	}
 }
 

--- a/backend/internal/repository/users/repository.go
+++ b/backend/internal/repository/users/repository.go
@@ -192,8 +192,9 @@ func (r *GormRepository) List(ctx context.Context, filters dusers.ListFilters) (
 func (r *GormRepository) ListUserBets(ctx context.Context, username string) ([]*dusers.UserBet, error) {
 	var bets []models.Bet
 	if err := r.db.WithContext(ctx).
+		Select("market_id", "placed_at").
 		Where("username = ?", username).
-		Order("placed_at DESC").
+		Order("placed_at DESC, id DESC").
 		Find(&bets).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/users/repository.go
+++ b/backend/internal/repository/users/repository.go
@@ -227,7 +227,7 @@ func (r *GormRepository) GetUserPositionInMarket(ctx context.Context, marketID i
 	var bets []models.Bet
 	if err := r.db.WithContext(ctx).
 		Where("market_id = ?", marketID).
-		Order("placed_at ASC").
+		Order("placed_at ASC, id ASC").
 		Find(&bets).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/users/repository_test.go
+++ b/backend/internal/repository/users/repository_test.go
@@ -73,14 +73,22 @@ func TestGormRepositoryListUserBets(t *testing.T) {
 	if err := db.Create(&user).Error; err != nil {
 		t.Fatalf("seed user: %v", err)
 	}
+	otherUser := modelstesting.GenerateUser("dave", 1000)
+	if err := db.Create(&otherUser).Error; err != nil {
+		t.Fatalf("seed other user: %v", err)
+	}
 
 	market := modelstesting.GenerateMarket(300, "creator")
 	if err := db.Create(&market).Error; err != nil {
 		t.Fatalf("seed market: %v", err)
 	}
+	otherMarket := modelstesting.GenerateMarket(301, "creator")
+	if err := db.Create(&otherMarket).Error; err != nil {
+		t.Fatalf("seed other market: %v", err)
+	}
 
 	earlier := time.Now().Add(-3 * time.Minute)
-	later := time.Now().Add(-1 * time.Minute)
+	later := time.Now().Add(-1 * time.Minute).UTC().Truncate(time.Second)
 	first := models.Bet{
 		Username: "carol",
 		MarketID: uint(market.ID),
@@ -95,26 +103,51 @@ func TestGormRepositoryListUserBets(t *testing.T) {
 		Outcome:  "NO",
 		PlacedAt: earlier,
 	}
+	third := models.Bet{
+		Username: "carol",
+		MarketID: uint(otherMarket.ID),
+		Amount:   7,
+		Outcome:  "YES",
+		PlacedAt: later,
+	}
+	unrelated := models.Bet{
+		Username: "dave",
+		MarketID: uint(market.ID),
+		Amount:   99,
+		Outcome:  "YES",
+		PlacedAt: later.Add(time.Minute),
+	}
 	if err := db.Create(&first).Error; err != nil {
 		t.Fatalf("insert first bet: %v", err)
 	}
 	if err := db.Create(&second).Error; err != nil {
 		t.Fatalf("insert second bet: %v", err)
 	}
+	if err := db.Create(&third).Error; err != nil {
+		t.Fatalf("insert third bet: %v", err)
+	}
+	if err := db.Create(&unrelated).Error; err != nil {
+		t.Fatalf("insert unrelated bet: %v", err)
+	}
 
 	bets, err := repo.ListUserBets(ctx, "carol")
 	if err != nil {
 		t.Fatalf("ListUserBets returned error: %v", err)
 	}
-	if len(bets) != 2 {
-		t.Fatalf("expected 2 bets, got %d", len(bets))
+	if len(bets) != 3 {
+		t.Fatalf("expected 3 bets, got %d", len(bets))
 	}
 
 	if bets[0].PlacedAt.Before(bets[1].PlacedAt) {
 		t.Fatalf("expected bets ordered descending by PlacedAt")
 	}
-	if bets[0].MarketID != uint(market.ID) {
-		t.Fatalf("unexpected market ID in response: %+v", bets[0])
+	if bets[0].MarketID != uint(otherMarket.ID) || bets[1].MarketID != uint(market.ID) {
+		t.Fatalf("expected same-time rows ordered by id desc, got %+v", bets)
+	}
+	for _, bet := range bets {
+		if bet.MarketID != uint(market.ID) && bet.MarketID != uint(otherMarket.ID) {
+			t.Fatalf("unexpected market ID in response: %+v", bet)
+		}
 	}
 }
 

--- a/backend/migration/migrations/20260625_090000_add_bet_query_indexes.go
+++ b/backend/migration/migrations/20260625_090000_add_bet_query_indexes.go
@@ -15,6 +15,7 @@ func MigrateAddBetQueryIndexes(db *gorm.DB) error {
 		"CREATE INDEX IF NOT EXISTS idx_bets_market_id_placed_at_id ON bets (market_id, placed_at, id)",
 		"CREATE INDEX IF NOT EXISTS idx_bets_market_id_username ON bets (market_id, username)",
 		"CREATE INDEX IF NOT EXISTS idx_bets_username_market_id_placed_at_id ON bets (username, market_id, placed_at, id)",
+		"CREATE INDEX IF NOT EXISTS idx_bets_username_placed_at_id ON bets (username, placed_at, id)",
 	}
 
 	for _, statement := range indexStatements {

--- a/backend/migration/migrations/20260625_090000_add_bet_query_indexes.go
+++ b/backend/migration/migrations/20260625_090000_add_bet_query_indexes.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"socialpredict/migration"
+
+	"gorm.io/gorm"
+)
+
+// MigrateAddBetQueryIndexes adds composite indexes for canonical bet-history
+// replay and common market/user lookup paths. These indexes add write/storage
+// cost on each bet insert, but keep high-volume reads scoped to the intended
+// market or user boundary.
+func MigrateAddBetQueryIndexes(db *gorm.DB) error {
+	indexStatements := []string{
+		"CREATE INDEX IF NOT EXISTS idx_bets_market_id_placed_at_id ON bets (market_id, placed_at, id)",
+		"CREATE INDEX IF NOT EXISTS idx_bets_market_id_username ON bets (market_id, username)",
+		"CREATE INDEX IF NOT EXISTS idx_bets_username_market_id_placed_at_id ON bets (username, market_id, placed_at, id)",
+	}
+
+	for _, statement := range indexStatements {
+		if err := db.Exec(statement).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	migration.Register("20260625090000", func(db *gorm.DB) error {
+		return MigrateAddBetQueryIndexes(db)
+	})
+}

--- a/backend/migration/migrations/20260625_090000_add_bet_query_indexes_test.go
+++ b/backend/migration/migrations/20260625_090000_add_bet_query_indexes_test.go
@@ -1,0 +1,44 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"socialpredict/migration/migrations"
+	"socialpredict/models"
+	"socialpredict/models/modelstesting"
+)
+
+func TestMigrateAddBetQueryIndexesCreatesIndexes(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := db.AutoMigrate(&models.User{}, &models.Market{}, &models.Bet{}); err != nil {
+		t.Fatalf("auto migrate core models: %v", err)
+	}
+
+	if err := migrations.MigrateAddBetQueryIndexes(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	for _, indexName := range []string{
+		"idx_bets_market_id_placed_at_id",
+		"idx_bets_market_id_username",
+		"idx_bets_username_market_id_placed_at_id",
+	} {
+		if !db.Migrator().HasIndex(&models.Bet{}, indexName) {
+			t.Fatalf("expected index %s after migration", indexName)
+		}
+	}
+}
+
+func TestMigrateAddBetQueryIndexesIsIdempotent(t *testing.T) {
+	db := modelstesting.NewTestDB(t)
+	if err := db.AutoMigrate(&models.User{}, &models.Market{}, &models.Bet{}); err != nil {
+		t.Fatalf("auto migrate core models: %v", err)
+	}
+
+	if err := migrations.MigrateAddBetQueryIndexes(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	if err := migrations.MigrateAddBetQueryIndexes(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}

--- a/backend/migration/migrations/20260625_090000_add_bet_query_indexes_test.go
+++ b/backend/migration/migrations/20260625_090000_add_bet_query_indexes_test.go
@@ -22,6 +22,7 @@ func TestMigrateAddBetQueryIndexesCreatesIndexes(t *testing.T) {
 		"idx_bets_market_id_placed_at_id",
 		"idx_bets_market_id_username",
 		"idx_bets_username_market_id_placed_at_id",
+		"idx_bets_username_placed_at_id",
 	} {
 		if !db.Migrator().HasIndex(&models.Bet{}, indexName) {
 			t.Fatalf("expected index %s after migration", indexName)

--- a/frontend/src/components/layouts/trade/SellSharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.jsx
@@ -326,19 +326,30 @@ const SaleQuotePanel = ({ quote, quoteError, isLoading, selectedOutcome, onSelec
     const panelTone = quote.allowed
         ? 'border-emerald-400/50 bg-emerald-950/30 text-emerald-50'
         : 'border-amber-300/70 bg-amber-950/40 text-amber-50';
+    const statusLabel = quote.allowed
+        ? 'Allowed'
+        : quote.positionLocked
+            ? 'Locked'
+            : 'Adjust amount';
 
     return (
         <div className={`mb-4 rounded-lg border p-3 text-sm ${panelTone}`}>
             <div className="mb-2 flex items-center justify-between gap-3">
                 <h3 className="text-base font-semibold">Sale Preview</h3>
                 <span className="rounded-full bg-white/10 px-2 py-1 text-xs">
-                    {quote.allowed ? 'Allowed' : 'Adjust amount'}
+                    {statusLabel}
                 </span>
             </div>
             <div className="grid gap-2 sm:grid-cols-2">
                 <QuoteMetric label="Sale order" value={quote.requestedCredits} />
                 <QuoteMetric label="Credits received" value={quote.netProceeds ?? quote.saleValue} />
                 <QuoteMetric label="Shares sold" value={quote.sharesSold} />
+                {quote.positionLocked && (
+                    <>
+                        <QuoteMetric label="Sellable shares" value={quote.sellableShares ?? 0} />
+                        <QuoteMetric label="Locked shares" value={quote.lockedShares ?? 0} />
+                    </>
+                )}
                 <QuoteMetric label="Dust fee" value={`${quote.dust} / ${quote.maxDust}`} />
                 <QuoteMetric label="Value per share" value={quote.valuePerShare} />
                 <QuoteMetric label="Dust coverage" value={`${coverageLabel}%`} />

--- a/frontend/src/components/layouts/trade/TradeUtils.jsx
+++ b/frontend/src/components/layouts/trade/TradeUtils.jsx
@@ -28,6 +28,10 @@ const formatApiError = (errorData, fallback) => {
         return `${errorData.message || 'Sale would create too much rounding dust.'}${suffix} Try a different Sale Order amount.`;
     }
 
+    if (errorData.reason === 'POSITION_LOCKED_AWAITING_EXTERNAL_MARKET_MOVEMENT') {
+        return errorData.message || 'Sale is locked until another user places a later bet on this market.';
+    }
+
     return errorData.message || errorData.reason || errorData.error || fallback;
 };
 


### PR DESCRIPTION
**Summary**

- Moves the GORM query-scoping feature spec to Feature 22 after rebasing onto current main.
- Adds deterministic per-market bet replay ordering with `placed_at ASC, id ASC` across market, analytics, sale, and user-position replay reads.
- Adds composite bet indexes for market chronology, market/user existence checks, user/market chronological reads, and user bet-history display.
- Narrows user bet-history display reads to `market_id` and `placed_at`.
- Collapses grouped work-profit member hydration from one query per group into a single `group_id IN ?` query.
- Adds migration and repository tests proving scoped market reads exclude unrelated rows and preserve ID tie ordering.
- Adds `FEATURES/22/QUERY_AUDIT.md` with the repository-wide regex audit, findings, and follow-up candidates.

**Tests**

- `cd backend && go test ./migration/migrations ./internal/repository/markets ./internal/repository/analytics ./internal/repository/bets ./internal/repository/users`
- `cd backend && go test ./...`
