### PR TITLE
ci: make Docker cache export non-blocking

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -56,8 +56,8 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: socialpredict-${{ matrix.image }}:staging-candidate
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=socialpredict-staging-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=socialpredict-staging-${{ matrix.image }},ignore-error=true
 
       - name: Scan ${{ matrix.image }} staging candidate for SARIF security alerts
         uses: aquasecurity/trivy-action@v0.36.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,8 +54,8 @@ jobs:
           context: .
           file: docker/frontend/Dockerfile
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=socialpredict-release-frontend
+          cache-to: type=gha,mode=max,scope=socialpredict-release-frontend,ignore-error=true
           push: true
           tags: ${{ steps.frontend-meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-frontend:latest
           labels: ${{ steps.frontend-meta.outputs.labels }}
@@ -113,8 +113,8 @@ jobs:
           context: .
           file: docker/backend/Dockerfile
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=socialpredict-release-backend
+          cache-to: type=gha,mode=max,scope=socialpredict-release-backend,ignore-error=true
           push: true
           tags: ${{ steps.backend-meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend:latest
           labels: ${{ steps.backend-meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- give staging Docker candidate builds image-specific GitHub Actions cache scopes
- give release Docker image builds image-specific GitHub Actions cache scopes
- make Docker cache export failures non-blocking so optional cache writes cannot block staging deploys or release image scans

## Why
The staging deploy rerun for #770 failed after both Docker images built successfully. The failing step was exporting the optional Buildx GitHub Actions cache:

- frontend: `ERROR: failed to build: failed to solve: failed to reserve cache`
- backend: `ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache`

Because the build step failed during cache export, the staging deploy dispatch was skipped even though the application image build had completed.

Docker documents `scope` for separating caches across multiple images and `ignore-error=true` for ignoring failed cache exports. This keeps real build and Trivy scan failures blocking, while treating cache export as best-effort.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/deploy-to-staging.yml .github/workflows/docker.yml`
- `actionlint` not installed locally; skipped

## Follow-up
After merge, manually run `Deploy To Staging` via `workflow_dispatch` on `main` to deploy the already-merged sell-share fix.
