### PR TITLE
fix: prevent unresolved position value inflation

### DIFF
--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -586,6 +586,36 @@ func TestServiceSell_DustAtCapCreditsNetProceeds(t *testing.T) {
 	}
 }
 
+func TestServiceSell_OneCreditShareDoesNotCashOutHistoricalVolume(t *testing.T) {
+	now := serviceTestTime()
+	fixture, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(0),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(&dmarkets.UserPosition{Username: "alice", MarketID: 1, NoSharesOwned: 1, Value: 1}),
+		withFixtureUser(&dusers.User{Username: "alice"}),
+	)
+
+	quote, err := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 141, Outcome: "NO"})
+	if err != nil {
+		t.Fatalf("QuoteSell returned error: %v", err)
+	}
+	if quote.SharesSold != 1 || quote.SaleValue != 1 || quote.NetProceeds != 1 || quote.RequestedCredits != 1 {
+		t.Fatalf("quote cashed out more than the current share value: %+v", quote)
+	}
+
+	result, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 141, Outcome: "NO"})
+	if err != nil {
+		t.Fatalf("Sell returned error: %v", err)
+	}
+	if result.SharesSold != 1 || result.SaleValue != 1 || result.NetProceeds != 1 {
+		t.Fatalf("sell cashed out more than the current share value: %+v", result)
+	}
+	if len(fixture.users.calls) != 1 || fixture.users.calls[0].amount != 1 {
+		t.Fatalf("unexpected user credit: %+v", fixture.users.calls)
+	}
+}
+
 func TestServiceSell_FullPositionSellRequiresZeroProjectedValue(t *testing.T) {
 	now := serviceTestTime()
 

--- a/backend/internal/domain/math/positions/valuation.go
+++ b/backend/internal/domain/math/positions/valuation.go
@@ -106,7 +106,8 @@ func (c ValuationCalculator) Calculate(
 		}
 	}
 
-	adjusted := c.adjuster.Adjust(result, earliestBets, totalVolume)
+	targetValue := targetValuationPool(userPositions, totalVolume, isResolved)
+	adjusted := c.adjuster.Adjust(result, earliestBets, targetValue)
 	return adjusted, nil
 }
 
@@ -146,6 +147,26 @@ func calculatePositionValue(
 	resolutionResult string,
 ) float64 {
 	return valuationModel{}.PositionValue(position, finalProbability, isResolved, resolutionResult)
+}
+
+func targetValuationPool(userPositions map[string]UserMarketPosition, marketVolume int64, isResolved bool) int64 {
+	if isResolved {
+		return marketVolume
+	}
+
+	var outstandingShares int64
+	for _, position := range userPositions {
+		outstandingShares += positiveInt64(position.YesSharesOwned)
+		outstandingShares += positiveInt64(position.NoSharesOwned)
+	}
+	return outstandingShares
+}
+
+func positiveInt64(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
 }
 
 func (valuationModel) PositionValue(

--- a/backend/internal/domain/math/positions/valuation_test.go
+++ b/backend/internal/domain/math/positions/valuation_test.go
@@ -82,6 +82,17 @@ func TestCalculateRoundedUserValuationsFromUserMarketPositions(t *testing.T) {
 			Expected:         map[string]int64{"alice": 10, "bob": 10},
 		},
 		{
+			Name: "Unresolved market does not assign inactive historical volume to sole holder",
+			UserPositions: []valuationPositionInput{
+				{"alice", 0, 1},
+			},
+			Probability:      0.5,
+			TotalVolume:      141,
+			IsResolved:       false,
+			ResolutionResult: "",
+			Expected:         map[string]int64{"alice": 1},
+		},
+		{
 			Name: "Resolved market: YES wins",
 			UserPositions: []valuationPositionInput{
 				{"alice", 10, 0},


### PR DESCRIPTION
## Summary
- fix unresolved position valuation so inactive historical market volume is not assigned to the only current holder
- keep resolved-market payout valuation using market volume
- add regressions for the reported `NO: 1` / `141 credits` cashout path

## Root Cause
The fork commit the testers referenced (`guardiansoftheball/guardianspredictions@610716e`) did merge upstream `v3.6.0`: its second parent is `b31b8188`, the `v3.6.0` target commit, and the sell-fix files match that tag.

The remaining bug is a different path. For unresolved markets, `AdjustUserValuationsToMarketVolume` adjusted positive user values to total historical market volume. If prior volume/dust existed but only one user currently held `NO: 1`, that holder could be assigned the whole market volume as position value. Sell quote/settlement then used that inflated `position.Value / sharesOwned`, allowing a one-share position to cash out for values like `141`.

This changes unresolved valuation adjustment to target current outstanding net shares instead. That preserves normal fresh-market behavior while preventing sold-out historical volume from becoming someone else's cashout value. Resolved markets still target full market volume for final payout-style valuation.

## Validation
- `go test ./internal/domain/math/positions`
- `go test ./internal/domain/bets`
- `go test ./internal/domain/bets ./internal/domain/markets ./internal/repository/bets ./handlers/bets ./internal/domain/math/positions`
- `JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...`
