### PR TITLE
docs: update repository traffic badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 [release-img]: https://img.shields.io/github/v/release/openpredictionmarkets/socialpredict?label=release
 [release]: https://github.com/openpredictionmarkets/socialpredict/releases/latest
-[clones-14d-img]: https://img.shields.io/badge/14d%20clones-15%2C321-62c3f8
-[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-219-2ea043
+[clones-14d-img]: https://img.shields.io/badge/14d%20clones-27%2C962-62c3f8
+[unique-cloners-14d-img]: https://img.shields.io/badge/14d%20cloners-146-2ea043
 [traffic]: https://github.com/openpredictionmarkets/socialpredict/graphs/traffic
 [test-img]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml/badge.svg?branch=main
 [test]: https://github.com/openpredictionmarkets/socialpredict/actions/workflows/backend.yml

--- a/README/METRICS/clones-14d.json
+++ b/README/METRICS/clones-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d clones",
-  "message": "15,321",
+  "message": "27,962",
   "color": "62c3f8"
 }

--- a/README/METRICS/github-traffic-latest.json
+++ b/README/METRICS/github-traffic-latest.json
@@ -1,49 +1,9 @@
 {
-  "updated_at": "2026-07-18T04:46:03Z",
-  "clones_14d": 15321,
-  "unique_cloners_14d": 219,
+  "updated_at": "2026-07-26T05:28:39Z",
+  "clones_14d": 27962,
+  "unique_cloners_14d": 146,
   "source": "GitHub repository traffic API, rolling 14-day window",
   "clones": [
-    {
-      "timestamp": "2026-07-03T00:00:00Z",
-      "count": 160,
-      "uniques": 40
-    },
-    {
-      "timestamp": "2026-07-04T00:00:00Z",
-      "count": 132,
-      "uniques": 30
-    },
-    {
-      "timestamp": "2026-07-05T00:00:00Z",
-      "count": 51,
-      "uniques": 19
-    },
-    {
-      "timestamp": "2026-07-06T00:00:00Z",
-      "count": 38,
-      "uniques": 22
-    },
-    {
-      "timestamp": "2026-07-07T00:00:00Z",
-      "count": 12,
-      "uniques": 6
-    },
-    {
-      "timestamp": "2026-07-08T00:00:00Z",
-      "count": 611,
-      "uniques": 37
-    },
-    {
-      "timestamp": "2026-07-09T00:00:00Z",
-      "count": 1653,
-      "uniques": 52
-    },
-    {
-      "timestamp": "2026-07-10T00:00:00Z",
-      "count": 1815,
-      "uniques": 16
-    },
     {
       "timestamp": "2026-07-11T00:00:00Z",
       "count": 1703,
@@ -73,6 +33,46 @@
       "timestamp": "2026-07-16T00:00:00Z",
       "count": 1976,
       "uniques": 24
+    },
+    {
+      "timestamp": "2026-07-17T00:00:00Z",
+      "count": 1781,
+      "uniques": 20
+    },
+    {
+      "timestamp": "2026-07-18T00:00:00Z",
+      "count": 1957,
+      "uniques": 33
+    },
+    {
+      "timestamp": "2026-07-19T00:00:00Z",
+      "count": 1829,
+      "uniques": 23
+    },
+    {
+      "timestamp": "2026-07-20T00:00:00Z",
+      "count": 2097,
+      "uniques": 9
+    },
+    {
+      "timestamp": "2026-07-21T00:00:00Z",
+      "count": 2555,
+      "uniques": 14
+    },
+    {
+      "timestamp": "2026-07-22T00:00:00Z",
+      "count": 2593,
+      "uniques": 16
+    },
+    {
+      "timestamp": "2026-07-23T00:00:00Z",
+      "count": 2414,
+      "uniques": 17
+    },
+    {
+      "timestamp": "2026-07-24T00:00:00Z",
+      "count": 1887,
+      "uniques": 17
     }
   ]
 }

--- a/README/METRICS/unique-cloners-14d.json
+++ b/README/METRICS/unique-cloners-14d.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "14d cloners",
-  "message": "219",
+  "message": "146",
   "color": "2ea043"
 }


### PR DESCRIPTION
Updates the repository traffic badge metrics from GitHub's rolling 14-day traffic API.

This PR is created automatically by the Repository Traffic Badges workflow.
