### PR TITLE
Fix sell-share 422 guidance and verify unlocked-share sell flow

### DIFF
--- a/backend/handlers/bets/selling/sellpositionhandler.go
+++ b/backend/handlers/bets/selling/sellpositionhandler.go
@@ -151,7 +151,15 @@ func handleSellError(w http.ResponseWriter, err error) {
 			},
 		)
 	case errors.Is(err, bets.ErrInsufficientShares):
-		_ = handlers.WriteFailure(w, http.StatusUnprocessableEntity, handlers.ReasonInsufficientShares)
+		_ = handlers.WriteFailureWithDetails(
+			w,
+			http.StatusUnprocessableEntity,
+			handlers.ReasonInsufficientShares,
+			bets.InsufficientSellableSharesMessage,
+			map[string]any{
+				"hint": "Use a smaller sale amount or wait for another user's later buy to unlock the newest value.",
+			},
+		)
 	case errors.Is(err, dmarkets.ErrMarketNotFound):
 		_ = handlers.WriteFailure(w, http.StatusNotFound, handlers.ReasonMarketNotFound)
 	default:

--- a/backend/handlers/bets/selling/sellpositionhandler_test.go
+++ b/backend/handlers/bets/selling/sellpositionhandler_test.go
@@ -405,6 +405,35 @@ func TestSellPositionHandler_NoSellableSharesIncludesUserGuidance(t *testing.T) 
 	}
 }
 
+func TestSellQuoteHandler_InsufficientSharesIncludesUserGuidance(t *testing.T) {
+	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
+	svc := &fakeSellService{quoteErr: bets.ErrInsufficientShares}
+	users := &fakeUsersService{user: &dusers.User{Username: "alice"}}
+
+	body, _ := json.Marshal(dto.SellBetRequest{MarketID: 1, Amount: 10, Outcome: "YES"})
+	req := httptest.NewRequest(http.MethodPost, "/v0/sell/quote", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+modelstesting.GenerateValidJWT("alice"))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	SellQuoteHandler(svc, users).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+
+	var resp handlers.FailureEnvelope
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode failure envelope: %v", err)
+	}
+	if resp.Reason != string(handlers.ReasonInsufficientShares) {
+		t.Fatalf("expected insufficient-shares reason, got %q", resp.Reason)
+	}
+	if resp.Message != bets.InsufficientSellableSharesMessage {
+		t.Fatalf("expected insufficient-shares guidance, got %q", resp.Message)
+	}
+}
+
 func TestSellPositionHandler_InvalidJSON(t *testing.T) {
 	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
 	svc := &fakeSellService{}

--- a/backend/internal/domain/bets/errors.go
+++ b/backend/internal/domain/bets/errors.go
@@ -54,6 +54,8 @@ var (
 
 const NoSellableSharesMessage = "No sellable shares yet. Initial value cannot be sold until a follow-up order from another user has been placed. Wait for another order from another user, then try selling again."
 
+const InsufficientSellableSharesMessage = "Not enough sellable shares for that sale amount. Try a smaller Sale Order amount, or wait for more market activity if your latest shares are still locked."
+
 // ErrDustCapExceeded is returned when a sell transaction would generate dust above the configured cap.
 type ErrDustCapExceeded struct {
 	Cap       int64

--- a/backend/internal/domain/math/positions/positionsmath_test.go
+++ b/backend/internal/domain/math/positions/positionsmath_test.go
@@ -304,6 +304,38 @@ func TestCalculateUnlockedSellablePosition_WPAM_DBPM(t *testing.T) {
 			username: "bob",
 			outcome:  "NO",
 		},
+		{
+			name: "three alternating users unlock only previous buys",
+			bets: []struct {
+				Amount   int64
+				Outcome  string
+				Username string
+				Offset   time.Duration
+			}{
+				{Amount: 1, Outcome: "NO", Username: "alice", Offset: 0},
+				{Amount: 1, Outcome: "NO", Username: "bob", Offset: time.Minute},
+				{Amount: 1, Outcome: "NO", Username: "carol", Offset: 2 * time.Minute},
+			},
+			username: "bob",
+			outcome:  "NO",
+			wantNo:   1,
+			wantVal:  1,
+		},
+		{
+			name: "newest user in three-user sequence remains locked",
+			bets: []struct {
+				Amount   int64
+				Outcome  string
+				Username string
+				Offset   time.Duration
+			}{
+				{Amount: 1, Outcome: "NO", Username: "alice", Offset: 0},
+				{Amount: 1, Outcome: "NO", Username: "bob", Offset: time.Minute},
+				{Amount: 1, Outcome: "NO", Username: "carol", Offset: 2 * time.Minute},
+			},
+			username: "carol",
+			outcome:  "NO",
+		},
 	}
 
 	for _, tt := range tests {

--- a/frontend/src/components/layouts/trade/TradeUtils.jsx
+++ b/frontend/src/components/layouts/trade/TradeUtils.jsx
@@ -25,6 +25,10 @@ const formatApiError = (errorData, fallback) => {
         return fallback;
     }
 
+    if (errorData.reason === 'INSUFFICIENT_SHARES') {
+        return errorData.message || 'Not enough sellable shares for that sale amount. Try a smaller Sale Order amount, or wait for more market activity if your latest shares are still locked.';
+    }
+
     if (errorData.reason === 'DUST_CAP_EXCEEDED') {
         const dust = errorData.details?.dust;
         const maxDust = errorData.details?.maxDust;
@@ -50,7 +54,7 @@ const parseErrorResponse = async (response, fallbackPrefix) => {
     }
 
     errorMessage = formatApiError(errorData, text);
-    if (fallbackPrefix.startsWith('Sale') && errorData?.reason === 'NO_POSITION') {
+    if (fallbackPrefix.startsWith('Sale') && ['NO_POSITION', 'INSUFFICIENT_SHARES'].includes(errorData?.reason)) {
         throw new Error(errorMessage || NO_SELLABLE_SHARES_MESSAGE);
     }
     throw new Error(`${fallbackPrefix} (${response.status}): ${errorMessage}`);


### PR DESCRIPTION
## Summary
- Preserve the backend sell-share business contract: locked or unsafe sale attempts still return 422 with stable failure reasons.
- Add a user-facing backend message/details for sell `INSUFFICIENT_SHARES` responses so clients do not have to show raw reason codes.
- Update frontend sell error parsing so sell quote/sell business failures render guidance instead of `Sale quote failed (422): INSUFFICIENT_SHARES`.
- Add regression coverage for the insufficient-shares sell quote envelope.
- Add coverage for the unlocked-share rule: older value unlocked by a later different-user buy remains sellable, while the latest top contribution stays locked until another user buys after it.

## Behavior Verified
- A single initial buy cannot be sold yet and returns the follow-up-user guidance.
- A later buy from another user unlocks the earlier user's prior sellable value.
- The later buyer's newest contribution remains locked.
- Previously unlocked value remains sellable; the lock applies to the top contribution that has not yet been followed by another user's buy.
- Same-side and opposite-side follow-up buys both unlock the earlier user's prior value in the live app flow.
- The frontend no longer renders raw `Sale quote failed (422): INSUFFICIENT_SHARES` text.

## Automated Tests
- `go test ./handlers/bets/selling ./internal/domain/math/positions ./internal/domain/bets`
- `go test ./...` from `backend`
- `npm ci && npm run build` from `frontend`

## Live End-to-End Verification
Ran a local Docker stack:
- `./SocialPredict up`
- `./SocialPredict dev-bootstrap-users`

Then ran the existing live API integration scenario:
- `node integrationtest/scripts/sell-shares-two-share-cap.mjs --base-url http://localhost:8080 --api-prefix /v0 --artifact integrationtest/artifacts/sell-shares-two-share-cap-e2e-local.json`
- Result: `45 passed, 0 failed`

Also ran a temporary headless browser smoke against `http://localhost:5173` using Playwright under `.context`:
- verified locked-share UI guidance appears for the real 422 quote response
- verified same-side follow-up unlock shows Sale Preview
- verified opposite-side follow-up unlock shows Sale Preview
- verified raw `Sale quote failed (422):` / `INSUFFICIENT_SHARES` text does not appear in the UI

## Notes
- The browser smoke required temporarily raising local dev rate limits because automated setup makes many rapid login/read requests and can otherwise hit unrelated 429 rate limits. The override was removed afterward and the backend was recreated with normal dev settings.
- The temporary browser scripts and Playwright install were kept under `.context` and are not part of this PR.
