### PR TITLE
fix: prevent sell share overcashout

### DIFF
--- a/backend/internal/domain/bets/bet_sell.go
+++ b/backend/internal/domain/bets/bet_sell.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sort"
 
+	"socialpredict/internal/domain/boundary"
 	dmarkets "socialpredict/internal/domain/markets"
 )
 
@@ -56,6 +57,12 @@ func (s *Service) QuoteSell(ctx context.Context, req SellRequest) (*SellQuoteRes
 	if err := validateDustCap(sale.Dust, s.config.MaxDustPerSale); err != nil {
 		allowed = false
 	}
+	if allowed {
+		bet := req.NewSaleBet(outcome, sale.SharesToSell, s.clock.Now())
+		if err := validateProjectedSale(ctx, s.markets, req, outcome, position, sale, *bet); err != nil {
+			return nil, err
+		}
+	}
 
 	suggested := suggestSaleAmounts(sale, sharesOwned, s.config.MaxDustPerSale)
 	return new(SellQuoteResult).Build(req, outcome, sale, s.config.MaxDustPerSale, allowed, suggested, s.clock.Now()), nil
@@ -83,6 +90,9 @@ func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcom
 
 		now := s.clock.Now()
 		bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
+		if err := validateProjectedSale(txCtx, markets, req, outcome, position, sale, *bet); err != nil {
+			return err
+		}
 		if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, netSaleProceeds(sale)); err != nil {
 			return err
 		}
@@ -115,6 +125,68 @@ func loadUserSharesFrom(ctx context.Context, markets PositionReader, req SellReq
 	}
 
 	return sharesOwned, position, nil
+}
+
+func validateProjectedSale(
+	ctx context.Context,
+	markets PositionProjector,
+	req SellRequest,
+	outcome string,
+	current *dmarkets.UserPosition,
+	sale SaleQuote,
+	saleBet boundary.Bet,
+) error {
+	if sale.SharesToSell <= 0 {
+		return ErrInsufficientShares
+	}
+	projected, err := markets.ProjectUserPositionAfterBet(ctx, int64(req.MarketID), req.Username, saleBet)
+	if err != nil {
+		return err
+	}
+	return validateSaleProjection(current, projected, outcome, sale)
+}
+
+func validateSaleProjection(current *dmarkets.UserPosition, projected *dmarkets.UserPosition, outcome string, sale SaleQuote) error {
+	if current == nil {
+		return ErrNoPosition
+	}
+	if projected == nil {
+		projected = &dmarkets.UserPosition{}
+	}
+
+	currentSoldShares, err := sharesForOutcome(current, outcome)
+	if err != nil {
+		return err
+	}
+	projectedSoldShares, err := sharesForOutcome(projected, outcome)
+	if err != nil {
+		return err
+	}
+	if currentSoldShares-projectedSoldShares < sale.SharesToSell {
+		return ErrInsufficientShares
+	}
+
+	currentOppositeShares, err := sharesForOutcome(current, oppositeOutcome(outcome))
+	if err != nil {
+		return err
+	}
+	projectedOppositeShares, err := sharesForOutcome(projected, oppositeOutcome(outcome))
+	if err != nil {
+		return err
+	}
+	if projectedOppositeShares > currentOppositeShares {
+		return ErrInsufficientShares
+	}
+
+	maxProjectedValue := current.Value - sale.SaleValue
+	if maxProjectedValue < 0 {
+		maxProjectedValue = 0
+	}
+	if projected.Value > maxProjectedValue {
+		return ErrInsufficientShares
+	}
+
+	return nil
 }
 
 // SaleQuote summarises how a sale request would be executed.
@@ -190,6 +262,31 @@ func sharesOwnedForOutcome(pos *dmarkets.UserPosition, outcome string) (int64, e
 		return pos.NoSharesOwned, nil
 	default:
 		return 0, ErrInvalidOutcome
+	}
+}
+
+func sharesForOutcome(pos *dmarkets.UserPosition, outcome string) (int64, error) {
+	if pos == nil {
+		return 0, nil
+	}
+	switch outcome {
+	case "YES":
+		return pos.YesSharesOwned, nil
+	case "NO":
+		return pos.NoSharesOwned, nil
+	default:
+		return 0, ErrInvalidOutcome
+	}
+}
+
+func oppositeOutcome(outcome string) string {
+	switch outcome {
+	case "YES":
+		return "NO"
+	case "NO":
+		return "YES"
+	default:
+		return ""
 	}
 }
 

--- a/backend/internal/domain/bets/service.go
+++ b/backend/internal/domain/bets/service.go
@@ -51,10 +51,16 @@ type PositionReader interface {
 	GetUserPositionInMarket(ctx context.Context, marketID int64, username string) (*dmarkets.UserPosition, error)
 }
 
+// PositionProjector exposes transaction-aware position projections for proposed sell rows.
+type PositionProjector interface {
+	ProjectUserPositionAfterBet(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error)
+}
+
 // MarketService exposes the subset of market operations required by bets.
 type MarketService interface {
 	MarketReader
 	PositionReader
+	PositionProjector
 }
 
 // MarketGate ensures market openness before betting operations.

--- a/backend/internal/domain/bets/service_helpers_test.go
+++ b/backend/internal/domain/bets/service_helpers_test.go
@@ -21,6 +21,7 @@ var errUnexpectedHelperCall = errors.New("unexpected call")
 type stubMarketService struct {
 	marketGetter   stubMarketGetter
 	positionGetter stubPositionGetter
+	projector      stubPositionProjector
 }
 
 func newStubMarketService(opts ...func(*stubMarketService)) stubMarketService {
@@ -32,6 +33,11 @@ func newStubMarketService(opts ...func(*stubMarketService)) stubMarketService {
 		},
 		positionGetter: stubPositionGetter{
 			getUserPositionInMarketFn: func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
+				return nil, errUnexpectedHelperCall
+			},
+		},
+		projector: stubPositionProjector{
+			projectUserPositionAfterBetFn: func(context.Context, int64, string, boundary.Bet) (*dmarkets.UserPosition, error) {
 				return nil, errUnexpectedHelperCall
 			},
 		},
@@ -54,6 +60,12 @@ func withStubPosition(getPosition func(ctx context.Context, marketID int64, user
 	}
 }
 
+func withStubProjection(projectPosition func(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error)) func(*stubMarketService) {
+	return func(stub *stubMarketService) {
+		stub.projector.projectUserPositionAfterBetFn = projectPosition
+	}
+}
+
 type stubMarketGetter struct {
 	getMarketFunc func(ctx context.Context, id int64) (*dmarkets.Market, error)
 }
@@ -66,8 +78,16 @@ type stubPositionGetter struct {
 	getUserPositionInMarketFn func(ctx context.Context, marketID int64, username string) (*dmarkets.UserPosition, error)
 }
 
+type stubPositionProjector struct {
+	projectUserPositionAfterBetFn func(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error)
+}
+
 func (s stubMarketService) GetUserPositionInMarket(ctx context.Context, marketID int64, username string) (*dmarkets.UserPosition, error) {
 	return s.positionGetter.GetUserPositionInMarket(ctx, marketID, username)
+}
+
+func (s stubMarketService) ProjectUserPositionAfterBet(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+	return s.projector.ProjectUserPositionAfterBet(ctx, marketID, username, bet)
 }
 
 func (s stubMarketGetter) GetMarket(ctx context.Context, id int64) (*dmarkets.Market, error) {
@@ -82,6 +102,13 @@ func (s stubPositionGetter) GetUserPositionInMarket(ctx context.Context, marketI
 		return nil, errUnexpectedHelperCall
 	}
 	return s.getUserPositionInMarketFn(ctx, marketID, username)
+}
+
+func (s stubPositionProjector) ProjectUserPositionAfterBet(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+	if s.projectUserPositionAfterBetFn == nil {
+		return nil, errUnexpectedHelperCall
+	}
+	return s.projectUserPositionAfterBetFn(ctx, marketID, username, bet)
 }
 
 type gateClock struct {

--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -116,6 +116,7 @@ func (f fakeBetHistoryReader) UserHasBet(ctx context.Context, marketID uint, use
 type fakeMarkets struct {
 	reader    fakeMarketReader
 	positions fakePositionReader
+	projector fakePositionProjector
 }
 
 func newFakeMarkets(opts ...func(*fakeMarkets)) *fakeMarkets {
@@ -127,6 +128,11 @@ func newFakeMarkets(opts ...func(*fakeMarkets)) *fakeMarkets {
 		},
 		positions: fakePositionReader{
 			getUserPositionInMarketFunc: func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
+				return nil, errUnexpectedServiceCall
+			},
+		},
+		projector: fakePositionProjector{
+			projectUserPositionAfterBetFunc: func(context.Context, int64, string, boundary.Bet) (*dmarkets.UserPosition, error) {
 				return nil, errUnexpectedServiceCall
 			},
 		},
@@ -149,6 +155,12 @@ func withFakePosition(fn func(ctx context.Context, marketID int64, username stri
 	}
 }
 
+func withFakePositionProjection(fn func(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error)) func(*fakeMarkets) {
+	return func(markets *fakeMarkets) {
+		markets.projector.projectUserPositionAfterBetFunc = fn
+	}
+}
+
 type fakeMarketReader struct {
 	getMarketFunc func(ctx context.Context, id int64) (*dmarkets.Market, error)
 }
@@ -165,6 +177,14 @@ func (f *fakeMarkets) GetUserPositionInMarket(ctx context.Context, marketID int6
 	return f.positions.GetUserPositionInMarket(ctx, marketID, username)
 }
 
+type fakePositionProjector struct {
+	projectUserPositionAfterBetFunc func(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error)
+}
+
+func (f *fakeMarkets) ProjectUserPositionAfterBet(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+	return f.projector.ProjectUserPositionAfterBet(ctx, marketID, username, bet)
+}
+
 func (f fakeMarketReader) GetMarket(ctx context.Context, id int64) (*dmarkets.Market, error) {
 	if f.getMarketFunc == nil {
 		return nil, errUnexpectedServiceCall
@@ -177,6 +197,13 @@ func (f fakePositionReader) GetUserPositionInMarket(ctx context.Context, marketI
 		return nil, errUnexpectedServiceCall
 	}
 	return f.getUserPositionInMarketFunc(ctx, marketID, username)
+}
+
+func (f fakePositionProjector) ProjectUserPositionAfterBet(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+	if f.projectUserPositionAfterBetFunc == nil {
+		return nil, errUnexpectedServiceCall
+	}
+	return f.projectUserPositionAfterBetFunc(ctx, marketID, username, bet)
 }
 
 type applyCall struct {
@@ -283,9 +310,12 @@ type serviceFixtureOption func(*serviceFixture)
 
 func withFixtureMarket(market *dmarkets.Market) serviceFixtureOption {
 	return func(f *serviceFixture) {
-		f.markets = newFakeMarkets(withFakeMarket(func(context.Context, int64) (*dmarkets.Market, error) {
+		if f.markets == nil {
+			f.markets = newFakeMarkets()
+		}
+		f.markets.reader.getMarketFunc = func(context.Context, int64) (*dmarkets.Market, error) {
 			return market, nil
-		}))
+		}
 	}
 }
 
@@ -294,14 +324,61 @@ func withFixturePosition(position *dmarkets.UserPosition) serviceFixtureOption {
 		if f.markets == nil {
 			f.markets = newFakeMarkets()
 		}
-		current := f.markets.reader.getMarketFunc
-		f.markets = newFakeMarkets(
-			withFakeMarket(current),
-			withFakePosition(func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
-				return position, nil
-			}),
-		)
+		f.markets.positions.getUserPositionInMarketFunc = func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
+			return position, nil
+		}
+		f.markets.projector.projectUserPositionAfterBetFunc = func(_ context.Context, _ int64, _ string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+			return projectedFixturePosition(position, bet), nil
+		}
 	}
+}
+
+func withFixtureProjection(projected *dmarkets.UserPosition) serviceFixtureOption {
+	return func(f *serviceFixture) {
+		if f.markets == nil {
+			f.markets = newFakeMarkets()
+		}
+		f.markets.projector.projectUserPositionAfterBetFunc = func(context.Context, int64, string, boundary.Bet) (*dmarkets.UserPosition, error) {
+			return projected, nil
+		}
+	}
+}
+
+func projectedFixturePosition(position *dmarkets.UserPosition, bet boundary.Bet) *dmarkets.UserPosition {
+	if position == nil {
+		return nil
+	}
+	projected := *position
+	if bet.Amount >= 0 {
+		return &projected
+	}
+
+	sharesSold := -bet.Amount
+	switch bet.Outcome {
+	case "YES":
+		projected.YesSharesOwned -= sharesSold
+		if projected.YesSharesOwned < 0 {
+			projected.YesSharesOwned = 0
+		}
+		projected.Value -= sharesSold * fixtureValuePerShare(position.Value, position.YesSharesOwned)
+	case "NO":
+		projected.NoSharesOwned -= sharesSold
+		if projected.NoSharesOwned < 0 {
+			projected.NoSharesOwned = 0
+		}
+		projected.Value -= sharesSold * fixtureValuePerShare(position.Value, position.NoSharesOwned)
+	}
+	if projected.Value < 0 {
+		projected.Value = 0
+	}
+	return &projected
+}
+
+func fixtureValuePerShare(value, shares int64) int64 {
+	if value <= 0 || shares <= 0 {
+		return 0
+	}
+	return value / shares
 }
 
 func withFixtureUser(user *dusers.User) serviceFixtureOption {
@@ -509,6 +586,54 @@ func TestServiceSell_DustAtCapCreditsNetProceeds(t *testing.T) {
 	}
 }
 
+func TestServiceSell_FullPositionSellRequiresZeroProjectedValue(t *testing.T) {
+	now := serviceTestTime()
+
+	t.Run("full position sell succeeds at zero projected value", func(t *testing.T) {
+		fixture, svc := newServiceFixture(
+			now,
+			withFixtureMaxDust(0),
+			withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+			withFixturePosition(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 10, Value: 100}),
+			withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 0, Value: 0}),
+			withFixtureUser(&dusers.User{Username: "alice"}),
+		)
+
+		result, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 100, Outcome: "YES"})
+		if err != nil {
+			t.Fatalf("Sell returned error: %v", err)
+		}
+		if result.SharesSold != 10 || result.SaleValue != 100 || result.NetProceeds != 100 {
+			t.Fatalf("unexpected full-position sell result: %+v", result)
+		}
+		if fixture.repo.created == nil || fixture.repo.created.Amount != -10 {
+			t.Fatalf("unexpected sale ledger row: %+v", fixture.repo.created)
+		}
+		if len(fixture.users.calls) != 1 || fixture.users.calls[0].amount != 100 {
+			t.Fatalf("unexpected user credit: %+v", fixture.users.calls)
+		}
+	})
+
+	t.Run("full position sell rejects residual projected value", func(t *testing.T) {
+		fixture, svc := newServiceFixture(
+			now,
+			withFixtureMaxDust(0),
+			withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+			withFixturePosition(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 10, Value: 100}),
+			withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 0, Value: 1}),
+			withFixtureUser(&dusers.User{Username: "alice"}),
+		)
+
+		_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 100, Outcome: "YES"})
+		if !errors.Is(err, bets.ErrInsufficientShares) {
+			t.Fatalf("expected residual projected value to return ErrInsufficientShares, got %v", err)
+		}
+		if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
+			t.Fatalf("residual projected value must not mutate ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
+		}
+	})
+}
+
 func TestServiceSell_NoPosition(t *testing.T) {
 	now := serviceTestTime()
 	_, svc := newServiceFixture(
@@ -605,6 +730,193 @@ func TestServiceQuoteSell_OverCapRoundsPreviewToCap(t *testing.T) {
 	}
 	if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
 		t.Fatalf("quote should not mutate repo or user ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
+	}
+}
+
+func TestServiceQuoteSell_RejectsUnsafeProjectedSale(t *testing.T) {
+	now := serviceTestTime()
+	_, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(1),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 2, Value: 502}),
+		withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, NoSharesOwned: 2, Value: 500}),
+		withFixtureUser(&dusers.User{Username: "alice"}),
+	)
+
+	_, err := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 502, Outcome: "YES"})
+	if !errors.Is(err, bets.ErrInsufficientShares) {
+		t.Fatalf("expected unsafe projected quote to return ErrInsufficientShares, got %v", err)
+	}
+}
+
+func TestServiceSell_RejectsUnsafeProjectedSaleBeforeMutatingLedger(t *testing.T) {
+	now := serviceTestTime()
+	current := &dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 2, Value: 502}
+	fixture, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(1),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(current),
+		withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 0, NoSharesOwned: 2, Value: 500}),
+		withFixtureUser(&dusers.User{Username: "alice"}),
+	)
+
+	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 502, Outcome: "YES"})
+	if !errors.Is(err, bets.ErrInsufficientShares) {
+		t.Fatalf("expected unsafe projected sale to return ErrInsufficientShares, got %v", err)
+	}
+	if fixture.repo.created != nil {
+		t.Fatalf("unsafe sale must not create a ledger row: %+v", fixture.repo.created)
+	}
+	if len(fixture.users.calls) != 0 {
+		t.Fatalf("unsafe sale must not credit user ledger: %+v", fixture.users.calls)
+	}
+}
+
+func TestServiceSell_RejectsProjectedSaleThatKeepsTooMuchValue(t *testing.T) {
+	now := serviceTestTime()
+	fixture, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(0),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 10, Value: 100}),
+		withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 7, Value: 80}),
+		withFixtureUser(&dusers.User{Username: "alice"}),
+	)
+
+	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 30, Outcome: "YES"})
+	if !errors.Is(err, bets.ErrInsufficientShares) {
+		t.Fatalf("expected inflated projected value to return ErrInsufficientShares, got %v", err)
+	}
+	if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
+		t.Fatalf("inflated projection must not mutate ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
+	}
+}
+
+func TestServiceSell_AttachmentSequenceRejectsOvercashoutBeforeTinyTail(t *testing.T) {
+	now := serviceTestTime()
+	var history []boundary.Bet
+	nextNow := now
+	clock := fixedClock{nowFunc: func() time.Time {
+		nextNow = nextNow.Add(time.Second)
+		return nextNow
+	}}
+	market := &dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}
+	snapshot := positionsmath.MarketSnapshot{ID: market.ID, CreatedAt: now}
+
+	projectPosition := func(extra *boundary.Bet) (*dmarkets.UserPosition, error) {
+		projectedHistory := append([]boundary.Bet(nil), history...)
+		if extra != nil {
+			projectedHistory = append(projectedHistory, *extra)
+		}
+		position, err := positionsmath.CalculateMarketPositionForUser_WPAM_DBPM(snapshot, projectedHistory, "alice")
+		if err != nil {
+			return nil, err
+		}
+		return &dmarkets.UserPosition{
+			Username:         "alice",
+			MarketID:         market.ID,
+			YesSharesOwned:   position.YesSharesOwned,
+			NoSharesOwned:    position.NoSharesOwned,
+			Value:            position.Value,
+			TotalSpent:       position.TotalSpent,
+			TotalSpentInPlay: position.TotalSpentInPlay,
+			IsResolved:       position.IsResolved,
+			ResolutionResult: position.ResolutionResult,
+		}, nil
+	}
+
+	repo := newFakeRepo(
+		withFakeRepoCreate(func(_ context.Context, bet *boundary.Bet) error {
+			copied := *bet
+			history = append(history, copied)
+			return nil
+		}),
+		withFakeRepoHasBet(func(_ context.Context, marketID uint, username string) (bool, error) {
+			for _, bet := range history {
+				if bet.MarketID == marketID && bet.Username == username {
+					return true, nil
+				}
+			}
+			return false, nil
+		}),
+	)
+	markets := newFakeMarkets(
+		withFakeMarket(func(context.Context, int64) (*dmarkets.Market, error) { return market, nil }),
+		withFakePosition(func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
+			return projectPosition(nil)
+		}),
+		withFakePositionProjection(func(_ context.Context, _ int64, _ string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+			return projectPosition(&bet)
+		}),
+	)
+	users := newFakeUsers(
+		withFakeUserLookup(func(context.Context, string) (*dusers.User, error) {
+			return &dusers.User{Username: "alice", AccountBalance: 10000}, nil
+		}),
+		withFakeApplyTransaction(func(context.Context, string, int64, string) error { return nil }),
+	)
+	svc := bets.NewService(
+		repo,
+		markets,
+		users,
+		bets.Config{MaxDustPerSale: 1, MaximumDebtAllowed: 10000},
+		clock,
+		bets.WithPlaceUnitOfWork(fakePlaceUnit{repo: repo, users: users}),
+		bets.WithSellUnitOfWork(fakeSellUnit{repo: repo, markets: markets, users: users}),
+	)
+
+	steps := []struct {
+		seq     int
+		kind    string
+		outcome string
+		amount  int64
+	}{
+		{seq: 1, kind: "buy", outcome: "NO", amount: 50},
+		{seq: 2, kind: "buy", outcome: "YES", amount: 100},
+		{seq: 3, kind: "buy", outcome: "YES", amount: 50},
+		{seq: 4, kind: "sell", outcome: "YES", amount: 200},
+		{seq: 5, kind: "buy", outcome: "YES", amount: 100},
+		{seq: 6, kind: "buy", outcome: "NO", amount: 10},
+		{seq: 7, kind: "buy", outcome: "NO", amount: 40},
+		{seq: 8, kind: "buy", outcome: "YES", amount: 100},
+		{seq: 9, kind: "buy", outcome: "NO", amount: 50},
+		{seq: 10, kind: "sell", outcome: "YES", amount: 400},
+		{seq: 11, kind: "buy", outcome: "NO", amount: 200},
+		{seq: 12, kind: "buy", outcome: "YES", amount: 100},
+		{seq: 13, kind: "sell", outcome: "NO", amount: 600},
+		{seq: 14, kind: "buy", outcome: "NO", amount: 10},
+		{seq: 15, kind: "buy", outcome: "NO", amount: 10},
+		{seq: 16, kind: "sell", outcome: "NO", amount: 520},
+		{seq: 17, kind: "buy", outcome: "NO", amount: 10},
+		{seq: 18, kind: "buy", outcome: "NO", amount: 10},
+	}
+	for _, step := range steps {
+		switch step.kind {
+		case "buy":
+			if _, err := svc.Place(context.Background(), bets.PlaceRequest{Username: "alice", MarketID: 1, Amount: step.amount, Outcome: step.outcome}); err != nil {
+				t.Fatalf("setup buy seq %d failed: %v", step.seq, err)
+			}
+		case "sell":
+			if _, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: step.amount, Outcome: step.outcome}); err != nil {
+				t.Fatalf("setup sell seq %d failed: %v", step.seq, err)
+			}
+		}
+	}
+
+	beforeRows := len(history)
+	_, quoteErr := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 507, Outcome: "NO"})
+	if !errors.Is(quoteErr, bets.ErrInsufficientShares) {
+		t.Fatalf("expected quote for attachment seq 19 over-cashout to return ErrInsufficientShares, got %v", quoteErr)
+	}
+
+	_, sellErr := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 507, Outcome: "NO"})
+	if !errors.Is(sellErr, bets.ErrInsufficientShares) {
+		t.Fatalf("expected sell for attachment seq 19 over-cashout to return ErrInsufficientShares, got %v", sellErr)
+	}
+	if len(history) != beforeRows {
+		t.Fatalf("rejected over-cashout must not append a sale row: before=%d after=%d", beforeRows, len(history))
 	}
 }
 

--- a/backend/internal/domain/markets/market_positions.go
+++ b/backend/internal/domain/markets/market_positions.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"sort"
 	"strings"
+
+	"socialpredict/internal/domain/boundary"
+	positionsmath "socialpredict/internal/domain/math/positions"
 )
 
 // GetMarketPositions returns all user positions in a market.
@@ -67,6 +70,66 @@ func (s *Service) GetUserPositionInMarket(ctx context.Context, marketID int64, u
 		return nil, err
 	}
 	return position, nil
+}
+
+// ProjectUserPositionAfterBet returns the user's projected position after appending
+// a proposed bet to the market history without mutating stored state.
+func (s *Service) ProjectUserPositionAfterBet(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*UserPosition, error) {
+	if marketID <= 0 {
+		return nil, ErrInvalidInput
+	}
+	if strings.TrimSpace(username) == "" {
+		return nil, ErrInvalidInput
+	}
+
+	market, err := s.repo.GetByID(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+	if market == nil {
+		return nil, ErrMarketNotFound
+	}
+
+	bets, err := s.repo.ListBetsForMarket(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+	boundaryBets := ToBoundaryBets(bets)
+	projectedBet := bet
+	projectedBet.MarketID = uint(marketID)
+	if strings.TrimSpace(projectedBet.Username) == "" {
+		projectedBet.Username = username
+	}
+	boundaryBets = append(boundaryBets, projectedBet)
+
+	position, err := positionsmath.CalculateMarketPositionForUser_WPAM_DBPM(
+		positionsmath.MarketSnapshot{
+			ID:               market.ID,
+			CreatedAt:        market.CreatedAt,
+			IsResolved:       market.IsResolved(),
+			ResolutionResult: market.ResolutionResult,
+		},
+		boundaryBets,
+		username,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return userPositionFromMathPosition(marketID, username, position), nil
+}
+
+func userPositionFromMathPosition(marketID int64, username string, position positionsmath.UserMarketPosition) *UserPosition {
+	return &UserPosition{
+		Username:         username,
+		MarketID:         marketID,
+		YesSharesOwned:   position.YesSharesOwned,
+		NoSharesOwned:    position.NoSharesOwned,
+		Value:            position.Value,
+		TotalSpent:       position.TotalSpent,
+		TotalSpentInPlay: position.TotalSpentInPlay,
+		IsResolved:       position.IsResolved,
+		ResolutionResult: position.ResolutionResult,
+	}
 }
 
 func activeMarketPositions(positions MarketPositions) MarketPositions {

--- a/backend/internal/repository/bets/sell_transaction.go
+++ b/backend/internal/repository/bets/sell_transaction.go
@@ -71,6 +71,37 @@ func (r sellMarketRepository) GetUserPositionInMarket(ctx context.Context, marke
 	}, nil
 }
 
+func (r sellMarketRepository) ProjectUserPositionAfterBet(ctx context.Context, marketID int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+	snapshot, bets, err := r.loadMarketData(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+
+	projectedBet := bet
+	projectedBet.MarketID = uint(marketID)
+	if projectedBet.Username == "" {
+		projectedBet.Username = username
+	}
+	bets = append(bets, projectedBet)
+
+	position, err := positionsmath.CalculateMarketPositionForUser_WPAM_DBPM(snapshot, bets, username)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dmarkets.UserPosition{
+		Username:         username,
+		MarketID:         marketID,
+		YesSharesOwned:   position.YesSharesOwned,
+		NoSharesOwned:    position.NoSharesOwned,
+		Value:            position.Value,
+		TotalSpent:       position.TotalSpent,
+		TotalSpentInPlay: position.TotalSpentInPlay,
+		IsResolved:       position.IsResolved,
+		ResolutionResult: position.ResolutionResult,
+	}, nil
+}
+
 func (r sellMarketRepository) loadMarketData(ctx context.Context, marketID int64) (positionsmath.MarketSnapshot, []boundary.Bet, error) {
 	var market models.Market
 	marketQuery := r.db.WithContext(ctx)

--- a/backend/internal/repository/bets/sell_transaction_test.go
+++ b/backend/internal/repository/bets/sell_transaction_test.go
@@ -60,6 +60,47 @@ func TestGormRepositorySellBetTransactionRollsBackCreditWhenSaleBetCreateFails(t
 	assertBetCount(t, db, "seller", 201, 1)
 }
 
+func TestGormRepositorySellBetTransactionProjectsSaleInsideTransaction(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	sqlDB, _ := db.DB()
+	if sqlDB != nil {
+		t.Cleanup(func() { _ = sqlDB.Close() })
+	}
+
+	seedSellRows(t, db, "creator", "seller", 1000, 202)
+
+	repo := NewGormRepository(db)
+	err := repo.SellBetTransaction(context.Background(), func(ctx context.Context, _ dbets.Repository, markets dbets.MarketService, _ dbets.UserService) error {
+		current, err := markets.GetUserPositionInMarket(ctx, 202, "seller")
+		if err != nil {
+			return err
+		}
+		projected, err := markets.ProjectUserPositionAfterBet(ctx, 202, "seller", boundary.Bet{
+			Username: "seller",
+			MarketID: 202,
+			Amount:   -2,
+			Outcome:  "YES",
+			PlacedAt: time.Date(2026, time.May, 11, 22, 30, 0, 0, time.UTC),
+		})
+		if err != nil {
+			return err
+		}
+		if projected.YesSharesOwned >= current.YesSharesOwned {
+			t.Fatalf("projected YES shares must decrease after sale: current=%+v projected=%+v", current, projected)
+		}
+		if projected.NoSharesOwned > current.NoSharesOwned {
+			t.Fatalf("projected sale must not create opposite-side shares: current=%+v projected=%+v", current, projected)
+		}
+		if projected.Value > current.Value {
+			t.Fatalf("projected sale must not increase value: current=%+v projected=%+v", current, projected)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("transaction projection returned error: %v", err)
+	}
+}
+
 func seedSellRows(t *testing.T, db *gorm.DB, creatorUsername string, sellerUsername string, sellerBalance int64, marketID int64) {
 	t.Helper()
 

--- a/integrationtest/README.md
+++ b/integrationtest/README.md
@@ -16,9 +16,11 @@ from `loadtest/`, which is for capacity and performance testing.
 ## Current Coverage
 
 - `cases/multiple-choice-binary-markets.md`
+- `cases/sell-shares-overcashout.md`
 - `reports/multiple-choice-binary-markets-2026-06-15.md`
 - `reports/schemathesis-read-2026-06-16.md`
 - `scripts/multiple-choice-binary-api.mjs`
+- `scripts/sell-shares-overcashout.mjs`
 - `scripts/schemathesis-read.sh`
 - `scripts/schemathesis-grouped-market.mjs`
 
@@ -31,6 +33,7 @@ Last updated: 2026-06-17.
 | Suite | Command | Current result |
 |-------|---------|----------------|
 | Multiple-choice binary API scenario runner | `node integrationtest/scripts/multiple-choice-binary-api.mjs --base-url http://localhost:8080 --api-prefix /v0` | 17/17 checks passing |
+| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers valid quote/sell, dust accounting, and rejected over-cashout |
 | Read-only Schemathesis contract smoke | `MAX_EXAMPLES=1 integrationtest/scripts/schemathesis-read.sh` | 4/4 operations passing |
 | Grouped-market Schemathesis contract runner | `node integrationtest/scripts/schemathesis-grouped-market.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers grouped read schemas with a real group ID |
 | Backend tests | `JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...` | Passing |
@@ -42,6 +45,14 @@ Run against a local dev stack after `./SocialPredict dev-bootstrap-users`:
 
 ```bash
 node integrationtest/scripts/multiple-choice-binary-api.mjs \
+  --base-url http://localhost:8080 \
+  --api-prefix /v0
+```
+
+Run the sell-shares over-cashout regression:
+
+```bash
+node integrationtest/scripts/sell-shares-overcashout.mjs \
   --base-url http://localhost:8080 \
   --api-prefix /v0
 ```

--- a/integrationtest/cases/sell-shares-overcashout.md
+++ b/integrationtest/cases/sell-shares-overcashout.md
@@ -1,0 +1,54 @@
+# Sell Shares Over-Cashout Regression
+
+## Purpose
+
+Verify that selling shares cannot repeatedly cash out more value than the user's
+remaining market position supports.
+
+This scenario covers both sell quote and settlement behavior:
+
+- `/v0/sell/quote` must reject unsafe projected sales before returning an
+  allowed quote.
+- `/v0/sell` must reject the same unsafe sale through the existing
+  insufficient-shares API contract.
+- Rejected sells must not credit the user, append a sell row, increase position
+  value, or increase market dust/volume.
+
+## Setup
+
+Run against a local dev stack after seeded users exist:
+
+```bash
+./SocialPredict dev-bootstrap-users
+node integrationtest/scripts/sell-shares-overcashout.mjs \
+  --base-url http://localhost:8080 \
+  --api-prefix /v0
+```
+
+Defaults assume seeded users `admin`, `testuser01`, and `testuser02` all use
+password `password`.
+
+## Scenario
+
+The runner creates fresh binary markets through `/v0/markets` and approves them
+through the admin route when market governance creates proposals.
+
+Happy path:
+
+- Replays the opening trades from the reported sequence.
+- Quotes and sells the valid seq 4 YES sale.
+- Replays additional buys and quotes/sells the valid seq 10 dust-generating YES
+  sale.
+- Asserts `sharesSold`, `saleValue`, `dust`, `netProceeds`, user balance,
+  projected position value, and market detail dust/volume fields.
+
+Sad path:
+
+- Replays the reported sequence through seq 18.
+- Attempts the seq 19 NO sale that would previously set up the alternating
+  tiny-share large-cashout tail.
+- Asserts both quote and sell return the existing `INSUFFICIENT_SHARES` failure
+  reason and that user balance, position, market dust, and market volume remain
+  unchanged.
+
+The input is based on `.context/attachments/pPjgi8/sell_market.json`.

--- a/integrationtest/scripts/sell-shares-overcashout.mjs
+++ b/integrationtest/scripts/sell-shares-overcashout.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const args = parseArgs(process.argv.slice(2));
+const baseUrl = args['base-url'] || 'http://localhost:8080';
+const apiPrefix = args['api-prefix'] || '/v0';
+const password = args.password || 'password';
+const moderator = args.moderator || 'testuser01';
+const bettor = args.bettor || 'testuser02';
+const admin = args.admin || 'admin';
+const artifact = args.artifact || 'integrationtest/artifacts/sell-shares-overcashout-latest.json';
+const keepGoing = Boolean(args['keep-going']);
+const delayMs = Number(args.delay || 150);
+const results = [];
+const marketIds = [];
+let rejectedSeq = 0;
+
+const attachmentSetupThroughSeq18 = [
+  { seq: 1, type: 'buy', outcome: 'NO', amount: 50 },
+  { seq: 2, type: 'buy', outcome: 'YES', amount: 100 },
+  { seq: 3, type: 'buy', outcome: 'YES', amount: 50 },
+  { seq: 4, type: 'sell', outcome: 'YES', amount: 200 },
+  { seq: 5, type: 'buy', outcome: 'YES', amount: 100 },
+  { seq: 6, type: 'buy', outcome: 'NO', amount: 10 },
+  { seq: 7, type: 'buy', outcome: 'NO', amount: 40 },
+  { seq: 8, type: 'buy', outcome: 'YES', amount: 100 },
+  { seq: 9, type: 'buy', outcome: 'NO', amount: 50 },
+  { seq: 10, type: 'sell', outcome: 'YES', amount: 400 },
+  { seq: 11, type: 'buy', outcome: 'NO', amount: 200 },
+  { seq: 12, type: 'buy', outcome: 'YES', amount: 100 },
+  { seq: 13, type: 'sell', outcome: 'NO', amount: 600 },
+  { seq: 14, type: 'buy', outcome: 'NO', amount: 10 },
+  { seq: 15, type: 'buy', outcome: 'NO', amount: 10 },
+  { seq: 16, type: 'sell', outcome: 'NO', amount: 520 },
+  { seq: 17, type: 'buy', outcome: 'NO', amount: 10 },
+  { seq: 18, type: 'buy', outcome: 'NO', amount: 10 },
+];
+
+const attachmentOvercashoutAttempt = { seq: 19, type: 'sell', outcome: 'NO', amount: 507 };
+
+function parseArgs(items) {
+  const out = {};
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+    if (!item.startsWith('--')) continue;
+    const key = item.slice(2);
+    if (items[i + 1] && !items[i + 1].startsWith('--')) out[key] = items[++i];
+    else out[key] = true;
+  }
+  return out;
+}
+
+function unwrap(data) {
+  return data?.ok === true && Object.hasOwn(data, 'result') ? data.result : data;
+}
+
+function apiUrl(path) {
+  return `${baseUrl.replace(/\/$/, '')}${apiPrefix.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+}
+
+async function wait(ms) {
+  if (ms > 0) await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function apiRaw(method, path, { body, token, expect = [200], retries = 4 } = {}) {
+  const url = apiUrl(path);
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Accept: 'application/json',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+    if (expect.includes(response.status)) {
+      return { status: response.status, data, result: unwrap(data), text };
+    }
+    if (response.status === 429 && attempt < retries) {
+      await wait(1200 * (attempt + 1));
+      continue;
+    }
+    throw new Error(`${method} ${url} -> ${response.status}: ${text.slice(0, 500)}`);
+  }
+  throw new Error(`${method} ${url} did not complete`);
+}
+
+async function api(method, path, options) {
+  return (await apiRaw(method, path, options)).result;
+}
+
+function check(name, ok, detail = '') {
+  results.push({ name, ok: Boolean(ok), detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ` - ${detail}` : ''}`);
+  if (!ok && !keepGoing) throw new Error(name);
+}
+
+function sameInt(name, got, want) {
+  check(name, Number(got) === Number(want), `got=${got}, want=${want}`);
+}
+
+function reason(raw) {
+  return raw?.data?.reason || raw?.result?.reason || raw?.data?.code || '';
+}
+
+function numberField(row, camelName, exportedName) {
+  return Number(row?.[camelName] ?? row?.[exportedName] ?? 0);
+}
+
+function shares(position, outcome) {
+  return outcome === 'YES'
+    ? numberField(position, 'yesSharesOwned', 'YesSharesOwned')
+    : numberField(position, 'noSharesOwned', 'NoSharesOwned');
+}
+
+function positionValue(position) {
+  return numberField(position, 'value', 'Value');
+}
+
+function opposite(outcome) {
+  return outcome === 'YES' ? 'NO' : 'YES';
+}
+
+async function login(username) {
+  return (await api('POST', '/login', { body: { username, password } })).token;
+}
+
+async function createMarket(label, moderatorToken, adminToken) {
+  const stamp = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+  const closeAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  const created = await api('POST', '/markets', {
+    token: moderatorToken,
+    expect: [201],
+    body: {
+      questionTitle: `Sell overcashout ${label} ${stamp}`,
+      description: 'sell shares over-cashout integration scenario',
+      outcomeType: 'BINARY',
+      resolutionDateTime: closeAt,
+      yesLabel: 'YES',
+      noLabel: 'NO',
+    },
+  });
+  const marketId = Number(created.id);
+  check(`${label} market created`, marketId > 0, `marketId=${marketId}`);
+  marketIds.push(marketId);
+
+  if (created.lifecycleStatus === 'proposed' || created.status === 'proposed') {
+    await api('PATCH', `/admin/markets/${marketId}/approve`, {
+      token: adminToken,
+      body: { confirm: true },
+    });
+    check(`${label} market approved`, true);
+  }
+  return marketId;
+}
+
+async function place(token, marketId, outcome, amount) {
+  const result = await api('POST', '/bet', {
+    token,
+    expect: [201],
+    body: { marketId, outcome, amount },
+  });
+  await wait(delayMs);
+  return result;
+}
+
+async function quoteRaw(token, marketId, outcome, amount, expect = [200]) {
+  return apiRaw('POST', '/sell/quote', {
+    token,
+    expect,
+    body: { marketId, outcome, amount },
+  });
+}
+
+async function sellRaw(token, marketId, outcome, amount, expect = [201]) {
+  const result = await apiRaw('POST', '/sell', {
+    token,
+    expect,
+    body: { marketId, outcome, amount },
+  });
+  await wait(delayMs);
+  return result;
+}
+
+async function position(token, marketId) {
+  return api('GET', `/userposition/${marketId}`, { token });
+}
+
+async function details(marketId) {
+  return api('GET', `/markets/${marketId}`);
+}
+
+async function financial(username) {
+  const response = await api('GET', `/users/${username}/financial`);
+  return response.financial || {};
+}
+
+function assertSaleFields(prefix, sale, expected) {
+  sameInt(`${prefix} sharesSold`, sale.sharesSold, expected.sharesSold);
+  sameInt(`${prefix} saleValue`, sale.saleValue, expected.saleValue);
+  sameInt(`${prefix} dust`, sale.dust, expected.dust);
+  sameInt(`${prefix} netProceeds`, sale.netProceeds, expected.netProceeds);
+}
+
+async function assertQuoteAndSell({ prefix, token, marketId, outcome, amount, expected, requireDust = false }) {
+  const beforePosition = await position(token, marketId);
+  const beforeFinancial = await financial(bettor);
+  const beforeDetails = await details(marketId);
+
+  const quote = (await quoteRaw(token, marketId, outcome, amount)).result;
+  check(`${prefix} quote allowed`, quote.allowed === true);
+  assertSaleFields(`${prefix} quote`, quote, expected);
+  sameInt(`${prefix} quote net formula`, quote.netProceeds, quote.saleValue - quote.dust);
+  if (requireDust) check(`${prefix} quote has retained dust`, quote.dust > 0, `dust=${quote.dust}`);
+
+  const sell = (await sellRaw(token, marketId, outcome, amount)).result;
+  assertSaleFields(`${prefix} sell`, sell, expected);
+  sameInt(`${prefix} sell matches quote shares`, sell.sharesSold, quote.sharesSold);
+  sameInt(`${prefix} sell matches quote value`, sell.saleValue, quote.saleValue);
+  sameInt(`${prefix} sell credits only net proceeds`, sell.netProceeds, sell.saleValue - sell.dust);
+
+  const afterPosition = await position(token, marketId);
+  const afterFinancial = await financial(bettor);
+  const afterDetails = await details(marketId);
+  const soldDelta = shares(beforePosition, outcome) - shares(afterPosition, outcome);
+  const oppositeDelta = shares(afterPosition, opposite(outcome)) - shares(beforePosition, opposite(outcome));
+  const maxProjectedValue = Math.max(0, positionValue(beforePosition) - sell.saleValue);
+  check(`${prefix} position sold-outcome shares decrease`, soldDelta >= sell.sharesSold, `delta=${soldDelta}, sold=${sell.sharesSold}`);
+  check(`${prefix} position opposite shares do not increase`, oppositeDelta <= 0, `delta=${oppositeDelta}`);
+  check(`${prefix} position value reduced by gross sale value`, positionValue(afterPosition) <= maxProjectedValue, `after=${positionValue(afterPosition)}, max=${maxProjectedValue}`);
+  sameInt(`${prefix} balance increases by net proceeds`, Number(afterFinancial.accountBalance || 0) - Number(beforeFinancial.accountBalance || 0), sell.netProceeds);
+
+  if (requireDust) {
+    const dustDelta = Number(afterDetails.marketDust || 0) - Number(beforeDetails.marketDust || 0);
+    const volumeDelta = Number(afterDetails.totalVolume || 0) - Number(beforeDetails.totalVolume || 0);
+    sameInt(`${prefix} market dust retained`, dustDelta, sell.dust);
+    sameInt(`${prefix} market volume accounts for sell row and dust`, volumeDelta, -sell.sharesSold + sell.dust);
+  } else {
+    check(`${prefix} market detail dust numeric`, Number.isFinite(Number(afterDetails.marketDust || 0)));
+    check(`${prefix} market detail volume numeric`, Number.isFinite(Number(afterDetails.totalVolume || 0)));
+  }
+}
+
+async function replaySetupThroughSeq18(token, marketId) {
+  for (const step of attachmentSetupThroughSeq18) {
+    if (step.type === 'buy') {
+      await place(token, marketId, step.outcome, step.amount);
+      continue;
+    }
+    const quote = (await quoteRaw(token, marketId, step.outcome, step.amount)).result;
+    check(`setup seq ${step.seq} quote allowed`, quote.allowed === true);
+    const sell = (await sellRaw(token, marketId, step.outcome, step.amount)).result;
+    check(`setup seq ${step.seq} sell succeeded`, sell.sharesSold > 0 && sell.netProceeds >= 0, `shares=${sell.sharesSold}, net=${sell.netProceeds}`);
+  }
+}
+
+function assertUnchangedAfterRejection(prefix, beforeFinancial, afterFinancial, beforePosition, afterPosition, beforeDetails, afterDetails) {
+  sameInt(`${prefix} balance unchanged`, afterFinancial.accountBalance || 0, beforeFinancial.accountBalance || 0);
+  sameInt(`${prefix} YES shares unchanged`, shares(afterPosition, 'YES'), shares(beforePosition, 'YES'));
+  sameInt(`${prefix} NO shares unchanged`, shares(afterPosition, 'NO'), shares(beforePosition, 'NO'));
+  sameInt(`${prefix} position value unchanged`, positionValue(afterPosition), positionValue(beforePosition));
+  sameInt(`${prefix} market dust unchanged`, afterDetails.marketDust || 0, beforeDetails.marketDust || 0);
+  sameInt(`${prefix} market volume unchanged`, afterDetails.totalVolume || 0, beforeDetails.totalVolume || 0);
+}
+
+async function assertOvercashoutRejected(token, marketId) {
+  const beforeFinancial = await financial(bettor);
+  const beforePosition = await position(token, marketId);
+  const beforeDetails = await details(marketId);
+  const attempt = attachmentOvercashoutAttempt;
+
+  const quote = await quoteRaw(token, marketId, attempt.outcome, attempt.amount, [200, 422]);
+  check(`sad seq ${attempt.seq} quote rejected/not allowed`, quote.status === 422 || quote.result?.allowed === false, `status=${quote.status}`);
+  if (quote.status === 422) {
+    check(`sad seq ${attempt.seq} quote uses insufficient-shares contract`, reason(quote) === 'INSUFFICIENT_SHARES', `reason=${reason(quote)}`);
+  }
+
+  const sell = await sellRaw(token, marketId, attempt.outcome, attempt.amount, [201, 422]);
+  check(`sad seq ${attempt.seq} sell rejected`, sell.status === 422, `status=${sell.status}`);
+  if (sell.status === 422) {
+    check(`sad seq ${attempt.seq} sell uses insufficient-shares contract`, reason(sell) === 'INSUFFICIENT_SHARES', `reason=${reason(sell)}`);
+  }
+  if (sell.status === 201) {
+    check(`sad seq ${attempt.seq} does not produce large proceeds from small shares`, !(sell.result.sharesSold <= 4 && sell.result.netProceeds >= 400), JSON.stringify(sell.result));
+  }
+
+  const afterFinancial = await financial(bettor);
+  const afterPosition = await position(token, marketId);
+  const afterDetails = await details(marketId);
+  assertUnchangedAfterRejection(`sad seq ${attempt.seq}`, beforeFinancial, afterFinancial, beforePosition, afterPosition, beforeDetails, afterDetails);
+  rejectedSeq = attempt.seq;
+}
+
+async function main() {
+  const modToken = await login(moderator);
+  const bettorToken = await login(bettor);
+  const adminToken = await login(admin);
+  check('login seeded moderator, bettor, admin', true);
+
+  const happyMarketId = await createMarket('happy', modToken, adminToken);
+  await place(bettorToken, happyMarketId, 'NO', 50);
+  await place(bettorToken, happyMarketId, 'YES', 100);
+  await place(bettorToken, happyMarketId, 'YES', 50);
+  await assertQuoteAndSell({
+    prefix: 'happy attachment seq 4 exact sell',
+    token: bettorToken,
+    marketId: happyMarketId,
+    outcome: 'YES',
+    amount: 200,
+    expected: { sharesSold: 100, saleValue: 200, dust: 0, netProceeds: 200 },
+  });
+
+  await place(bettorToken, happyMarketId, 'YES', 100);
+  await place(bettorToken, happyMarketId, 'NO', 10);
+  await place(bettorToken, happyMarketId, 'NO', 40);
+  await place(bettorToken, happyMarketId, 'YES', 100);
+  await place(bettorToken, happyMarketId, 'NO', 50);
+  await assertQuoteAndSell({
+    prefix: 'happy attachment seq 10 dust sell',
+    token: bettorToken,
+    marketId: happyMarketId,
+    outcome: 'YES',
+    amount: 400,
+    expected: { sharesSold: 98, saleValue: 392, dust: 1, netProceeds: 391 },
+    requireDust: true,
+  });
+
+  const sadMarketId = await createMarket('sad', modToken, adminToken);
+  await replaySetupThroughSeq18(bettorToken, sadMarketId);
+  await assertOvercashoutRejected(bettorToken, sadMarketId);
+  check('attachment over-cashout sequence was blocked', rejectedSeq === attachmentOvercashoutAttempt.seq, `seq=${rejectedSeq}`);
+}
+
+async function finish() {
+  await mkdir(dirname(artifact), { recursive: true });
+  await writeFile(artifact, `${JSON.stringify({ marketIds, rejectedSeq, results }, null, 2)}\n`);
+  const failed = results.filter((result) => !result.ok);
+  console.log(`artifact: ${artifact}`);
+  console.log(`summary: ${results.length - failed.length} passed, ${failed.length} failed`);
+  process.exitCode = failed.length ? 1 : 0;
+}
+
+try {
+  await main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  results.push({ name: 'runner completed', ok: false, detail: message });
+  console.error(`FAIL runner completed - ${message}`);
+} finally {
+  await finish();
+}


### PR DESCRIPTION
## Summary
- add a shared post-sale projection invariant for sell quote and settlement
- run settlement projection inside the transaction-scoped sell repository using locked market/bet state
- add backend regressions and an HTTP integration scenario for the reported sell over-cashout sequence, including dust/volume assertions

## Validation
- go test ./internal/domain/bets ./internal/domain/markets ./internal/repository/bets ./handlers/bets
- JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...
- node --check integrationtest/scripts/sell-shares-overcashout.mjs
- node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:18080 --api-prefix /v0

Note: the port 18080 integration run used this branch's backend started locally against the dev Postgres because the existing :8080 container was bind-mounted to a different workspace.