### PR TITLE
docs: replace broken README stargazer chart

### DIFF
--- a/.github/workflows/readme-stargazers-chart.yml
+++ b/.github/workflows/readme-stargazers-chart.yml
@@ -1,0 +1,84 @@
+name: README Stargazers Chart
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 2 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  STARGAZERS_CHART_BRANCH: docs/update-readme-stargazers-chart
+
+jobs:
+  update-stargazers-chart:
+    name: Update README stargazers chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Generate stargazers chart
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_METRICS_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/readme-stargazers-chart.py
+
+      - name: Open pull request for updated chart
+        env:
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ secrets.TRAFFIC_METRICS_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README/METRICS/stargazers-over-time.svg README/METRICS/stargazers-over-time.json
+          if git diff --cached --quiet; then
+            echo "Stargazers chart unchanged."
+            exit 0
+          fi
+          git commit -m "docs: update README stargazers chart"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          remote_sha="$(git ls-remote --heads origin "$STARGAZERS_CHART_BRANCH" | awk '{print $1}')"
+          if [ -n "$remote_sha" ]; then
+            git push --force-with-lease="refs/heads/${STARGAZERS_CHART_BRANCH}:${remote_sha}" origin "HEAD:${STARGAZERS_CHART_BRANCH}"
+          else
+            git push origin "HEAD:${STARGAZERS_CHART_BRANCH}"
+          fi
+
+          pr_body="$(mktemp)"
+          cat > "$pr_body" <<'EOF'
+          Updates the README stargazers-over-time SVG from GitHub's stargazer API.
+
+          This PR is created automatically by the README Stargazers Chart workflow.
+          EOF
+
+          pr_number="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$STARGAZERS_CHART_BRANCH" \
+              --base "$BASE_BRANCH" \
+              --state open \
+              --json number \
+              --jq '.[0].number // ""'
+          )"
+
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "docs: update README stargazers chart" \
+              --body-file "$pr_body"
+            echo "Updated stargazers chart pull request #${pr_number}."
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "$BASE_BRANCH" \
+              --head "$STARGAZERS_CHART_BRANCH" \
+              --title "docs: update README stargazers chart" \
+              --body-file "$pr_body"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ node_modules/
 .go-run-cache/
 .tmp/
 .config/go/
+__pycache__/
 
 # Runtime CMS uploads
 /backend/data/uploads/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SocialPredict lets **anyone** – individuals, classrooms, companies, and even g
 * Kenyon College (Political Science course PSCI 303, Campaigns & Elections; syllabus [here](https://www.zacharymcgee.net/syllabi/PSCI_303_public.pdf))
                         
 ## Stargazers Over Time
-[![Star History Chart](https://app.repohistory.com/api/svg?repo=openpredictionmarkets/socialpredict&type=Date&background=0D1117&color=62C3F8)](https://app.repohistory.com/star-history)
+[![Stargazers over time](README/METRICS/stargazers-over-time.svg)](https://github.com/openpredictionmarkets/socialpredict/stargazers)
 
 ## Licensing
 

--- a/README/METRICS/README.md
+++ b/README/METRICS/README.md
@@ -1,4 +1,4 @@
-# Repository Traffic Metrics
+# Repository Metrics
 
 This directory stores public JSON snapshots backed by GitHub's repository traffic API.
 
@@ -7,3 +7,5 @@ GitHub only exposes repository clone/view traffic for a rolling 14-day window. T
 The top-level README uses static Shields badge URLs for the rolling clone metrics so badges render correctly before and after branch merges. The scheduled refresh workflow updates both the README badge URLs and these JSON snapshots from `gh api repos/$GITHUB_REPOSITORY/traffic/clones`.
 
 GitHub's traffic API requires access that the default `GITHUB_TOKEN` does not provide. Add a repository secret named `TRAFFIC_METRICS_TOKEN` using a fine-grained token or GitHub App token with read access to repository Administration, read/write access to repository Contents, and read/write access to Pull requests. The write permissions let the scheduled workflow open a PR instead of pushing directly to protected `main`. If this secret is absent, the scheduled workflow exits successfully without updating the traffic badges.
+
+The stargazers-over-time chart is generated from GitHub's stargazers API with `starred_at` timestamps. Run `python3 scripts/readme-stargazers-chart.py` from the repository root to refresh `stargazers-over-time.svg` and `stargazers-over-time.json`. The scheduled README Stargazers Chart workflow uses the default `GITHUB_TOKEN`, writes updated chart artifacts to a docs branch, and opens or updates a pull request.

--- a/README/METRICS/stargazers-over-time.json
+++ b/README/METRICS/stargazers-over-time.json
@@ -1,0 +1,131 @@
+{
+  "repo": "openpredictionmarkets/socialpredict",
+  "source": "GitHub stargazers API with starred_at timestamps",
+  "total_stargazers": 212,
+  "points": [
+    {
+      "month": "2024-01",
+      "total": 3
+    },
+    {
+      "month": "2024-02",
+      "total": 5
+    },
+    {
+      "month": "2024-03",
+      "total": 6
+    },
+    {
+      "month": "2024-04",
+      "total": 18
+    },
+    {
+      "month": "2024-05",
+      "total": 24
+    },
+    {
+      "month": "2024-06",
+      "total": 26
+    },
+    {
+      "month": "2024-07",
+      "total": 29
+    },
+    {
+      "month": "2024-08",
+      "total": 36
+    },
+    {
+      "month": "2024-09",
+      "total": 50
+    },
+    {
+      "month": "2024-10",
+      "total": 52
+    },
+    {
+      "month": "2024-11",
+      "total": 62
+    },
+    {
+      "month": "2024-12",
+      "total": 66
+    },
+    {
+      "month": "2025-01",
+      "total": 69
+    },
+    {
+      "month": "2025-02",
+      "total": 72
+    },
+    {
+      "month": "2025-03",
+      "total": 74
+    },
+    {
+      "month": "2025-04",
+      "total": 78
+    },
+    {
+      "month": "2025-05",
+      "total": 81
+    },
+    {
+      "month": "2025-06",
+      "total": 83
+    },
+    {
+      "month": "2025-07",
+      "total": 86
+    },
+    {
+      "month": "2025-08",
+      "total": 92
+    },
+    {
+      "month": "2025-09",
+      "total": 100
+    },
+    {
+      "month": "2025-10",
+      "total": 112
+    },
+    {
+      "month": "2025-11",
+      "total": 131
+    },
+    {
+      "month": "2025-12",
+      "total": 144
+    },
+    {
+      "month": "2026-01",
+      "total": 151
+    },
+    {
+      "month": "2026-02",
+      "total": 155
+    },
+    {
+      "month": "2026-03",
+      "total": 161
+    },
+    {
+      "month": "2026-04",
+      "total": 186
+    },
+    {
+      "month": "2026-05",
+      "total": 197
+    },
+    {
+      "month": "2026-06",
+      "total": 209
+    },
+    {
+      "month": "2026-07",
+      "total": 212
+    }
+  ]
+}

--- a/README/METRICS/stargazers-over-time.svg
+++ b/README/METRICS/stargazers-over-time.svg
@@ -1,0 +1,33 @@
+<svg width="760" height="320" viewBox="0 0 760 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SocialPredict stargazers over time</title>
+  <desc id="desc">Cumulative GitHub stargazers for openpredictionmarkets/socialpredict, generated from GitHub stargazer timestamps.</desc>
+  <style>
+    .title { fill: #f8fafc; font: 700 22px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .subtitle { fill: #9fb2c8; font: 500 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .axis { fill: #9fb2c8; font: 500 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .total { fill: #f8fafc; font: 700 28px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  </style>
+  <rect width="760" height="320" rx="8" fill="#0d1117" />
+  <text x="62" y="30" class="title">Stargazers over time</text>
+  <text x="732" y="28" text-anchor="end" class="total">212</text>
+  <text x="732" y="47" text-anchor="end" class="subtitle">stars</text>
+  <text x="62" y="312" class="subtitle">Generated from GitHub stargazer timestamps</text>
+  <line x1="62" y1="266.0" x2="732" y2="266.0" stroke="#243244" stroke-width="1" />
+<line x1="62" y1="210.9" x2="732" y2="210.9" stroke="#243244" stroke-width="1" />
+<line x1="62" y1="155.0" x2="732" y2="155.0" stroke="#243244" stroke-width="1" />
+<line x1="62" y1="99.9" x2="732" y2="99.9" stroke="#243244" stroke-width="1" />
+<line x1="62" y1="44.0" x2="732" y2="44.0" stroke="#243244" stroke-width="1" />
+  <line x1="62" y1="266" x2="732" y2="266" stroke="#3a4658" stroke-width="1.5" />
+  <line x1="62" y1="44" x2="62" y2="266" stroke="#3a4658" stroke-width="1.5" />
+  <text x="50" y="270.0" text-anchor="end" class="axis">0</text>
+<text x="50" y="214.9" text-anchor="end" class="axis">62</text>
+<text x="50" y="159.0" text-anchor="end" class="axis">125</text>
+<text x="50" y="103.9" text-anchor="end" class="axis">187</text>
+<text x="50" y="48.0" text-anchor="end" class="axis">250</text>
+  <text x="62.0" y="298" text-anchor="middle" class="axis">2024-01</text>
+<text x="397.0" y="298" text-anchor="middle" class="axis">2025-04</text>
+<text x="732.0" y="298" text-anchor="middle" class="axis">2026-07</text>
+  <polygon points="62,266 62.0,263.3 84.3,261.6 106.7,260.7 129.0,250.0 151.3,244.7 173.7,242.9 196.0,240.2 218.3,234.0 240.7,221.6 263.0,219.8 285.3,210.9 307.7,207.4 330.0,204.7 352.3,202.1 374.7,200.3 397.0,196.7 419.3,194.1 441.7,192.3 464.0,189.6 486.3,184.3 508.7,177.2 531.0,166.5 553.3,149.7 575.7,138.1 598.0,131.9 620.3,128.4 642.7,123.0 665.0,100.8 687.3,91.1 709.7,80.4 732.0,77.7 732,266" fill="#62c3f8" opacity="0.16" />
+  <polyline points="62.0,263.3 84.3,261.6 106.7,260.7 129.0,250.0 151.3,244.7 173.7,242.9 196.0,240.2 218.3,234.0 240.7,221.6 263.0,219.8 285.3,210.9 307.7,207.4 330.0,204.7 352.3,202.1 374.7,200.3 397.0,196.7 419.3,194.1 441.7,192.3 464.0,189.6 486.3,184.3 508.7,177.2 531.0,166.5 553.3,149.7 575.7,138.1 598.0,131.9 620.3,128.4 642.7,123.0 665.0,100.8 687.3,91.1 709.7,80.4 732.0,77.7" fill="none" stroke="#62c3f8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="732.0" cy="77.7" r="5" fill="#2ea043" stroke="#f8fafc" stroke-width="2" />
+</svg>

--- a/scripts/readme-stargazers-chart.py
+++ b/scripts/readme-stargazers-chart.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Generate the README stargazers-over-time chart from GitHub stargazer data."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import shutil
+import subprocess
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+GITHUB_API = "https://api.github.com"
+
+
+@dataclass(frozen=True)
+class ChartPoint:
+    label: str
+    count: int
+
+
+def parse_month(timestamp: str) -> str:
+    return datetime.fromisoformat(timestamp.replace("Z", "+00:00")).strftime("%Y-%m")
+
+
+def build_monthly_points(starred_at_values: Iterable[str]) -> list[ChartPoint]:
+    month_counts = Counter(parse_month(value) for value in starred_at_values)
+    if not month_counts:
+        return []
+
+    months = sorted(month_counts)
+    running_total = 0
+    points: list[ChartPoint] = []
+    for month in months:
+        running_total += month_counts[month]
+        points.append(ChartPoint(label=month, count=running_total))
+    return points
+
+
+def parse_next_link(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        pieces = part.strip().split(";")
+        if len(pieces) < 2:
+            continue
+        url_part = pieces[0].strip()
+        rels = [piece.strip() for piece in pieces[1:]]
+        if 'rel="next"' in rels and url_part.startswith("<") and url_part.endswith(">"):
+            return url_part[1:-1]
+    return None
+
+
+def fetch_stargazers(repo: str, token: str | None = None) -> list[dict]:
+    url = f"{GITHUB_API}/repos/{repo}/stargazers?per_page=100"
+    stargazers: list[dict] = []
+
+    while url:
+        request = Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github.star+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "socialpredict-readme-stargazers-chart",
+            },
+        )
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+
+        try:
+            with urlopen(request) as response:
+                stargazers.extend(json.loads(response.read().decode("utf-8")))
+                url = parse_next_link(response.headers.get("Link"))
+        except HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub stargazers request failed with HTTP {error.code}: {detail}") from error
+
+    return stargazers
+
+
+def resolve_token(cli_token: str | None = None) -> str | None:
+    if cli_token:
+        return cli_token
+    env_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if env_token:
+        return env_token
+    if not shutil.which("gh"):
+        return None
+    try:
+        return subprocess.check_output(["gh", "auth", "token"], text=True, stderr=subprocess.DEVNULL).strip() or None
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _nice_max(value: int) -> int:
+    if value <= 10:
+        return 10
+    magnitude = 10 ** (len(str(value)) - 1)
+    for multiplier in (1, 2, 2.5, 5, 10):
+        candidate = multiplier * magnitude
+        if candidate >= value:
+            return int(candidate)
+    return value
+
+
+def render_svg(repo: str, points: list[ChartPoint]) -> str:
+    width = 760
+    height = 320
+    margin_left = 62
+    margin_right = 28
+    margin_top = 44
+    margin_bottom = 54
+    plot_width = width - margin_left - margin_right
+    plot_height = height - margin_top - margin_bottom
+    max_count = _nice_max(max((point.count for point in points), default=0))
+
+    def x_for(index: int) -> float:
+        if len(points) <= 1:
+            return margin_left
+        return margin_left + (index / (len(points) - 1)) * plot_width
+
+    def y_for(count: int) -> float:
+        return margin_top + plot_height - (count / max_count) * plot_height
+
+    polyline = " ".join(f"{x_for(index):.1f},{y_for(point.count):.1f}" for index, point in enumerate(points))
+    area = ""
+    if points:
+        area = (
+            f"{margin_left},{margin_top + plot_height} "
+            f"{polyline} "
+            f"{margin_left + plot_width},{margin_top + plot_height}"
+        )
+
+    y_ticks = [0, max_count // 4, max_count // 2, (max_count * 3) // 4, max_count]
+    y_grid = "\n".join(
+        f'<line x1="{margin_left}" y1="{y_for(tick):.1f}" x2="{width - margin_right}" y2="{y_for(tick):.1f}" stroke="#243244" stroke-width="1" />'
+        for tick in y_ticks
+    )
+    y_labels = "\n".join(
+        f'<text x="{margin_left - 12}" y="{y_for(tick) + 4:.1f}" text-anchor="end" class="axis">{tick}</text>'
+        for tick in y_ticks
+    )
+
+    x_labels = ""
+    if points:
+        label_indexes = sorted(set([0, len(points) // 2, len(points) - 1]))
+        x_labels = "\n".join(
+            f'<text x="{x_for(index):.1f}" y="{height - 22}" text-anchor="middle" class="axis">{html.escape(points[index].label)}</text>'
+            for index in label_indexes
+        )
+
+    total = points[-1].count if points else 0
+    escaped_repo = html.escape(repo)
+
+    return f"""<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SocialPredict stargazers over time</title>
+  <desc id="desc">Cumulative GitHub stargazers for {escaped_repo}, generated from GitHub stargazer timestamps.</desc>
+  <style>
+    .title {{ fill: #f8fafc; font: 700 22px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+    .subtitle {{ fill: #9fb2c8; font: 500 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+    .axis {{ fill: #9fb2c8; font: 500 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+    .total {{ fill: #f8fafc; font: 700 28px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+  </style>
+  <rect width="{width}" height="{height}" rx="8" fill="#0d1117" />
+  <text x="{margin_left}" y="30" class="title">Stargazers over time</text>
+  <text x="{width - margin_right}" y="28" text-anchor="end" class="total">{total:,}</text>
+  <text x="{width - margin_right}" y="47" text-anchor="end" class="subtitle">stars</text>
+  <text x="{margin_left}" y="{height - 8}" class="subtitle">Generated from GitHub stargazer timestamps</text>
+  {y_grid}
+  <line x1="{margin_left}" y1="{margin_top + plot_height}" x2="{width - margin_right}" y2="{margin_top + plot_height}" stroke="#3a4658" stroke-width="1.5" />
+  <line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{margin_top + plot_height}" stroke="#3a4658" stroke-width="1.5" />
+  {y_labels}
+  {x_labels}
+  <polygon points="{area}" fill="#62c3f8" opacity="0.16" />
+  <polyline points="{polyline}" fill="none" stroke="#62c3f8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  {f'<circle cx="{x_for(len(points) - 1):.1f}" cy="{y_for(total):.1f}" r="5" fill="#2ea043" stroke="#f8fafc" stroke-width="2" />' if points else ''}
+</svg>
+"""
+
+
+def write_outputs(repo: str, stargazers: list[dict], svg_path: Path, json_path: Path) -> None:
+    starred_at_values = [item["starred_at"] for item in stargazers if item.get("starred_at")]
+    points = build_monthly_points(starred_at_values)
+
+    svg_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    svg_path.write_text(render_svg(repo, points), encoding="utf-8")
+    json_path.write_text(
+        json.dumps(
+            {
+                "repo": repo,
+                "source": "GitHub stargazers API with starred_at timestamps",
+                "total_stargazers": points[-1].count if points else 0,
+                "points": [{"month": point.label, "total": point.count} for point in points],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "openpredictionmarkets/socialpredict"))
+    parser.add_argument("--output", default="README/METRICS/stargazers-over-time.svg")
+    parser.add_argument("--json-output", default="README/METRICS/stargazers-over-time.json")
+    parser.add_argument("--token", default=None)
+    args = parser.parse_args()
+
+    stargazers = fetch_stargazers(args.repo, resolve_token(args.token))
+    write_outputs(args.repo, stargazers, Path(args.output), Path(args.json_output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_readme_stargazers_chart.py
+++ b/scripts/tests/test_readme_stargazers_chart.py
@@ -1,0 +1,60 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "readme-stargazers-chart.py"
+SPEC = importlib.util.spec_from_file_location("readme_stargazers_chart", SCRIPT_PATH)
+chart = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = chart
+SPEC.loader.exec_module(chart)
+
+
+class ReadmeStargazersChartTests(unittest.TestCase):
+    def test_build_monthly_points_returns_cumulative_totals(self):
+        points = chart.build_monthly_points(
+            [
+                "2026-02-03T12:00:00Z",
+                "2026-01-01T00:00:00Z",
+                "2026-02-20T23:59:59Z",
+            ]
+        )
+
+        self.assertEqual(
+            points,
+            [
+                chart.ChartPoint(label="2026-01", count=1),
+                chart.ChartPoint(label="2026-02", count=3),
+            ],
+        )
+
+    def test_parse_next_link_finds_next_relation(self):
+        link = '<https://api.github.com/repositories/1/stargazers?page=2>; rel="next", <https://api.github.com/repositories/1/stargazers?page=3>; rel="last"'
+
+        self.assertEqual(
+            chart.parse_next_link(link),
+            "https://api.github.com/repositories/1/stargazers?page=2",
+        )
+
+    def test_nice_max_uses_tight_readable_scale(self):
+        self.assertEqual(chart._nice_max(212), 250)
+
+    def test_render_svg_contains_chart_metadata_and_polyline(self):
+        svg = chart.render_svg(
+            "openpredictionmarkets/socialpredict",
+            [
+                chart.ChartPoint(label="2026-01", count=1),
+                chart.ChartPoint(label="2026-02", count=3),
+            ],
+        )
+
+        self.assertIn("<svg", svg)
+        self.assertIn("Stargazers over time", svg)
+        self.assertIn("openpredictionmarkets/socialpredict", svg)
+        self.assertIn("<polyline", svg)
+        self.assertIn(">3<", svg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace the broken external repohistory stargazer image with a checked-in SVG generated from GitHub stargazer timestamps.
- Add a stdlib Python generator that paginates GitHub's stargazers endpoint, buckets stars by month, and writes both SVG and JSON artifacts under README/METRICS.
- Add a scheduled/manual workflow to refresh the chart and open or update a docs PR when the stargazer data changes.
- Document the stargazer refresh flow alongside the existing repository metrics docs.

## Testing
- python3 -m unittest scripts.tests.test_readme_stargazers_chart
- python3 scripts/readme-stargazers-chart.py
- python3 -m json.tool README/METRICS/stargazers-over-time.json >/dev/null
- xmllint --noout README/METRICS/stargazers-over-time.svg
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/readme-stargazers-chart.yml'); puts 'workflow yaml ok'"