### PR TITLE
docs: update repository traffic badges

### DIFF
--- a/README/METRICS/github-traffic-latest.json
+++ b/README/METRICS/github-traffic-latest.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-06-28T06:14:33Z",
+  "updated_at": "2026-06-29T06:42:53Z",
   "clones_14d": 6126,
   "unique_cloners_14d": 702,
   "source": "GitHub repository traffic API, rolling 14-day window",


### PR DESCRIPTION
Updates the repository traffic badge metrics from GitHub's rolling 14-day traffic API.

This PR is created automatically by the Repository Traffic Badges workflow.
