### PR TITLE
Fix deployed frontend cache busting

### DIFF
--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -22,6 +22,14 @@ server {
     try_files $uri =404;
   }
 
+  # Hashed build assets can be cached aggressively because the filename changes
+  # whenever the content changes. index.html remains no-store and points to the
+  # current hashed assets after each deployment.
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
   # Basic compression
   gzip on;
   gzip_types text/plain text/css application/javascript application/json application/xml application/xml+rss image/svg+xml;

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -23,11 +23,11 @@ export default defineConfig(() => {
       chunkSizeWarningLimit: 1000,
       rollupOptions: {
         output: {
-          entryFileNames: 'assets/[name].js',
+          entryFileNames: 'assets/[name]-[hash].js',
           chunkFileNames: 'assets/[name]-[hash].js',
           assetFileNames: (assetInfo) => {
             if (assetInfo.name && assetInfo.name.endsWith('.css')) {
-              return 'assets/[name][extname]';
+              return 'assets/[name]-[hash][extname]';
             }
             return 'assets/[name]-[hash][extname]';
           },


### PR DESCRIPTION
## Summary
- emit content-hashed frontend entry JS and CSS files
- cache hashed /assets files immutably while keeping index.html and env-config.js no-store
- prevents deployed browsers from continuing to use stale /assets/index.js after staging or production deploys

## Verification
- npm run build

## Context
Staging was serving the current bundle when fetched fresh, but the previous build emitted stable asset names such as /assets/index.js. That made stale browser cache a plausible reason the deployed admin panel did not show newly deployed features.