### PR TITLE
docs: update repository traffic badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 [release-img]: https://img.shields.io/github/v/release/openpredictionmarkets/socialpredict?label=release
 [release]: https://github.com/openpredictionmarkets/socialpredict/releases/latest
-[clones-14d-img]: https://img.shields.io/badge/14d%20clones-3%2C702-62c3f8
-[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-535-2ea043
+[clones-14d-img]: https://img.shields.io/badge/14d%20clones-15%2C321-62c3f8
+[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-219-2ea043
 [traffic]: https://github.com/openpredictionmarkets/socialpredict/graphs/traffic
 [test-img]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml/badge.svg?branch=main
 [test]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml

--- a/README/METRICS/clones-14d.json
+++ b/README/METRICS/clones-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d clones",
-  "message": "3,702",
+  "message": "15,321",
   "color": "62c3f8"
 }

--- a/README/METRICS/github-traffic-latest.json
+++ b/README/METRICS/github-traffic-latest.json
@@ -1,78 +1,78 @@
 {
-  "updated_at": "2026-07-01T06:22:51Z",
-  "clones_14d": 3702,
-  "unique_cloners_14d": 535,
+  "updated_at": "2026-07-18T04:46:03Z",
+  "clones_14d": 15321,
+  "unique_cloners_14d": 219,
   "source": "GitHub repository traffic API, rolling 14-day window",
   "clones": [
     {
-      "timestamp": "2026-06-17T00:00:00Z",
-      "count": 397,
-      "uniques": 60
+      "timestamp": "2026-07-03T00:00:00Z",
+      "count": 160,
+      "uniques": 40
     },
     {
-      "timestamp": "2026-06-18T00:00:00Z",
-      "count": 163,
-      "uniques": 35
-    },
-    {
-      "timestamp": "2026-06-19T00:00:00Z",
-      "count": 503,
-      "uniques": 62
-    },
-    {
-      "timestamp": "2026-06-20T00:00:00Z",
-      "count": 930,
-      "uniques": 103
-    },
-    {
-      "timestamp": "2026-06-21T00:00:00Z",
-      "count": 479,
-      "uniques": 76
-    },
-    {
-      "timestamp": "2026-06-22T00:00:00Z",
-      "count": 167,
-      "uniques": 73
-    },
-    {
-      "timestamp": "2026-06-23T00:00:00Z",
-      "count": 111,
-      "uniques": 44
-    },
-    {
-      "timestamp": "2026-06-24T00:00:00Z",
-      "count": 335,
-      "uniques": 54
-    },
-    {
-      "timestamp": "2026-06-25T00:00:00Z",
-      "count": 233,
-      "uniques": 24
-    },
-    {
-      "timestamp": "2026-06-26T00:00:00Z",
-      "count": 163,
+      "timestamp": "2026-07-04T00:00:00Z",
+      "count": 132,
       "uniques": 30
     },
     {
-      "timestamp": "2026-06-27T00:00:00Z",
-      "count": 125,
+      "timestamp": "2026-07-05T00:00:00Z",
+      "count": 51,
       "uniques": 19
     },
     {
-      "timestamp": "2026-06-28T00:00:00Z",
-      "count": 41,
+      "timestamp": "2026-07-06T00:00:00Z",
+      "count": 38,
       "uniques": 22
     },
     {
-      "timestamp": "2026-06-29T00:00:00Z",
-      "count": 40,
-      "uniques": 23
+      "timestamp": "2026-07-07T00:00:00Z",
+      "count": 12,
+      "uniques": 6
     },
     {
-      "timestamp": "2026-06-30T00:00:00Z",
-      "count": 15,
-      "uniques": 8
+      "timestamp": "2026-07-08T00:00:00Z",
+      "count": 611,
+      "uniques": 37
+    },
+    {
+      "timestamp": "2026-07-09T00:00:00Z",
+      "count": 1653,
+      "uniques": 52
+    },
+    {
+      "timestamp": "2026-07-10T00:00:00Z",
+      "count": 1815,
+      "uniques": 16
+    },
+    {
+      "timestamp": "2026-07-11T00:00:00Z",
+      "count": 1703,
+      "uniques": 7
+    },
+    {
+      "timestamp": "2026-07-12T00:00:00Z",
+      "count": 1771,
+      "uniques": 11
+    },
+    {
+      "timestamp": "2026-07-13T00:00:00Z",
+      "count": 1780,
+      "uniques": 15
+    },
+    {
+      "timestamp": "2026-07-14T00:00:00Z",
+      "count": 1813,
+      "uniques": 13
+    },
+    {
+      "timestamp": "2026-07-15T00:00:00Z",
+      "count": 1806,
+      "uniques": 12
+    },
+    {
+      "timestamp": "2026-07-16T00:00:00Z",
+      "count": 1976,
+      "uniques": 24
     }
   ]
 }

--- a/README/METRICS/unique-cloners-14d.json
+++ b/README/METRICS/unique-cloners-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d cloners",
-  "message": "535",
+  "message": "219",
   "color": "2ea043"
 }


### PR DESCRIPTION
Updates the repository traffic badge metrics from GitHub's rolling 14-day traffic API.

This PR is created automatically by the Repository Traffic Badges workflow.
