### PR TITLE
docs: update repository traffic badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 [release-img]: https://img.shields.io/github/v/release/openpredictionmarkets/socialpredict?label=release
 [release]: https://github.com/openpredictionmarkets/socialpredict/releases/latest
-[clones-14d-img]: https://img.shields.io/badge/14d%20clones-10%2C666-62c3f8
-[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-813-2ea043
+[clones-14d-img]: https://img.shields.io/badge/14d%20clones-6%2C126-62c3f8
+[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-702-2ea043
 [traffic]: https://github.com/openpredictionmarkets/socialpredict/graphs/traffic
 [test-img]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml/badge.svg?branch=main
 [test]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml

--- a/README/METRICS/clones-14d.json
+++ b/README/METRICS/clones-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d clones",
-  "message": "10,666",
+  "message": "6,126",
   "color": "62c3f8"
 }

--- a/README/METRICS/github-traffic-latest.json
+++ b/README/METRICS/github-traffic-latest.json
@@ -1,19 +1,9 @@
 {
-  "updated_at": "2026-06-26T17:20:53Z",
-  "clones_14d": 10666,
-  "unique_cloners_14d": 813,
+  "updated_at": "2026-06-28T06:14:33Z",
+  "clones_14d": 6126,
+  "unique_cloners_14d": 702,
   "source": "GitHub repository traffic API, rolling 14-day window",
   "clones": [
-    {
-      "timestamp": "2026-06-12T00:00:00Z",
-      "count": 1953,
-      "uniques": 67
-    },
-    {
-      "timestamp": "2026-06-13T00:00:00Z",
-      "count": 2875,
-      "uniques": 133
-    },
     {
       "timestamp": "2026-06-14T00:00:00Z",
       "count": 1959,
@@ -73,6 +63,16 @@
       "timestamp": "2026-06-25T00:00:00Z",
       "count": 233,
       "uniques": 24
+    },
+    {
+      "timestamp": "2026-06-26T00:00:00Z",
+      "count": 163,
+      "uniques": 30
+    },
+    {
+      "timestamp": "2026-06-27T00:00:00Z",
+      "count": 125,
+      "uniques": 19
     }
   ]
 }

--- a/README/METRICS/unique-cloners-14d.json
+++ b/README/METRICS/unique-cloners-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d cloners",
-  "message": "813",
+  "message": "702",
   "color": "2ea043"
 }


### PR DESCRIPTION
Updates the repository traffic badge metrics from GitHub's rolling 14-day traffic API.

This PR is created automatically by the Repository Traffic Badges workflow.
