### PR TITLE
docs: update repository traffic badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 [release-img]: https://img.shields.io/github/v/release/openpredictionmarkets/socialpredict?label=release
 [release]: https://github.com/openpredictionmarkets/socialpredict/releases/latest
-[clones-14d-img]: https://img.shields.io/badge/14d%20clones-6%2C126-62c3f8
-[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-702-2ea043
+[clones-14d-img]: https://img.shields.io/badge/14d%20clones-3%2C702-62c3f8
+[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-535-2ea043
 [traffic]: https://github.com/openpredictionmarkets/socialpredict/graphs/traffic
 [test-img]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml/badge.svg?branch=main
 [test]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml

--- a/README/METRICS/clones-14d.json
+++ b/README/METRICS/clones-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d clones",
-  "message": "6,126",
+  "message": "3,702",
   "color": "62c3f8"
 }

--- a/README/METRICS/github-traffic-latest.json
+++ b/README/METRICS/github-traffic-latest.json
@@ -1,24 +1,9 @@
 {
-  "updated_at": "2026-06-29T06:42:53Z",
-  "clones_14d": 6126,
-  "unique_cloners_14d": 702,
+  "updated_at": "2026-07-01T06:22:51Z",
+  "clones_14d": 3702,
+  "unique_cloners_14d": 535,
   "source": "GitHub repository traffic API, rolling 14-day window",
   "clones": [
-    {
-      "timestamp": "2026-06-14T00:00:00Z",
-      "count": 1959,
-      "uniques": 123
-    },
-    {
-      "timestamp": "2026-06-15T00:00:00Z",
-      "count": 283,
-      "uniques": 47
-    },
-    {
-      "timestamp": "2026-06-16T00:00:00Z",
-      "count": 278,
-      "uniques": 64
-    },
     {
       "timestamp": "2026-06-17T00:00:00Z",
       "count": 397,
@@ -73,6 +58,21 @@
       "timestamp": "2026-06-27T00:00:00Z",
       "count": 125,
       "uniques": 19
+    },
+    {
+      "timestamp": "2026-06-28T00:00:00Z",
+      "count": 41,
+      "uniques": 22
+    },
+    {
+      "timestamp": "2026-06-29T00:00:00Z",
+      "count": 40,
+      "uniques": 23
+    },
+    {
+      "timestamp": "2026-06-30T00:00:00Z",
+      "count": 15,
+      "uniques": 8
     }
   ]
 }

--- a/README/METRICS/unique-cloners-14d.json
+++ b/README/METRICS/unique-cloners-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d cloners",
-  "message": "702",
+  "message": "535",
   "color": "2ea043"
 }


### PR DESCRIPTION
Updates the repository traffic badge metrics from GitHub's rolling 14-day traffic API.

This PR is created automatically by the Repository Traffic Badges workflow.
