### PR TITLE
Fix traffic badge workflow permissions

### DIFF
--- a/.github/workflows/repo-traffic-badges.yml
+++ b/.github/workflows/repo-traffic-badges.yml
@@ -20,12 +20,23 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Fetch rolling 14-day clone metrics
+        id: traffic
         env:
-          GH_TOKEN: ${{ secrets.TRAFFIC_METRICS_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.TRAFFIC_METRICS_TOKEN }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Traffic metrics token missing::Skipping repository traffic badge refresh. Add TRAFFIC_METRICS_TOKEN with read access to repository Administration to update these badges."
+            exit 0
+          fi
+
           mkdir -p "$METRICS_DIR"
-          gh api "repos/$GITHUB_REPOSITORY/traffic/clones" > "$RUNNER_TEMP/clones.json"
+          if ! gh api "repos/$GITHUB_REPOSITORY/traffic/clones" > "$RUNNER_TEMP/clones.json"; then
+            echo "::error title=Traffic metrics API denied::TRAFFIC_METRICS_TOKEN must have read access to repository Administration for $GITHUB_REPOSITORY."
+            exit 1
+          fi
+
           python3 - <<'PY'
           import json
           import os
@@ -76,8 +87,10 @@ jobs:
           )
           readme.write_text(readme_text)
           PY
+          echo "updated=true" >> "$GITHUB_OUTPUT"
 
       - name: Commit updated traffic badges
+        if: steps.traffic.outputs.updated == 'true'
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"

--- a/README/METRICS/README.md
+++ b/README/METRICS/README.md
@@ -6,4 +6,4 @@ GitHub only exposes repository clone/view traffic for a rolling 14-day window. T
 
 The top-level README uses static Shields badge URLs for the rolling clone metrics so badges render correctly before and after branch merges. The scheduled refresh workflow updates both the README badge URLs and these JSON snapshots from `gh api repos/$GITHUB_REPOSITORY/traffic/clones`.
 
-If the default `GITHUB_TOKEN` cannot read traffic metrics, add a repository secret named `TRAFFIC_METRICS_TOKEN` using a fine-grained token with read access to repository administration/traffic metrics.
+GitHub's traffic API requires access that the default `GITHUB_TOKEN` does not provide. Add a repository secret named `TRAFFIC_METRICS_TOKEN` using a fine-grained token or GitHub App token with read access to repository Administration. If this secret is absent, the scheduled workflow exits successfully without updating the traffic badges.


### PR DESCRIPTION
## Summary
- stop falling back to the default GITHUB_TOKEN for repository traffic metrics
- skip the badge refresh cleanly when TRAFFIC_METRICS_TOKEN is not configured
- document the required traffic metrics token permissions

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/repo-traffic-badges.yml"); puts "YAML ok"'
- git diff --check


... to update/activate:

```
  Repo → Settings → Secrets and variables → Actions → New repository secret

  Name it exactly:

  TRAFFIC_METRICS_TOKEN

  Value: a fine-grained PAT or GitHub App token that can read traffic metrics for openpredictionmarkets/socialpredict. For a fine-grained PAT, scope it to
  this repo and give it:

  Repository permissions → Administration → Read-only

  The workflow already maps that secret into the step as GH_TOKEN, so you do not need to add a separate env var manually. If the secret is missing, the
  workflow will now pass but skip updating the traffic badges.
```