### PR TITLE
Show stewarded markets in profile queues

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1536,9 +1536,11 @@ paths:
       operationId: listMyLifecycleMarkets
       summary: List current user's lifecycle markets
       description: >
-        Returns proposed, published, or rejected markets created by the authenticated
-        user. This private moderator profile queue includes lifecycle review
-        metadata that public market lists intentionally exclude.
+        Returns proposed, published, or rejected markets currently stewarded by the
+        authenticated user. Current steward ownership falls back to creator ownership
+        for legacy markets without an explicit steward. This private moderator profile
+        queue includes lifecycle review metadata that public market lists intentionally
+        exclude.
       security:
         - bearerAuth: []
       parameters:
@@ -4797,16 +4799,16 @@ paths:
       operationId: getUserOwnedMarkets
       summary: Get user-owned markets
       description: >
-        Returns markets created by or currently stewarded by the requested user.
-        This is login-only game transparency data. Current steward ownership
-        falls back to creator ownership for legacy markets without an explicit steward.
+        Returns markets currently stewarded by the requested user. This is login-only
+        game transparency data. Current steward ownership falls back to creator ownership
+        for legacy markets without an explicit steward.
       security:
         - bearerAuth: []
       parameters:
         - in: path
           name: username
           required: true
-          description: Username whose created and stewarded markets should be returned.
+          description: Username whose currently stewarded markets should be returned.
           schema:
             type: string
         - in: query

--- a/backend/handlers/markets/lifecycle_markets.go
+++ b/backend/handlers/markets/lifecycle_markets.go
@@ -26,7 +26,7 @@ type lifecycleMarketsResponse struct {
 	Total   int                   `json:"total"`
 }
 
-// ListMyLifecycleMarketsHandler returns proposed/published/rejected markets for the current user.
+// ListMyLifecycleMarketsHandler returns proposed/published/rejected markets stewarded by the current user.
 func ListMyLifecycleMarketsHandler(svc lifecycleMarketLister, auth authsvc.Authenticator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -48,7 +48,7 @@ func ListMyLifecycleMarketsHandler(svc lifecycleMarketLister, auth authsvc.Authe
 		if !ok {
 			return
 		}
-		filters.CreatedBy = user.Username
+		filters.OwnedBy = user.Username
 
 		if discoverySvc, ok := svc.(lifecycleMarketDiscoveryLister); ok {
 			page, err := discoverySvc.ListLifecycleMarketDiscovery(r.Context(), filters)

--- a/backend/handlers/markets/lifecycle_markets_test.go
+++ b/backend/handlers/markets/lifecycle_markets_test.go
@@ -55,8 +55,11 @@ func TestListMyLifecycleMarketsAttachesMarketGroupMetadata(t *testing.T) {
 	}
 	svc := &MockService{
 		ListLifecycleFn: func(_ context.Context, filters dmarkets.ListFilters) ([]*dmarkets.Market, error) {
-			if filters.CreatedBy != "moderator" {
-				t.Fatalf("CreatedBy = %q, want moderator", filters.CreatedBy)
+			if filters.OwnedBy != "moderator" {
+				t.Fatalf("OwnedBy = %q, want moderator", filters.OwnedBy)
+			}
+			if filters.CreatedBy != "" {
+				t.Fatalf("CreatedBy = %q, want empty", filters.CreatedBy)
 			}
 			if filters.Status != dmarkets.MarketLifecyclePublished {
 				t.Fatalf("Status = %q, want published", filters.Status)

--- a/backend/handlers/markets/user_owned_markets.go
+++ b/backend/handlers/markets/user_owned_markets.go
@@ -24,7 +24,7 @@ type userOwnedMarketsResponse struct {
 	Total   int                   `json:"total"`
 }
 
-// ListUserOwnedMarketsHandler returns markets created by or currently stewarded by a user.
+// ListUserOwnedMarketsHandler returns markets currently stewarded by a user.
 func ListUserOwnedMarketsHandler(svc userOwnedMarketLister, auth authsvc.Authenticator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/backend/internal/repository/markets/repository.go
+++ b/backend/internal/repository/markets/repository.go
@@ -235,11 +235,7 @@ func applyOwnedByFilter(query *gorm.DB, ownedBy string) *gorm.DB {
 	if ownedBy == "" {
 		return query
 	}
-	return query.Where(
-		"markets.creator_username = ? OR COALESCE(NULLIF(markets.steward_username, ''), markets.creator_username) = ?",
-		ownedBy,
-		ownedBy,
-	)
+	return query.Where("COALESCE(NULLIF(markets.steward_username, ''), markets.creator_username) = ?", ownedBy)
 }
 
 func applyTagSlugFilter(query *gorm.DB, tagSlug string) *gorm.DB {

--- a/backend/internal/repository/markets/repository_test.go
+++ b/backend/internal/repository/markets/repository_test.go
@@ -519,7 +519,7 @@ func TestGormRepositoryListByLifecycleHydratesStewardshipAudits(t *testing.T) {
 	}
 }
 
-func TestGormRepositoryListByLifecycleOwnedByIncludesCreatorAndCurrentSteward(t *testing.T) {
+func TestGormRepositoryListByLifecycleOwnedByUsesCurrentSteward(t *testing.T) {
 	db := modelstesting.NewFakeDB(t)
 	repo := NewGormRepository(db)
 	ctx := context.Background()
@@ -533,19 +533,27 @@ func TestGormRepositoryListByLifecycleOwnedByIncludesCreatorAndCurrentSteward(t 
 		}
 	}
 
-	createdByAlice := modelstesting.GenerateMarket(710, alice.Username)
-	createdByAlice.LifecycleStatus = dmarkets.MarketLifecyclePublished
-	createdByAlice.StewardUsername = alice.Username
+	createdAndStewardedByAlice := modelstesting.GenerateMarket(710, alice.Username)
+	createdAndStewardedByAlice.LifecycleStatus = dmarkets.MarketLifecyclePublished
+	createdAndStewardedByAlice.StewardUsername = alice.Username
 
-	stewardedByAlice := modelstesting.GenerateMarket(711, bob.Username)
-	stewardedByAlice.LifecycleStatus = dmarkets.MarketLifecyclePublished
-	stewardedByAlice.StewardUsername = alice.Username
+	createdByBobStewardedByAlice := modelstesting.GenerateMarket(711, bob.Username)
+	createdByBobStewardedByAlice.LifecycleStatus = dmarkets.MarketLifecyclePublished
+	createdByBobStewardedByAlice.StewardUsername = alice.Username
 
-	unowned := modelstesting.GenerateMarket(712, bob.Username)
+	createdByAliceStewardedByBob := modelstesting.GenerateMarket(712, alice.Username)
+	createdByAliceStewardedByBob.LifecycleStatus = dmarkets.MarketLifecyclePublished
+	createdByAliceStewardedByBob.StewardUsername = bob.Username
+
+	legacyCreatorOwnedByAlice := modelstesting.GenerateMarket(713, alice.Username)
+	legacyCreatorOwnedByAlice.LifecycleStatus = dmarkets.MarketLifecyclePublished
+	legacyCreatorOwnedByAlice.StewardUsername = ""
+
+	unowned := modelstesting.GenerateMarket(714, bob.Username)
 	unowned.LifecycleStatus = dmarkets.MarketLifecyclePublished
 	unowned.StewardUsername = carol.Username
 
-	for _, market := range []any{&createdByAlice, &stewardedByAlice, &unowned} {
+	for _, market := range []any{&createdAndStewardedByAlice, &createdByBobStewardedByAlice, &createdByAliceStewardedByBob, &legacyCreatorOwnedByAlice, &unowned} {
 		if err := db.Create(market).Error; err != nil {
 			t.Fatalf("seed market: %v", err)
 		}
@@ -564,11 +572,33 @@ func TestGormRepositoryListByLifecycleOwnedByIncludesCreatorAndCurrentSteward(t 
 	for _, market := range markets {
 		got[market.ID] = true
 	}
-	if !got[createdByAlice.ID] || !got[stewardedByAlice.ID] {
-		t.Fatalf("expected created and stewarded markets, got %+v", got)
+	if !got[createdAndStewardedByAlice.ID] || !got[createdByBobStewardedByAlice.ID] || !got[legacyCreatorOwnedByAlice.ID] {
+		t.Fatalf("expected current-stewarded and legacy creator-owned markets, got %+v", got)
+	}
+	if got[createdByAliceStewardedByBob.ID] {
+		t.Fatalf("did not expect creator market reassigned to another steward: %+v", got)
 	}
 	if got[unowned.ID] {
 		t.Fatalf("did not expect unowned market in results: %+v", got)
+	}
+
+	bobMarkets, err := repo.ListByLifecycle(ctx, dmarkets.ListFilters{
+		Status:  dmarkets.MarketStatusAll,
+		OwnedBy: bob.Username,
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListByLifecycle for bob returned error: %v", err)
+	}
+	bobGot := map[int64]bool{}
+	for _, market := range bobMarkets {
+		bobGot[market.ID] = true
+	}
+	if !bobGot[createdByAliceStewardedByBob.ID] {
+		t.Fatalf("expected reassigned market in bob's stewarded results, got %+v", bobGot)
+	}
+	if bobGot[createdByBobStewardedByAlice.ID] {
+		t.Fatalf("did not expect bob-created market currently stewarded by alice: %+v", bobGot)
 	}
 }
 


### PR DESCRIPTION
## Summary
- change /v0/profile/markets to filter by current steward ownership instead of creator username
- tighten OwnedBy repository filtering so reassigned markets leave the original creator's owned/published queues and appear for the assigned steward
- update OpenAPI wording and tests for steward ownership, with legacy fallback when no steward is stored

## Tests
- cd backend && go test ./handlers/markets ./internal/repository/markets
- cd backend && go test ./...