### PR TITLE
Fix read-model caching on market display paths

### DIFF
--- a/backend/handlers/markets/discovery_read_model.go
+++ b/backend/handlers/markets/discovery_read_model.go
@@ -214,6 +214,17 @@ func (h *MarketDiscoveryReadModelHandler) pinnedMarketResponses(ctx context.Cont
 		if pin.PinType != marketdiscovery.PinTypeMarket || pin.MarketID <= 0 {
 			continue
 		}
+		if summaryProvider, ok := h.markets.(marketSummaryProvider); ok {
+			summary, err := summaryProvider.GetMarketSummaryReadModel(ctx, pin.MarketID)
+			if err != nil {
+				return nil, fmt.Errorf("pinned market %d: %w", pin.MarketID, err)
+			}
+			responses = append(responses, pinnedMarketResponse{
+				Pin:     pin,
+				Details: marketSummaryToDetailsResponse(summary),
+			})
+			continue
+		}
 		details, err := h.markets.GetMarketDetails(ctx, pin.MarketID)
 		if err != nil {
 			return nil, fmt.Errorf("pinned market %d: %w", pin.MarketID, err)
@@ -227,7 +238,7 @@ func (h *MarketDiscoveryReadModelHandler) pinnedMarketResponses(ctx context.Cont
 }
 
 func (h *MarketDiscoveryReadModelHandler) snapshotUsable(snapshot *readmodelrepo.Snapshot) bool {
-	if snapshot == nil || snapshot.IsStale || snapshot.PayloadJSON == "" {
+	if snapshot == nil || snapshot.PayloadJSON == "" {
 		return false
 	}
 	return h.now().Sub(snapshot.GeneratedAt) <= marketDiscoverySnapshotTargetFreshness

--- a/backend/handlers/markets/handler.go
+++ b/backend/handlers/markets/handler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	"socialpredict/handlers"
 	"socialpredict/handlers/markets/dto"
@@ -468,11 +467,8 @@ func (h *Handler) marketLeaderboardReadModel(ctx context.Context, marketID int64
 		return nil, err
 	}
 
-	if snapshot == nil || snapshot.IsStale || snapshot.GeneratedAt.IsZero() || time.Since(snapshot.GeneratedAt) > dmarkets.MarketLeaderboardSnapshotTargetFreshness {
+	if snapshot == nil {
 		if _, refreshErr := service.RefreshMarketLeaderboardSnapshot(ctx, marketID); refreshErr != nil {
-			if snapshot != nil {
-				return snapshot, nil
-			}
 			return nil, refreshErr
 		}
 		snapshot, err = service.GetMarketLeaderboardReadModel(ctx, marketID, page)

--- a/backend/handlers/markets/handler_status_leaderboard_test.go
+++ b/backend/handlers/markets/handler_status_leaderboard_test.go
@@ -184,6 +184,58 @@ func TestMarketLeaderboardHandler_UsesSnapshotFreshnessWhenAvailable(t *testing.
 	}
 }
 
+func TestMarketLeaderboardHandler_ServesStaleSnapshotWithoutRefresh(t *testing.T) {
+	generatedAt := time.Now().UTC().Add(-2 * dmarkets.MarketLeaderboardSnapshotTargetFreshness)
+	svc := &readModelLeaderboardServiceMock{
+		MockService: MockService{
+			MarketLeaderboardFn: func(ctx context.Context, marketID int64, p dmarkets.Page) ([]*dmarkets.LeaderboardRow, error) {
+				t.Fatalf("raw leaderboard calculator should not be used when stale snapshot is available")
+				return nil, nil
+			},
+		},
+		ReadModelFn: func(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketLeaderboardSnapshot, error) {
+			return &dmarkets.MarketLeaderboardSnapshot{
+				MarketID:    marketID,
+				GeneratedAt: generatedAt,
+				Source:      "read_model",
+				IsStale:     true,
+				StaleReason: "bet_accepted",
+				Rows: []*dmarkets.LeaderboardRow{{
+					Username: "stale_snapshot_alice",
+					Rank:     1,
+				}},
+			}, nil
+		},
+		RefreshFn: func(ctx context.Context, marketID int64) (*dmarkets.MarketLeaderboardSnapshot, error) {
+			t.Fatalf("stale leaderboard snapshot should not refresh on read")
+			return nil, nil
+		},
+	}
+
+	handler := NewHandler(svc, nil, security.NewSecurityService())
+	req := httptest.NewRequest(http.MethodGet, "/v0/markets/77/leaderboard?limit=25", nil)
+	rr := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/v0/markets/{id}/leaderboard", handler.MarketLeaderboard)
+
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp handlers.SuccessEnvelope[dto.LeaderboardResponse]
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Result.Leaderboard) != 1 || resp.Result.Leaderboard[0].Username != "stale_snapshot_alice" {
+		t.Fatalf("unexpected leaderboard payload: %+v", resp.Result.Leaderboard)
+	}
+	if resp.Result.Freshness == nil || !resp.Result.Freshness.IsStale {
+		t.Fatalf("expected stale freshness metadata, got %+v", resp.Result.Freshness)
+	}
+}
+
 func TestMarketLeaderboardHandler_FailureEnvelope(t *testing.T) {
 	svc := &MockService{}
 	svc.MarketLeaderboardFn = func(ctx context.Context, marketID int64, p dmarkets.Page) ([]*dmarkets.LeaderboardRow, error) {

--- a/backend/handlers/markets/overview_helpers.go
+++ b/backend/handlers/markets/overview_helpers.go
@@ -13,6 +13,10 @@ type marketOverviewProvider interface {
 	GetMarketDetails(ctx context.Context, marketID int64) (*dmarkets.MarketOverview, error)
 }
 
+type marketSummaryProvider interface {
+	GetMarketSummaryReadModel(ctx context.Context, marketID int64) (*dmarkets.MarketSummaryReadModel, error)
+}
+
 func buildMarketOverviewResponses(ctx context.Context, provider marketOverviewProvider, markets []*dmarkets.Market) ([]*dto.MarketOverviewResponse, error) {
 	if len(markets) == 0 {
 		return []*dto.MarketOverviewResponse{}, nil
@@ -20,6 +24,14 @@ func buildMarketOverviewResponses(ctx context.Context, provider marketOverviewPr
 
 	overviews := make([]*dto.MarketOverviewResponse, 0, len(markets))
 	for _, market := range markets {
+		if summaryProvider, ok := provider.(marketSummaryProvider); ok {
+			summary, err := summaryProvider.GetMarketSummaryReadModel(ctx, market.ID)
+			if err != nil {
+				return nil, fmt.Errorf("market_id=%d: %w", market.ID, err)
+			}
+			overviews = append(overviews, marketSummaryToOverviewResponse(summary))
+			continue
+		}
 		details, err := provider.GetMarketDetails(ctx, market.ID)
 		if err != nil {
 			return nil, fmt.Errorf("market_id=%d: %w", market.ID, err)
@@ -27,6 +39,21 @@ func buildMarketOverviewResponses(ctx context.Context, provider marketOverviewPr
 		overviews = append(overviews, marketOverviewToResponse(details))
 	}
 	return overviews, nil
+}
+
+func marketSummaryToOverviewResponse(summary *dmarkets.MarketSummaryReadModel) *dto.MarketOverviewResponse {
+	if summary == nil {
+		return &dto.MarketOverviewResponse{}
+	}
+
+	return &dto.MarketOverviewResponse{
+		Market:          marketToResponse(summary.Market),
+		Creator:         creatorResponseFromSummary(summary.Creator),
+		LastProbability: summary.Accounting.LastProbability,
+		NumUsers:        summary.Accounting.UserCount,
+		TotalVolume:     summary.Accounting.VolumeWithDust,
+		MarketDust:      summary.Accounting.MarketDust,
+	}
 }
 
 func marketOverviewToResponse(overview *dmarkets.MarketOverview) *dto.MarketOverviewResponse {
@@ -107,6 +134,20 @@ func publicMarketResponseFromDomain(market *dmarkets.Market) dto.PublicMarketRes
 		YesLabel:                market.YesLabel,
 		NoLabel:                 market.NoLabel,
 		Tags:                    marketTagResponsesFromDomain(market.Tags),
+	}
+}
+
+func marketSummaryToDetailsResponse(summary *dmarkets.MarketSummaryReadModel) dto.MarketDetailsResponse {
+	if summary == nil {
+		return dto.MarketDetailsResponse{}
+	}
+	return dto.MarketDetailsResponse{
+		Market:             publicMarketResponseFromDomain(summary.Market),
+		Creator:            creatorResponseFromSummary(summary.Creator),
+		ProbabilityChanges: probabilityChangesToResponse(summary.Accounting.ProbabilityChanges),
+		NumUsers:           summary.Accounting.UserCount,
+		TotalVolume:        summary.Accounting.VolumeWithDust,
+		MarketDust:         summary.Accounting.MarketDust,
 	}
 }
 

--- a/backend/handlers/markets/summary_read_model.go
+++ b/backend/handlers/markets/summary_read_model.go
@@ -8,11 +8,10 @@ import (
 	"socialpredict/handlers/markets/dto"
 	dmarkets "socialpredict/internal/domain/markets"
 	"socialpredict/internal/domain/readmodels"
-	"socialpredict/logger"
 )
 
-type marketAccountingSnapshotRefresher interface {
-	RefreshMarketAccountingSnapshot(ctx context.Context, marketID int64) (*dmarkets.MarketAccountingSnapshot, error)
+type marketSummaryReadModelService interface {
+	GetMarketSummaryReadModel(ctx context.Context, marketID int64) (*dmarkets.MarketSummaryReadModel, error)
 }
 
 type marketSummaryReadModelResponse struct {
@@ -49,29 +48,26 @@ func (h *Handler) MarketSummaryReadModel(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	details, err := h.service.GetMarketDetails(r.Context(), marketID)
+	service, ok := h.service.(marketSummaryReadModelService)
+	if !ok {
+		writeInternalError(w)
+		return
+	}
+
+	summary, err := service.GetMarketSummaryReadModel(r.Context(), marketID)
 	if err != nil {
 		writeDetailsError(w, err)
 		return
 	}
 
-	freshness := readmodels.NewFreshness(details.Market.UpdatedAt, "live", dmarkets.MarketAccountingSnapshotTargetFreshness, false)
-	if refresher, ok := h.service.(marketAccountingSnapshotRefresher); ok {
-		if snapshot, refreshErr := refresher.RefreshMarketAccountingSnapshot(r.Context(), marketID); refreshErr == nil && snapshot != nil {
-			freshness = snapshot.Freshness()
-		} else if refreshErr != nil {
-			logger.LogError("MarketSummaryReadModel", "RefreshMarketAccountingSnapshot", refreshErr)
-		}
-	}
-
 	response := marketSummaryReadModelResponse{
-		Market:      publicMarketResponseFromDomain(details.Market),
-		Creator:     creatorResponseFromSummary(details.Creator),
-		Probability: probabilityChangesToResponse(details.ProbabilityChanges),
-		NumUsers:    details.NumUsers,
-		TotalVolume: details.TotalVolume,
-		MarketDust:  details.MarketDust,
-		Freshness:   readModelFreshnessToResponse(freshness),
+		Market:      publicMarketResponseFromDomain(summary.Market),
+		Creator:     creatorResponseFromSummary(summary.Creator),
+		Probability: probabilityChangesToResponse(summary.Accounting.ProbabilityChanges),
+		NumUsers:    summary.Accounting.UserCount,
+		TotalVolume: summary.Accounting.VolumeWithDust,
+		MarketDust:  summary.Accounting.MarketDust,
+		Freshness:   readModelFreshnessToResponse(summary.Accounting.Freshness()),
 	}
 	_ = handlers.WriteResult(w, http.StatusOK, response)
 }

--- a/backend/handlers/markets/summary_read_model_test.go
+++ b/backend/handlers/markets/summary_read_model_test.go
@@ -1,0 +1,143 @@
+package marketshandlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"socialpredict/handlers"
+	dmarkets "socialpredict/internal/domain/markets"
+	readmodelrepo "socialpredict/internal/repository/readmodels"
+
+	"github.com/gorilla/mux"
+)
+
+func TestMarketSummaryReadModelUsesSnapshotBackedService(t *testing.T) {
+	generatedAt := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	svc := &MockService{
+		MarketSummaryFn: func(_ctx context.Context, marketID int64) (*dmarkets.MarketSummaryReadModel, error) {
+			return &dmarkets.MarketSummaryReadModel{
+				Market: &dmarkets.Market{
+					ID:                 marketID,
+					QuestionTitle:      "Cached Summary Market",
+					Description:        "summary",
+					OutcomeType:        "BINARY",
+					ResolutionDateTime: generatedAt.Add(24 * time.Hour),
+					CreatorUsername:    "creator",
+					YesLabel:           "YES",
+					NoLabel:            "NO",
+					Status:             dmarkets.MarketStatusActive,
+					CreatedAt:          generatedAt,
+					UpdatedAt:          generatedAt,
+				},
+				Creator: &dmarkets.CreatorSummary{Username: "creator", DisplayName: "Creator"},
+				Accounting: dmarkets.MarketAccountingSnapshot{
+					MarketID:           marketID,
+					GeneratedAt:        generatedAt,
+					ProbabilityChanges: []dmarkets.ProbabilityPoint{{Probability: 0.7, Timestamp: generatedAt}},
+					LastProbability:    0.7,
+					UserCount:          4,
+					VolumeWithDust:     120,
+					MarketDust:         1,
+					Source:             "read_model",
+					IsStale:            true,
+					StaleReason:        "bet_accepted",
+				},
+			}, nil
+		},
+	}
+	handler := NewHandler(svc, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/read/markets/7/summary", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "7"})
+	rec := httptest.NewRecorder()
+
+	handler.MarketSummaryReadModel(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if svc.DetailsCalls != 0 {
+		t.Fatalf("GetMarketDetails was called %d times; want 0", svc.DetailsCalls)
+	}
+
+	var envelope handlers.SuccessEnvelope[marketSummaryReadModelResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.OK || envelope.Result.TotalVolume != 120 || envelope.Result.NumUsers != 4 {
+		t.Fatalf("unexpected summary response: %+v", envelope)
+	}
+	if !envelope.Result.Freshness.IsStale || envelope.Result.Freshness.StaleReason != "bet_accepted" {
+		t.Fatalf("expected stale freshness from snapshot, got %+v", envelope.Result.Freshness)
+	}
+	if len(envelope.Result.Probability) != 1 || envelope.Result.Probability[0].Probability != 0.7 {
+		t.Fatalf("unexpected probability response: %+v", envelope.Result.Probability)
+	}
+}
+
+func TestMarketOverviewResponsesPreferSummaryReadModel(t *testing.T) {
+	svc := &MockService{}
+	markets := []*dmarkets.Market{{ID: 1}, {ID: 2}}
+
+	responses, err := buildMarketOverviewResponses(context.Background(), svc, markets)
+	if err != nil {
+		t.Fatalf("buildMarketOverviewResponses returned error: %v", err)
+	}
+	if len(responses) != 2 {
+		t.Fatalf("expected 2 responses, got %d", len(responses))
+	}
+	if svc.DetailsCalls != 0 {
+		t.Fatalf("GetMarketDetails was called %d times; want 0", svc.DetailsCalls)
+	}
+	if responses[0].TotalVolume != 1000 || responses[0].MarketDust != 50 {
+		t.Fatalf("expected summary read-model values, got %+v", responses[0])
+	}
+}
+
+func TestMarketSummaryToDetailsResponseDoesNotIncludeAmendments(t *testing.T) {
+	generatedAt := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	response := marketSummaryToDetailsResponse(&dmarkets.MarketSummaryReadModel{
+		Market: &dmarkets.Market{ID: 3, QuestionTitle: "Pinned", CreatorUsername: "creator", CreatedAt: generatedAt},
+		Creator: &dmarkets.CreatorSummary{
+			Username: "creator",
+		},
+		Accounting: dmarkets.MarketAccountingSnapshot{
+			MarketID:           3,
+			GeneratedAt:        generatedAt,
+			ProbabilityChanges: []dmarkets.ProbabilityPoint{{Probability: 0.6, Timestamp: generatedAt}},
+			UserCount:          2,
+			VolumeWithDust:     30,
+			MarketDust:         1,
+		},
+	})
+
+	if response.Market.ID != 3 || response.TotalVolume != 30 || response.MarketDust != 1 {
+		t.Fatalf("unexpected details response: %+v", response)
+	}
+	if len(response.DescriptionAmendments) != 0 {
+		t.Fatalf("summary read model should not hydrate amendments, got %+v", response.DescriptionAmendments)
+	}
+}
+
+func TestMarketDiscoverySnapshotUsableAllowsYoungStaleSnapshot(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	handler := &MarketDiscoveryReadModelHandler{clock: func() time.Time { return now }}
+	snapshot := &readmodelrepo.Snapshot{
+		PayloadJSON: `{"markets":[]}`,
+		GeneratedAt: now.Add(-1 * time.Minute),
+		IsStale:     true,
+		StaleReason: "bet_accepted",
+	}
+
+	if !handler.snapshotUsable(snapshot) {
+		t.Fatalf("expected young stale discovery snapshot to be usable")
+	}
+
+	snapshot.GeneratedAt = now.Add(-marketDiscoverySnapshotTargetFreshness - time.Second)
+	if handler.snapshotUsable(snapshot) {
+		t.Fatalf("expected expired discovery snapshot to be unusable")
+	}
+}

--- a/backend/handlers/markets/test_service_mock_test.go
+++ b/backend/handlers/markets/test_service_mock_test.go
@@ -12,6 +12,8 @@ type MockService struct {
 	ListByStatusFn      func(ctx context.Context, status string, p dmarkets.Page) ([]*dmarkets.Market, error)
 	ListLifecycleFn     func(ctx context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error)
 	MarketLeaderboardFn func(ctx context.Context, marketID int64, p dmarkets.Page) ([]*dmarkets.LeaderboardRow, error)
+	MarketSummaryFn     func(ctx context.Context, marketID int64) (*dmarkets.MarketSummaryReadModel, error)
+	DetailsCalls        int
 }
 
 func (m *MockService) CreateMarket(ctx context.Context, req dmarkets.MarketCreateRequest, creatorUsername string) (*dmarkets.Market, error) {
@@ -88,6 +90,7 @@ func (m *MockService) ProjectProbability(ctx context.Context, req dmarkets.Proba
 }
 
 func (m *MockService) GetMarketDetails(ctx context.Context, marketID int64) (*dmarkets.MarketOverview, error) {
+	m.DetailsCalls += 1
 	now := time.Now()
 
 	market := &dmarkets.Market{
@@ -122,6 +125,39 @@ func (m *MockService) GetMarketDetails(ctx context.Context, marketID int64) (*dm
 		NumUsers:           numUsers,
 		TotalVolume:        totalVolume,
 		MarketDust:         marketDust,
+	}, nil
+}
+
+func (m *MockService) GetMarketSummaryReadModel(ctx context.Context, marketID int64) (*dmarkets.MarketSummaryReadModel, error) {
+	if m.MarketSummaryFn != nil {
+		return m.MarketSummaryFn(ctx, marketID)
+	}
+	now := time.Now()
+	return &dmarkets.MarketSummaryReadModel{
+		Market: &dmarkets.Market{
+			ID:                 marketID,
+			QuestionTitle:      "Test Market",
+			Description:        "Test market description",
+			OutcomeType:        "BINARY",
+			ResolutionDateTime: now.Add(24 * time.Hour),
+			CreatorUsername:    "testuser",
+			YesLabel:           "YES",
+			NoLabel:            "NO",
+			Status:             "active",
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		},
+		Creator: &dmarkets.CreatorSummary{Username: "testuser"},
+		Accounting: dmarkets.MarketAccountingSnapshot{
+			MarketID:           marketID,
+			GeneratedAt:        now,
+			ProbabilityChanges: []dmarkets.ProbabilityPoint{},
+			LastProbability:    0.5,
+			UserCount:          3,
+			VolumeWithDust:     1000,
+			MarketDust:         50,
+			Source:             "read_model",
+		},
 	}, nil
 }
 

--- a/backend/handlers/metrics/getgloballeaderboard.go
+++ b/backend/handlers/metrics/getgloballeaderboard.go
@@ -47,7 +47,7 @@ func globalLeaderboardReadModel(ctx context.Context, svc GlobalLeaderboardServic
 	}
 
 	readModel, err := readSvc.GetGlobalLeaderboardReadModel(ctx, limit, offset)
-	if err == nil && readModel != nil && freshnessWithinTargetAge(readModel.Freshness, analytics.GlobalLeaderboardSnapshotTargetFreshness) {
+	if err == nil && readModel != nil {
 		return readModel.Entries, &readModel.Freshness, nil
 	}
 

--- a/backend/handlers/metrics/getgloballeaderboard_test.go
+++ b/backend/handlers/metrics/getgloballeaderboard_test.go
@@ -169,8 +169,8 @@ func (s *cachedGlobalLeaderboardService) RefreshGlobalLeaderboardSnapshot(contex
 	}, nil
 }
 
-func TestGlobalLeaderboardReadModel_ServesStaleSnapshotUntilAgeExpires(t *testing.T) {
-	generatedAt := time.Now().UTC().Add(-5 * time.Minute)
+func TestGlobalLeaderboardReadModel_ServesStaleSnapshotWithoutRefresh(t *testing.T) {
+	generatedAt := time.Now().UTC().Add(-2 * analytics.GlobalLeaderboardSnapshotTargetFreshness)
 	svc := &cachedGlobalLeaderboardService{
 		readModel: &analytics.GlobalLeaderboardReadModel{
 			Entries: []analytics.GlobalUserProfitability{{Username: "cached", Rank: 1}},
@@ -196,7 +196,7 @@ func TestGlobalLeaderboardReadModel_ServesStaleSnapshotUntilAgeExpires(t *testin
 		t.Fatalf("expected stale freshness to be served, got %+v", freshness)
 	}
 	if svc.refreshCalls != 0 {
-		t.Fatalf("expected no refresh for stale-but-young snapshot, got %d", svc.refreshCalls)
+		t.Fatalf("expected no refresh for stale snapshot, got %d", svc.refreshCalls)
 	}
 }
 

--- a/backend/handlers/metrics/getsystemmetrics.go
+++ b/backend/handlers/metrics/getsystemmetrics.go
@@ -44,7 +44,7 @@ func systemMetricsReadModel(ctx context.Context, svc SystemMetricsService) (*ana
 	}
 
 	readModel, err := readSvc.GetSystemMetricsReadModel(ctx)
-	if err == nil && readModel != nil && freshnessWithinTargetAge(readModel.Freshness, analytics.SystemMetricsSnapshotTargetFreshness) {
+	if err == nil && readModel != nil {
 		return &readModel.Metrics, &readModel.Freshness, nil
 	}
 

--- a/backend/handlers/metrics/getsystemmetrics_test.go
+++ b/backend/handlers/metrics/getsystemmetrics_test.go
@@ -90,8 +90,8 @@ func (s *cachedSystemMetricsService) RefreshSystemMetricsSnapshot(context.Contex
 	}, nil
 }
 
-func TestSystemMetricsReadModel_ServesStaleSnapshotUntilAgeExpires(t *testing.T) {
-	generatedAt := time.Now().UTC().Add(-5 * time.Minute)
+func TestSystemMetricsReadModel_ServesStaleSnapshotWithoutRefresh(t *testing.T) {
+	generatedAt := time.Now().UTC().Add(-2 * analytics.SystemMetricsSnapshotTargetFreshness)
 	svc := &cachedSystemMetricsService{
 		readModel: &analytics.SystemMetricsReadModel{
 			Metrics: analytics.SystemMetrics{},
@@ -114,7 +114,7 @@ func TestSystemMetricsReadModel_ServesStaleSnapshotUntilAgeExpires(t *testing.T)
 		t.Fatalf("expected stale freshness to be served, got %+v", freshness)
 	}
 	if svc.refreshCalls != 0 {
-		t.Fatalf("expected no refresh for stale-but-young snapshot, got %d", svc.refreshCalls)
+		t.Fatalf("expected no refresh for stale snapshot, got %d", svc.refreshCalls)
 	}
 }
 

--- a/backend/handlers/metrics/service.go
+++ b/backend/handlers/metrics/service.go
@@ -50,10 +50,3 @@ func freshnessResponseFromDomain(freshness readmodels.Freshness) FreshnessRespon
 		MarkedStaleAt:          freshness.MarkedStaleAt,
 	}
 }
-
-func freshnessWithinTargetAge(freshness readmodels.Freshness, target time.Duration) bool {
-	if freshness.GeneratedAt.IsZero() {
-		return false
-	}
-	return time.Since(freshness.GeneratedAt) <= target
-}

--- a/backend/handlers/positions/positionshandler.go
+++ b/backend/handlers/positions/positionshandler.go
@@ -92,11 +92,8 @@ func marketPositionsReadModel(ctx context.Context, svc dmarkets.ServiceInterface
 		return nil, err
 	}
 
-	if snapshot == nil || snapshot.IsStale || snapshot.GeneratedAt.IsZero() || time.Since(snapshot.GeneratedAt) > dmarkets.MarketPositionsSnapshotTargetFreshness {
+	if snapshot == nil {
 		if _, refreshErr := service.RefreshMarketPositionsSnapshot(ctx, marketID); refreshErr != nil {
-			if snapshot != nil {
-				return snapshot, nil
-			}
 			return nil, refreshErr
 		}
 		snapshot, err = service.GetMarketPositionsReadModel(ctx, marketID, page)

--- a/backend/handlers/positions/positionshandler_test.go
+++ b/backend/handlers/positions/positionshandler_test.go
@@ -349,6 +349,47 @@ func TestMarketPositionsHandlerWithService_UsesSnapshotFreshnessWhenAvailable(t 
 	}
 }
 
+func TestMarketPositionsHandlerWithService_ServesStaleSnapshotWithoutRefresh(t *testing.T) {
+	generatedAt := time.Now().UTC().Add(-2 * dmarkets.MarketPositionsSnapshotTargetFreshness)
+	mockSvc := &readModelPositionsService{
+		readModel: &dmarkets.MarketPositionsSnapshot{
+			MarketID:    7,
+			GeneratedAt: generatedAt,
+			Source:      "read_model",
+			IsStale:     true,
+			StaleReason: "bet_accepted",
+			Positions: dmarkets.MarketPositions{
+				{Username: "stale_snapshot_alice", MarketID: 7, YesSharesOwned: 3},
+			},
+		},
+	}
+	handler := MarketPositionsHandlerWithService(mockSvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/markets/positions/7?limit=20&offset=0", nil)
+	req = mux.SetURLVars(req, map[string]string{"marketId": "7"})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if mockSvc.refreshCalls != 0 {
+		t.Fatalf("stale positions snapshot should not refresh on read, got %d refreshes", mockSvc.refreshCalls)
+	}
+
+	var resp handlers.SuccessEnvelope[marketPositionsResponse]
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode success envelope: %v", err)
+	}
+	if len(resp.Result.Positions) != 1 || resp.Result.Positions[0].Username != "stale_snapshot_alice" {
+		t.Fatalf("unexpected positions payload: %+v", resp.Result.Positions)
+	}
+	if resp.Result.Freshness == nil || !resp.Result.Freshness.IsStale {
+		t.Fatalf("expected stale freshness metadata, got %+v", resp.Result.Freshness)
+	}
+}
+
 func TestMarketUserPositionHandlerWithService_FailureEnvelope(t *testing.T) {
 	handler := MarketUserPositionHandlerWithService(&mockUserPositionService{
 		mockPositionsService: mockPositionsService{err: errors.New("boom")},
@@ -378,7 +419,8 @@ func TestMarketUserPositionHandlerWithService_FailureEnvelope(t *testing.T) {
 
 type readModelPositionsService struct {
 	mockPositionsService
-	readModel *dmarkets.MarketPositionsSnapshot
+	readModel    *dmarkets.MarketPositionsSnapshot
+	refreshCalls int
 }
 
 func (m *readModelPositionsService) GetMarketPositionsReadModel(ctx context.Context, marketID int64, p dmarkets.Page) (*dmarkets.MarketPositionsSnapshot, error) {
@@ -398,6 +440,7 @@ func (m *readModelPositionsService) GetMarketPositionsReadModel(ctx context.Cont
 }
 
 func (m *readModelPositionsService) RefreshMarketPositionsSnapshot(ctx context.Context, marketID int64) (*dmarkets.MarketPositionsSnapshot, error) {
+	m.refreshCalls++
 	return m.readModel, nil
 }
 

--- a/backend/internal/domain/markets/market_accounting_snapshot_refresh.go
+++ b/backend/internal/domain/markets/market_accounting_snapshot_refresh.go
@@ -35,6 +35,46 @@ func (s *Service) RefreshMarketAccountingSnapshot(ctx context.Context, marketID 
 	return &snapshot, nil
 }
 
+// GetMarketSummaryReadModel returns display-safe market summary data from the
+// durable accounting snapshot. Existing stale snapshots are returned rather
+// than synchronously refreshed so high-traffic display reads do not recompute
+// market accounting on every write.
+func (s *Service) GetMarketSummaryReadModel(ctx context.Context, marketID int64) (*MarketSummaryReadModel, error) {
+	if marketID <= 0 {
+		return nil, ErrInvalidInput
+	}
+
+	snapshotRepo, ok := s.repo.(MarketAccountingSnapshotRepository)
+	if !ok {
+		return nil, ErrInvalidState
+	}
+
+	market, err := s.repo.GetByID(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+	if market == nil {
+		return nil, ErrMarketNotFound
+	}
+
+	snapshot, err := snapshotRepo.GetMarketAccountingSnapshot(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+	if snapshot == nil {
+		snapshot, err = s.RefreshMarketAccountingSnapshot(ctx, marketID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &MarketSummaryReadModel{
+		Market:     market,
+		Creator:    s.buildCreatorSummary(ctx, market.CreatorUsername),
+		Accounting: *snapshot,
+	}, nil
+}
+
 // MarkMarketAccountingSnapshotStale marks a market accounting read model stale
 // after canonical market activity. It does not update market/bet truth.
 func (s *Service) MarkMarketAccountingSnapshotStale(ctx context.Context, marketID int64, reason string) error {

--- a/backend/internal/domain/markets/market_accounting_snapshot_refresh_test.go
+++ b/backend/internal/domain/markets/market_accounting_snapshot_refresh_test.go
@@ -69,6 +69,88 @@ func TestServiceRefreshMarketAccountingSnapshotPersistsRawRecomputedSnapshot(t *
 	}
 }
 
+func TestServiceGetMarketSummaryReadModelReturnsStaleSnapshotWithoutRecomputing(t *testing.T) {
+	service, db, _ := setupServiceWithDB(t)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("summary_snapshot_creator", 0)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("create creator: %v", err)
+	}
+
+	market := modelstesting.GenerateMarket(9092, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+
+	firstBet := modelstesting.GenerateBet(100, "YES", "alice", uint(market.ID), time.Minute)
+	if err := db.Create(&firstBet).Error; err != nil {
+		t.Fatalf("create first bet: %v", err)
+	}
+
+	if _, err := service.RefreshMarketAccountingSnapshot(ctx, market.ID); err != nil {
+		t.Fatalf("refresh snapshot: %v", err)
+	}
+
+	repo := rmarkets.NewGormRepository(db)
+	if err := repo.MarkMarketAccountingSnapshotStale(ctx, market.ID, "bet_accepted"); err != nil {
+		t.Fatalf("mark snapshot stale: %v", err)
+	}
+
+	secondBet := modelstesting.GenerateBet(50, "NO", "bob", uint(market.ID), 2*time.Minute)
+	if err := db.Create(&secondBet).Error; err != nil {
+		t.Fatalf("create second bet: %v", err)
+	}
+
+	summary, err := service.GetMarketSummaryReadModel(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("GetMarketSummaryReadModel returned error: %v", err)
+	}
+	if summary.Accounting.BetCount != 1 || summary.Accounting.UserCount != 1 || summary.Accounting.VolumeWithDust != 100 {
+		t.Fatalf("summary recomputed instead of returning stale snapshot: %+v", summary.Accounting)
+	}
+	freshness := summary.Accounting.Freshness()
+	if !freshness.IsStale || freshness.StaleReason != "bet_accepted" {
+		t.Fatalf("expected stale freshness from stored snapshot, got %+v", freshness)
+	}
+}
+
+func TestServiceGetMarketSummaryReadModelComputesMissingSnapshotOnce(t *testing.T) {
+	service, db, _ := setupServiceWithDB(t)
+	ctx := context.Background()
+
+	creator := modelstesting.GenerateUser("summary_missing_creator", 0)
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("create creator: %v", err)
+	}
+
+	market := modelstesting.GenerateMarket(9093, creator.Username)
+	if err := db.Create(&market).Error; err != nil {
+		t.Fatalf("create market: %v", err)
+	}
+	bet := modelstesting.GenerateBet(75, "YES", "alice", uint(market.ID), time.Minute)
+	if err := db.Create(&bet).Error; err != nil {
+		t.Fatalf("create bet: %v", err)
+	}
+
+	summary, err := service.GetMarketSummaryReadModel(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("GetMarketSummaryReadModel returned error: %v", err)
+	}
+	if summary.Accounting.BetCount != 1 || summary.Accounting.VolumeWithDust != 75 {
+		t.Fatalf("unexpected computed summary: %+v", summary.Accounting)
+	}
+
+	repo := rmarkets.NewGormRepository(db)
+	stored, err := repo.GetMarketAccountingSnapshot(ctx, market.ID)
+	if err != nil {
+		t.Fatalf("get stored snapshot: %v", err)
+	}
+	if stored == nil {
+		t.Fatalf("expected missing snapshot to be stored after first summary read")
+	}
+}
+
 func TestServiceRefreshMarketAccountingSnapshotRequiresSnapshotRepository(t *testing.T) {
 	service := markets.NewService(&snapshotlessMarketRepo{}, newNoopUserService(), newFixedClock(marketsTestTime()), markets.Config{})
 

--- a/backend/internal/domain/markets/service.go
+++ b/backend/internal/domain/markets/service.go
@@ -476,6 +476,14 @@ type MarketOverview struct {
 	DescriptionAmendments []MarketDescriptionAmendment
 }
 
+// MarketSummaryReadModel is a display-only market summary backed by the
+// market accounting snapshot. It must not be used for transaction decisions.
+type MarketSummaryReadModel struct {
+	Market     *Market
+	Creator    *CreatorSummary
+	Accounting MarketAccountingSnapshot
+}
+
 // Page represents pagination parameters.
 type Page struct {
 	Limit  int


### PR DESCRIPTION
## Summary
- Make market summary reads use stored accounting snapshots instead of recomputing market details on every request
- Prefer snapshot-backed summaries for market discovery cards and pinned market responses
- Serve existing stale display snapshots for positions, market leaderboards, system metrics, and global leaderboard instead of refreshing synchronously on read
- Keep transaction paths unchanged; these read models remain display-only

## Testing
- go test ./handlers/markets ./handlers/positions ./handlers/metrics ./internal/domain/markets
- go test ./...

## Load-test context
This targets the read-path pressure observed during the June 10/11 mixed site load test. After this merges/deploys, rerun the reduced site-mix baseline, then ladder upward.