### PR TITLE
Fix frontend release image OpenSSL vulnerabilities

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+**/node_modules
+frontend/build
+frontend/dist

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -17,9 +17,71 @@ env:
   STAGING_URL: https://kconfs.com
 
 jobs:
+  scan-candidate-images:
+    name: Scan staging candidate images
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: frontend
+            dockerfile: docker/frontend/Dockerfile
+          - image: backend
+            dockerfile: docker/backend/Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build ${{ matrix.image }} staging candidate
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          load: true
+          tags: socialpredict-${{ matrix.image }}:staging-candidate
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan ${{ matrix.image }} staging candidate for SARIF security alerts
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: socialpredict-${{ matrix.image }}:staging-candidate
+          format: sarif
+          output: trivy-${{ matrix.image }}-staging-candidate.sarif
+          scanners: vuln,secret
+          vuln-type: os,library
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+
+      - name: Upload ${{ matrix.image }} staging candidate SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-${{ matrix.image }}-staging-candidate.sarif
+          category: trivy-${{ matrix.image }}-staging-candidate
+
+      - name: Block staging deploy on critical ${{ matrix.image }} vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: socialpredict-${{ matrix.image }}:staging-candidate
+          format: table
+          scanners: vuln
+          vuln-type: os,library
+          severity: CRITICAL
+          ignore-unfixed: false
+          exit-code: '1'
+
   dispatch-deploy:
     name: Dispatch staging deploy
     runs-on: ubuntu-latest
+    needs: scan-candidate-images
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     permissions:
       contents: read

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -9,6 +9,8 @@ RUN npm run build
 
 FROM nginx:1.29.3-alpine3.22
 
+RUN apk add --no-cache --upgrade libcrypto3 libssl3
+
 COPY --from=builder /app/frontend/build /usr/share/nginx/html
 COPY frontend/public/env-config.js.template /usr/share/nginx/html/env-config.js.template
 COPY docker/frontend/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- Upgrade Alpine OpenSSL runtime packages in the frontend nginx image so `libcrypto3` and `libssl3` resolve past the Trivy fixed version for CVE-2026-31789.
- Add a minimal `.dockerignore` so local Docker builds do not copy host `node_modules` or generated frontend builds into the image context.
- Add a staging pre-deploy candidate image scan that builds the frontend/backend Dockerfiles and blocks deployment if Trivy finds critical vulnerabilities.

## Validation
- `docker build --platform linux/amd64 -f docker/frontend/Dockerfile -t socialpredict-frontend-openssl-fix .`
- `docker run --rm --platform linux/amd64 --entrypoint sh socialpredict-frontend-openssl-fix -lc "apk info -v | grep -E '^(libcrypto3|libssl3)-'"`
- Verified built image contains `libcrypto3-3.5.7-r0` and `libssl3-3.5.7-r0`.
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |p| YAML.load_file(p) }; puts "workflow yaml ok"'`

## Release Failure Addressed
- Addresses failing release workflow: https://github.com/openpredictionmarkets/socialpredict/actions/runs/28066753883
- Failed step: `Block Frontend release image on critical vulnerabilities`
