### PR TITLE
Fix sequence-based sellability for unlocked lots

### DIFF
--- a/backend/handlers/bets/selling/sellpositionhandler.go
+++ b/backend/handlers/bets/selling/sellpositionhandler.go
@@ -125,6 +125,18 @@ func handleSellError(w http.ResponseWriter, err error) {
 		return
 	}
 
+	var projectionErr bets.SaleProjectionNotExecutableError
+	if errors.As(err, &projectionErr) {
+		_ = handlers.WriteFailureWithDetails(
+			w,
+			http.StatusUnprocessableEntity,
+			handlers.ReasonInsufficientShares,
+			bets.ProjectionInexecutableSaleMessage,
+			saleProjectionDetails(projectionErr.Details),
+		)
+		return
+	}
+
 	switch {
 	case errors.Is(err, bets.ErrInvalidOutcome), errors.Is(err, bets.ErrInvalidAmount):
 		_ = handlers.WriteFailure(w, http.StatusBadRequest, handlers.ReasonValidationFailed)
@@ -164,6 +176,21 @@ func handleSellError(w http.ResponseWriter, err error) {
 		_ = handlers.WriteFailure(w, http.StatusNotFound, handlers.ReasonMarketNotFound)
 	default:
 		_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+	}
+}
+
+func saleProjectionDetails(details bets.SaleProjectionDetails) map[string]any {
+	return map[string]any{
+		"outcome":                      details.Outcome,
+		"requestedCredits":             details.RequestedCredits,
+		"positionValue":                details.PositionValue,
+		"positionOutcomeShares":        details.PositionOutcomeShares,
+		"nominalUnlockedValue":         details.NominalUnlockedValue,
+		"nominalUnlockedOutcomeShares": details.NominalUnlockedOutcomeShares,
+		"projectedPositionValue":       details.ProjectedPositionValue,
+		"projectedOutcomeShares":       details.ProjectedOutcomeShares,
+		"executableSaleValue":          details.ExecutableSaleValue,
+		"hint":                         "This Position has value, but the requested Sale Order does not currently reduce the backend-projected position enough to pay credits safely.",
 	}
 }
 

--- a/backend/handlers/bets/selling/sellpositionhandler.go
+++ b/backend/handlers/bets/selling/sellpositionhandler.go
@@ -190,7 +190,7 @@ func saleProjectionDetails(details bets.SaleProjectionDetails) map[string]any {
 		"projectedPositionValue":       details.ProjectedPositionValue,
 		"projectedOutcomeShares":       details.ProjectedOutcomeShares,
 		"executableSaleValue":          details.ExecutableSaleValue,
-		"hint":                         "This Position has value, but the requested Sale Order does not currently reduce the backend-projected position enough to pay credits safely.",
+		"hint":                         bets.ProjectionInexecutableSaleHint,
 	}
 }
 

--- a/backend/handlers/bets/selling/sellpositionhandler_test.go
+++ b/backend/handlers/bets/selling/sellpositionhandler_test.go
@@ -434,6 +434,95 @@ func TestSellQuoteHandler_InsufficientSharesIncludesUserGuidance(t *testing.T) {
 	}
 }
 
+func TestSellQuoteHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(t *testing.T) {
+	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
+	svc := &fakeSellService{quoteErr: bets.SaleProjectionNotExecutableError{Details: bets.SaleProjectionDetails{
+		Outcome:                      "NO",
+		RequestedCredits:             17,
+		PositionValue:                34,
+		PositionOutcomeShares:        34,
+		NominalUnlockedValue:         17,
+		NominalUnlockedOutcomeShares: 17,
+		ProjectedPositionValue:       34,
+		ProjectedOutcomeShares:       34,
+		ExecutableSaleValue:          0,
+	}}}
+	users := &fakeUsersService{user: &dusers.User{Username: "testuser03"}}
+
+	body, _ := json.Marshal(dto.SellBetRequest{MarketID: 1, Amount: 17, Outcome: "NO"})
+	req := httptest.NewRequest(http.MethodPost, "/v0/sell/quote", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+modelstesting.GenerateValidJWT("testuser03"))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	SellQuoteHandler(svc, users).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+	var resp handlers.FailureEnvelope
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode failure envelope: %v", err)
+	}
+	if resp.Reason != string(handlers.ReasonInsufficientShares) {
+		t.Fatalf("expected insufficient-shares reason, got %q", resp.Reason)
+	}
+	if resp.Message != bets.ProjectionInexecutableSaleMessage {
+		t.Fatalf("expected projection message, got %q", resp.Message)
+	}
+	if resp.Details["outcome"] != "NO" ||
+		resp.Details["requestedCredits"] != float64(17) ||
+		resp.Details["positionValue"] != float64(34) ||
+		resp.Details["nominalUnlockedValue"] != float64(17) ||
+		resp.Details["projectedPositionValue"] != float64(34) ||
+		resp.Details["executableSaleValue"] != float64(0) {
+		t.Fatalf("unexpected projection details: %+v", resp.Details)
+	}
+}
+
+func TestSellPositionHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(t *testing.T) {
+	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
+	svc := &fakeSellService{err: bets.SaleProjectionNotExecutableError{Details: bets.SaleProjectionDetails{
+		Outcome:                      "NO",
+		RequestedCredits:             17,
+		PositionValue:                34,
+		PositionOutcomeShares:        34,
+		NominalUnlockedValue:         17,
+		NominalUnlockedOutcomeShares: 17,
+		ProjectedPositionValue:       34,
+		ProjectedOutcomeShares:       34,
+		ExecutableSaleValue:          0,
+	}}}
+	users := &fakeUsersService{user: &dusers.User{Username: "testuser03"}}
+
+	body, _ := json.Marshal(dto.SellBetRequest{MarketID: 1, Amount: 17, Outcome: "NO"})
+	req := httptest.NewRequest(http.MethodPost, "/v0/sell", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+modelstesting.GenerateValidJWT("testuser03"))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	SellPositionHandler(svc, users).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+	var resp handlers.FailureEnvelope
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode failure envelope: %v", err)
+	}
+	if resp.Reason != string(handlers.ReasonInsufficientShares) {
+		t.Fatalf("expected insufficient-shares reason, got %q", resp.Reason)
+	}
+	if resp.Message != bets.ProjectionInexecutableSaleMessage {
+		t.Fatalf("expected projection message, got %q", resp.Message)
+	}
+	if resp.Details["positionOutcomeShares"] != float64(34) ||
+		resp.Details["nominalUnlockedOutcomeShares"] != float64(17) ||
+		resp.Details["projectedOutcomeShares"] != float64(34) {
+		t.Fatalf("unexpected share details: %+v", resp.Details)
+	}
+}
+
 func TestSellPositionHandler_InvalidJSON(t *testing.T) {
 	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
 	svc := &fakeSellService{}

--- a/backend/handlers/bets/selling/sellpositionhandler_test.go
+++ b/backend/handlers/bets/selling/sellpositionhandler_test.go
@@ -467,15 +467,17 @@ func TestSellQuoteHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(t *
 	if resp.Reason != string(handlers.ReasonInsufficientShares) {
 		t.Fatalf("expected insufficient-shares reason, got %q", resp.Reason)
 	}
-	if resp.Message != bets.ProjectionInexecutableSaleMessage {
-		t.Fatalf("expected projection message, got %q", resp.Message)
+	const expectedMessage = "This value is not sellable yet. Wait for more market activity, then try again."
+	if resp.Message != expectedMessage {
+		t.Fatalf("expected projection message %q, got %q", expectedMessage, resp.Message)
 	}
 	if resp.Details["outcome"] != "NO" ||
 		resp.Details["requestedCredits"] != float64(17) ||
 		resp.Details["positionValue"] != float64(34) ||
 		resp.Details["nominalUnlockedValue"] != float64(17) ||
 		resp.Details["projectedPositionValue"] != float64(34) ||
-		resp.Details["executableSaleValue"] != float64(0) {
+		resp.Details["executableSaleValue"] != float64(0) ||
+		resp.Details["hint"] != "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value." {
 		t.Fatalf("unexpected projection details: %+v", resp.Details)
 	}
 }
@@ -513,12 +515,14 @@ func TestSellPositionHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(
 	if resp.Reason != string(handlers.ReasonInsufficientShares) {
 		t.Fatalf("expected insufficient-shares reason, got %q", resp.Reason)
 	}
-	if resp.Message != bets.ProjectionInexecutableSaleMessage {
-		t.Fatalf("expected projection message, got %q", resp.Message)
+	const expectedMessage = "This value is not sellable yet. Wait for more market activity, then try again."
+	if resp.Message != expectedMessage {
+		t.Fatalf("expected projection message %q, got %q", expectedMessage, resp.Message)
 	}
 	if resp.Details["positionOutcomeShares"] != float64(34) ||
 		resp.Details["nominalUnlockedOutcomeShares"] != float64(17) ||
-		resp.Details["projectedOutcomeShares"] != float64(34) {
+		resp.Details["projectedOutcomeShares"] != float64(34) ||
+		resp.Details["hint"] != "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value." {
 		t.Fatalf("unexpected share details: %+v", resp.Details)
 	}
 }

--- a/backend/handlers/bets/selling/sellpositionhandler_test.go
+++ b/backend/handlers/bets/selling/sellpositionhandler_test.go
@@ -477,7 +477,7 @@ func TestSellQuoteHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(t *
 		resp.Details["nominalUnlockedValue"] != float64(17) ||
 		resp.Details["projectedPositionValue"] != float64(34) ||
 		resp.Details["executableSaleValue"] != float64(0) ||
-		resp.Details["hint"] != "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value." {
+		resp.Details["hint"] != "Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value." {
 		t.Fatalf("unexpected projection details: %+v", resp.Details)
 	}
 }
@@ -522,7 +522,7 @@ func TestSellPositionHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(
 	if resp.Details["positionOutcomeShares"] != float64(34) ||
 		resp.Details["nominalUnlockedOutcomeShares"] != float64(17) ||
 		resp.Details["projectedOutcomeShares"] != float64(34) ||
-		resp.Details["hint"] != "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value." {
+		resp.Details["hint"] != "Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value." {
 		t.Fatalf("unexpected share details: %+v", resp.Details)
 	}
 }

--- a/backend/internal/domain/bets/bet_sell.go
+++ b/backend/internal/domain/bets/bet_sell.go
@@ -63,7 +63,7 @@ func (s *Service) QuoteSell(ctx context.Context, req SellRequest) (*SellQuoteRes
 	}
 	if allowed {
 		bet := req.NewSaleBet(outcome, sale.SharesToSell, s.clock.Now())
-		if err := validateProjectedSale(ctx, s.markets, req, outcome, currentPosition, sale, *bet); err != nil {
+		if err := validateProjectedSale(ctx, s.markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
 			return nil, err
 		}
 	}
@@ -97,7 +97,7 @@ func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcom
 
 		now := s.clock.Now()
 		bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
-		if err := validateProjectedSale(txCtx, markets, req, outcome, currentPosition, sale, *bet); err != nil {
+		if err := validateProjectedSale(txCtx, markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
 			return err
 		}
 		if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, netSaleProceeds(sale)); err != nil {
@@ -172,6 +172,7 @@ func validateProjectedSale(
 	req SellRequest,
 	outcome string,
 	current *dmarkets.UserPosition,
+	sellable *dmarkets.UserPosition,
 	sale SaleQuote,
 	saleBet boundary.Bet,
 ) error {
@@ -182,10 +183,10 @@ func validateProjectedSale(
 	if err != nil {
 		return err
 	}
-	return validateSaleProjection(current, projected, outcome, sale)
+	return validateSaleProjection(req, current, sellable, projected, outcome, sale)
 }
 
-func validateSaleProjection(current *dmarkets.UserPosition, projected *dmarkets.UserPosition, outcome string, sale SaleQuote) error {
+func validateSaleProjection(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, projected *dmarkets.UserPosition, outcome string, sale SaleQuote) error {
 	if current == nil {
 		return ErrNoPosition
 	}
@@ -202,7 +203,7 @@ func validateSaleProjection(current *dmarkets.UserPosition, projected *dmarkets.
 		return err
 	}
 	if currentSoldShares-projectedSoldShares < sale.SharesToSell {
-		return ErrInsufficientShares
+		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
 	}
 
 	currentOppositeShares, err := sharesForOutcome(current, oppositeOutcome(outcome))
@@ -214,7 +215,7 @@ func validateSaleProjection(current *dmarkets.UserPosition, projected *dmarkets.
 		return err
 	}
 	if projectedOppositeShares > currentOppositeShares {
-		return ErrInsufficientShares
+		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
 	}
 
 	maxProjectedValue := current.Value - sale.SaleValue
@@ -222,7 +223,7 @@ func validateSaleProjection(current *dmarkets.UserPosition, projected *dmarkets.
 		maxProjectedValue = 0
 	}
 	if projected.Value > maxProjectedValue {
-		return ErrInsufficientShares
+		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
 	}
 
 	return nil
@@ -316,6 +317,37 @@ func sharesForOutcome(pos *dmarkets.UserPosition, outcome string) (int64, error)
 	default:
 		return 0, ErrInvalidOutcome
 	}
+}
+
+func newSaleProjectionNotExecutableError(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, projected *dmarkets.UserPosition, outcome string) SaleProjectionNotExecutableError {
+	return SaleProjectionNotExecutableError{
+		Details: SaleProjectionDetails{
+			Outcome:                      outcome,
+			RequestedCredits:             req.Amount,
+			PositionValue:                positionValueOrZero(current),
+			PositionOutcomeShares:        sharesForOutcomeOrZero(current, outcome),
+			NominalUnlockedValue:         positionValueOrZero(sellable),
+			NominalUnlockedOutcomeShares: sharesForOutcomeOrZero(sellable, outcome),
+			ProjectedPositionValue:       positionValueOrZero(projected),
+			ProjectedOutcomeShares:       sharesForOutcomeOrZero(projected, outcome),
+			ExecutableSaleValue:          0,
+		},
+	}
+}
+
+func positionValueOrZero(pos *dmarkets.UserPosition) int64 {
+	if pos == nil {
+		return 0
+	}
+	return pos.Value
+}
+
+func sharesForOutcomeOrZero(pos *dmarkets.UserPosition, outcome string) int64 {
+	shares, err := sharesForOutcome(pos, outcome)
+	if err != nil {
+		return 0
+	}
+	return shares
 }
 
 func oppositeOutcome(outcome string) string {

--- a/backend/internal/domain/bets/bet_sell.go
+++ b/backend/internal/domain/bets/bet_sell.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"sort"
 
-	"socialpredict/internal/domain/boundary"
 	dmarkets "socialpredict/internal/domain/markets"
 )
 
@@ -62,8 +61,7 @@ func (s *Service) QuoteSell(ctx context.Context, req SellRequest) (*SellQuoteRes
 		allowed = false
 	}
 	if allowed {
-		bet := req.NewSaleBet(outcome, sale.SharesToSell, s.clock.Now())
-		if err := validateProjectedSale(ctx, s.markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
+		if err := validateSaleWithinSellableInventory(req, currentPosition, sellablePosition, sellableShares, sale, outcome); err != nil {
 			return nil, err
 		}
 	}
@@ -97,7 +95,7 @@ func (s *Service) sellInTransaction(ctx context.Context, req SellRequest, outcom
 
 		now := s.clock.Now()
 		bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
-		if err := validateProjectedSale(txCtx, markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
+		if err := validateSaleWithinSellableInventory(req, currentPosition, sellablePosition, sellableShares, sale, outcome); err != nil {
 			return err
 		}
 		if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, netSaleProceeds(sale)); err != nil {
@@ -166,66 +164,19 @@ func loadUserSalePositionsFrom(ctx context.Context, markets PositionReader, req 
 	return currentShares, currentPosition, sellableShares, sellablePosition, nil
 }
 
-func validateProjectedSale(
-	ctx context.Context,
-	markets PositionProjector,
-	req SellRequest,
-	outcome string,
-	current *dmarkets.UserPosition,
-	sellable *dmarkets.UserPosition,
-	sale SaleQuote,
-	saleBet boundary.Bet,
-) error {
-	if sale.SharesToSell <= 0 {
-		return ErrInsufficientShares
-	}
-	projected, err := markets.ProjectUserPositionAfterBet(ctx, int64(req.MarketID), req.Username, saleBet)
-	if err != nil {
-		return err
-	}
-	return validateSaleProjection(req, current, sellable, projected, outcome, sale)
-}
-
-func validateSaleProjection(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, projected *dmarkets.UserPosition, outcome string, sale SaleQuote) error {
+func validateSaleWithinSellableInventory(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, sellableShares int64, sale SaleQuote, outcome string) error {
 	if current == nil {
 		return ErrNoPosition
 	}
-	if projected == nil {
-		projected = &dmarkets.UserPosition{}
+	if sellable == nil || sellableShares <= 0 || sellable.Value <= 0 {
+		return ErrNoSellableShares
 	}
-
-	currentSoldShares, err := sharesForOutcome(current, outcome)
-	if err != nil {
-		return err
+	if sale.SharesToSell <= 0 {
+		return ErrInsufficientShares
 	}
-	projectedSoldShares, err := sharesForOutcome(projected, outcome)
-	if err != nil {
-		return err
+	if sale.SharesToSell > sellableShares || sale.SaleValue > sellable.Value {
+		return newSaleProjectionNotExecutableError(req, current, sellable, sellable, outcome)
 	}
-	if currentSoldShares-projectedSoldShares < sale.SharesToSell {
-		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
-	}
-
-	currentOppositeShares, err := sharesForOutcome(current, oppositeOutcome(outcome))
-	if err != nil {
-		return err
-	}
-	projectedOppositeShares, err := sharesForOutcome(projected, oppositeOutcome(outcome))
-	if err != nil {
-		return err
-	}
-	if projectedOppositeShares > currentOppositeShares {
-		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
-	}
-
-	maxProjectedValue := current.Value - sale.SaleValue
-	if maxProjectedValue < 0 {
-		maxProjectedValue = 0
-	}
-	if projected.Value > maxProjectedValue {
-		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
-	}
-
 	return nil
 }
 
@@ -348,17 +299,6 @@ func sharesForOutcomeOrZero(pos *dmarkets.UserPosition, outcome string) int64 {
 		return 0
 	}
 	return shares
-}
-
-func oppositeOutcome(outcome string) string {
-	switch outcome {
-	case "YES":
-		return "NO"
-	case "NO":
-		return "YES"
-	default:
-		return ""
-	}
 }
 
 func validatePositionValue(value int64) error {

--- a/backend/internal/domain/bets/errors.go
+++ b/backend/internal/domain/bets/errors.go
@@ -56,6 +56,40 @@ const NoSellableSharesMessage = "No sellable shares yet. Initial value cannot be
 
 const InsufficientSellableSharesMessage = "Not enough sellable shares for that sale amount. Try a smaller Sale Order amount, or wait for more market activity if your latest shares are still locked."
 
+const ProjectionInexecutableSaleMessage = "Position value exists, but this Sale Order is not executable right now. Market accounting requires a sale to reduce your projected position before credits can be paid out. Wait for more market activity, then try again."
+
+// SaleProjectionDetails exposes requester-only values explaining why a Sale
+// Order failed the backend projection invariant.
+type SaleProjectionDetails struct {
+	Outcome                      string
+	RequestedCredits             int64
+	PositionValue                int64
+	PositionOutcomeShares        int64
+	NominalUnlockedValue         int64
+	NominalUnlockedOutcomeShares int64
+	ProjectedPositionValue       int64
+	ProjectedOutcomeShares       int64
+	ExecutableSaleValue          int64
+}
+
+// SaleProjectionNotExecutableError keeps the public insufficient-shares
+// contract while carrying backend-computed explanation details.
+type SaleProjectionNotExecutableError struct {
+	Details SaleProjectionDetails
+}
+
+func (e SaleProjectionNotExecutableError) Error() string {
+	return ProjectionInexecutableSaleMessage
+}
+
+func (e SaleProjectionNotExecutableError) Message() string {
+	return ProjectionInexecutableSaleMessage
+}
+
+func (e SaleProjectionNotExecutableError) Unwrap() error {
+	return ErrInsufficientShares
+}
+
 // ErrDustCapExceeded is returned when a sell transaction would generate dust above the configured cap.
 type ErrDustCapExceeded struct {
 	Cap       int64

--- a/backend/internal/domain/bets/errors.go
+++ b/backend/internal/domain/bets/errors.go
@@ -58,7 +58,7 @@ const InsufficientSellableSharesMessage = "Not enough sellable shares for that s
 
 const ProjectionInexecutableSaleMessage = "This value is not sellable yet. Wait for more market activity, then try again."
 
-const ProjectionInexecutableSaleHint = "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
+const ProjectionInexecutableSaleHint = "Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
 
 // SaleProjectionDetails exposes requester-only values explaining why a Sale
 // Order failed the backend projection invariant.

--- a/backend/internal/domain/bets/errors.go
+++ b/backend/internal/domain/bets/errors.go
@@ -56,7 +56,9 @@ const NoSellableSharesMessage = "No sellable shares yet. Initial value cannot be
 
 const InsufficientSellableSharesMessage = "Not enough sellable shares for that sale amount. Try a smaller Sale Order amount, or wait for more market activity if your latest shares are still locked."
 
-const ProjectionInexecutableSaleMessage = "Position value exists, but this Sale Order is not executable right now. Market accounting requires a sale to reduce your projected position before credits can be paid out. Wait for more market activity, then try again."
+const ProjectionInexecutableSaleMessage = "This value is not sellable yet. Wait for more market activity, then try again."
+
+const ProjectionInexecutableSaleHint = "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
 
 // SaleProjectionDetails exposes requester-only values explaining why a Sale
 // Order failed the backend projection invariant.

--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -934,6 +934,86 @@ func TestServiceSell_RejectsProjectedSaleThatKeepsTooMuchValue(t *testing.T) {
 	}
 }
 
+func TestServiceQuoteSell_ProjectionInexecutableSaleIncludesRequesterOnlyDetails(t *testing.T) {
+	now := serviceTestTime()
+	current := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	sellable := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 17, Value: 17}
+	projected := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	_, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(1),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(current),
+		func(f *serviceFixture) {
+			f.markets.positions.getUserSellablePositionInMarketFunc = func(context.Context, int64, string, string) (*dmarkets.UserPosition, error) {
+				return sellable, nil
+			}
+		},
+		withFixtureProjection(projected),
+		withFixtureUser(&dusers.User{Username: "testuser03"}),
+	)
+
+	_, err := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "testuser03", MarketID: 1, Amount: 17, Outcome: "NO"})
+	if !errors.Is(err, bets.ErrInsufficientShares) {
+		t.Fatalf("expected ErrInsufficientShares, got %v", err)
+	}
+	var projectionErr bets.SaleProjectionNotExecutableError
+	if !errors.As(err, &projectionErr) {
+		t.Fatalf("expected SaleProjectionNotExecutableError, got %T %v", err, err)
+	}
+	details := projectionErr.Details
+	if details.Outcome != "NO" || details.RequestedCredits != 17 {
+		t.Fatalf("unexpected request details: %+v", details)
+	}
+	if details.PositionValue != 34 || details.PositionOutcomeShares != 34 {
+		t.Fatalf("unexpected current position details: %+v", details)
+	}
+	if details.NominalUnlockedValue != 17 || details.NominalUnlockedOutcomeShares != 17 {
+		t.Fatalf("unexpected nominal unlocked details: %+v", details)
+	}
+	if details.ProjectedPositionValue != 34 || details.ProjectedOutcomeShares != 34 {
+		t.Fatalf("unexpected projection details: %+v", details)
+	}
+	if details.ExecutableSaleValue != 0 {
+		t.Fatalf("expected executable sale value 0, got %+v", details)
+	}
+}
+
+func TestServiceSell_ProjectionInexecutableSaleIncludesDetailsAndDoesNotMutate(t *testing.T) {
+	now := serviceTestTime()
+	current := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	sellable := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 17, Value: 17}
+	projected := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	fixture, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(1),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(current),
+		func(f *serviceFixture) {
+			f.markets.positions.getUserSellablePositionInMarketFunc = func(context.Context, int64, string, string) (*dmarkets.UserPosition, error) {
+				return sellable, nil
+			}
+		},
+		withFixtureProjection(projected),
+		withFixtureUser(&dusers.User{Username: "testuser03"}),
+	)
+
+	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "testuser03", MarketID: 1, Amount: 17, Outcome: "NO"})
+	if !errors.Is(err, bets.ErrInsufficientShares) {
+		t.Fatalf("expected ErrInsufficientShares, got %v", err)
+	}
+	var projectionErr bets.SaleProjectionNotExecutableError
+	if !errors.As(err, &projectionErr) {
+		t.Fatalf("expected SaleProjectionNotExecutableError, got %T %v", err, err)
+	}
+	if projectionErr.Details.PositionValue != 34 || projectionErr.Details.NominalUnlockedValue != 17 || projectionErr.Details.ExecutableSaleValue != 0 {
+		t.Fatalf("unexpected projection details: %+v", projectionErr.Details)
+	}
+	if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
+		t.Fatalf("projection-inexecutable sale must not mutate ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
+	}
+}
+
 func TestServiceSell_AttachmentSequenceRejectsOvercashoutBeforeTinyTail(t *testing.T) {
 	now := serviceTestTime()
 	var history []boundary.Bet

--- a/backend/internal/domain/bets/service_test.go
+++ b/backend/internal/domain/bets/service_test.go
@@ -47,6 +47,19 @@ func (f fakeSellUnit) SellBetTransaction(ctx context.Context, fn bets.SellTransa
 	return fn(ctx, f.repo, f.markets, f.users)
 }
 
+type fakeSaleCalculator struct {
+	quote bets.SaleQuote
+	err   error
+}
+
+func (f fakeSaleCalculator) Calculate(*dmarkets.UserPosition, int64, int64) (bets.SaleQuote, error) {
+	return f.quote, f.err
+}
+
+func (f fakeSaleCalculator) Quote(*dmarkets.UserPosition, int64, int64) (bets.SaleQuote, error) {
+	return f.quote, f.err
+}
+
 func newFakeRepo(opts ...func(*fakeRepo)) *fakeRepo {
 	repo := &fakeRepo{
 		writer: fakeBetWriter{
@@ -461,6 +474,20 @@ func serviceTestTime() time.Time {
 	return time.Date(2026, time.February, 3, 4, 5, 6, 0, time.UTC)
 }
 
+func positionToDomainUserPosition(marketID int64, username string, position positionsmath.UserMarketPosition) *dmarkets.UserPosition {
+	return &dmarkets.UserPosition{
+		Username:         username,
+		MarketID:         marketID,
+		YesSharesOwned:   position.YesSharesOwned,
+		NoSharesOwned:    position.NoSharesOwned,
+		Value:            position.Value,
+		TotalSpent:       position.TotalSpent,
+		TotalSpentInPlay: position.TotalSpentInPlay,
+		IsResolved:       position.IsResolved,
+		ResolutionResult: position.ResolutionResult,
+	}
+}
+
 func TestServicePlace_Succeeds(t *testing.T) {
 	now := serviceTestTime()
 	fixture, svc := newServiceFixture(
@@ -643,7 +670,7 @@ func TestServiceSell_OneCreditShareDoesNotCashOutHistoricalVolume(t *testing.T) 
 	}
 }
 
-func TestServiceSell_FullPositionSellRequiresZeroProjectedValue(t *testing.T) {
+func TestServiceSell_FullPositionSellUsesSellableInventory(t *testing.T) {
 	now := serviceTestTime()
 
 	t.Run("full position sell succeeds at zero projected value", func(t *testing.T) {
@@ -671,7 +698,7 @@ func TestServiceSell_FullPositionSellRequiresZeroProjectedValue(t *testing.T) {
 		}
 	})
 
-	t.Run("full position sell rejects residual projected value", func(t *testing.T) {
+	t.Run("full position sell succeeds even if aggregate projection would retain value", func(t *testing.T) {
 		fixture, svc := newServiceFixture(
 			now,
 			withFixtureMaxDust(0),
@@ -681,12 +708,18 @@ func TestServiceSell_FullPositionSellRequiresZeroProjectedValue(t *testing.T) {
 			withFixtureUser(&dusers.User{Username: "alice"}),
 		)
 
-		_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 100, Outcome: "YES"})
-		if !errors.Is(err, bets.ErrInsufficientShares) {
-			t.Fatalf("expected residual projected value to return ErrInsufficientShares, got %v", err)
+		result, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 100, Outcome: "YES"})
+		if err != nil {
+			t.Fatalf("Sell returned error: %v", err)
 		}
-		if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
-			t.Fatalf("residual projected value must not mutate ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
+		if result.SharesSold != 10 || result.SaleValue != 100 || result.NetProceeds != 100 {
+			t.Fatalf("unexpected full-position sell result: %+v", result)
+		}
+		if fixture.repo.created == nil || fixture.repo.created.Amount != -10 {
+			t.Fatalf("unexpected sale ledger row: %+v", fixture.repo.created)
+		}
+		if len(fixture.users.calls) != 1 || fixture.users.calls[0].amount != 100 {
+			t.Fatalf("unexpected user credit: %+v", fixture.users.calls)
 		}
 	})
 }
@@ -873,148 +906,53 @@ func TestServiceQuoteSell_OverCapRoundsPreviewToCap(t *testing.T) {
 	}
 }
 
-func TestServiceQuoteSell_RejectsUnsafeProjectedSale(t *testing.T) {
+func TestServiceSell_RejectsCalculatorResultBeyondSellableInventoryBeforeMutatingLedger(t *testing.T) {
 	now := serviceTestTime()
-	_, svc := newServiceFixture(
-		now,
-		withFixtureMaxDust(1),
-		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
-		withFixturePosition(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 2, Value: 502}),
-		withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, NoSharesOwned: 2, Value: 500}),
-		withFixtureUser(&dusers.User{Username: "alice"}),
+	current := &dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 2, Value: 2}
+	sellable := &dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 1, Value: 1}
+	repo := newFakeRepo()
+	markets := newFakeMarkets(
+		withFakeMarket(func(context.Context, int64) (*dmarkets.Market, error) {
+			return &dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}, nil
+		}),
+		withFakePosition(func(context.Context, int64, string) (*dmarkets.UserPosition, error) {
+			return current, nil
+		}),
+		withFakeSellablePosition(func(context.Context, int64, string, string) (*dmarkets.UserPosition, error) {
+			return sellable, nil
+		}),
+	)
+	users := newFakeUsers(
+		withFakeUserLookup(func(context.Context, string) (*dusers.User, error) {
+			return &dusers.User{Username: "alice"}, nil
+		}),
+	)
+	svc := bets.NewService(
+		repo,
+		markets,
+		users,
+		bets.Config{MaxDustPerSale: 1, MaximumDebtAllowed: 10000},
+		newFixedClock(now),
+		bets.WithSaleCalculator(fakeSaleCalculator{quote: bets.SaleQuote{
+			RequestedCredits: 3,
+			SharesToSell:     3,
+			SaleValue:        3,
+			Dust:             0,
+			ValuePerShare:    1,
+		}}),
+		bets.WithSellUnitOfWork(fakeSellUnit{repo: repo, markets: markets, users: users}),
 	)
 
-	_, err := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 502, Outcome: "YES"})
-	if !errors.Is(err, bets.ErrInsufficientShares) {
-		t.Fatalf("expected unsafe projected quote to return ErrInsufficientShares, got %v", err)
-	}
-}
-
-func TestServiceSell_RejectsUnsafeProjectedSaleBeforeMutatingLedger(t *testing.T) {
-	now := serviceTestTime()
-	current := &dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 2, Value: 502}
-	fixture, svc := newServiceFixture(
-		now,
-		withFixtureMaxDust(1),
-		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
-		withFixturePosition(current),
-		withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 0, NoSharesOwned: 2, Value: 500}),
-		withFixtureUser(&dusers.User{Username: "alice"}),
-	)
-
-	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 502, Outcome: "YES"})
-	if !errors.Is(err, bets.ErrInsufficientShares) {
-		t.Fatalf("expected unsafe projected sale to return ErrInsufficientShares, got %v", err)
-	}
-	if fixture.repo.created != nil {
-		t.Fatalf("unsafe sale must not create a ledger row: %+v", fixture.repo.created)
-	}
-	if len(fixture.users.calls) != 0 {
-		t.Fatalf("unsafe sale must not credit user ledger: %+v", fixture.users.calls)
-	}
-}
-
-func TestServiceSell_RejectsProjectedSaleThatKeepsTooMuchValue(t *testing.T) {
-	now := serviceTestTime()
-	fixture, svc := newServiceFixture(
-		now,
-		withFixtureMaxDust(0),
-		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
-		withFixturePosition(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 10, Value: 100}),
-		withFixtureProjection(&dmarkets.UserPosition{Username: "alice", MarketID: 1, YesSharesOwned: 7, Value: 80}),
-		withFixtureUser(&dusers.User{Username: "alice"}),
-	)
-
-	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 30, Outcome: "YES"})
-	if !errors.Is(err, bets.ErrInsufficientShares) {
-		t.Fatalf("expected inflated projected value to return ErrInsufficientShares, got %v", err)
-	}
-	if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
-		t.Fatalf("inflated projection must not mutate ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
-	}
-}
-
-func TestServiceQuoteSell_ProjectionInexecutableSaleIncludesRequesterOnlyDetails(t *testing.T) {
-	now := serviceTestTime()
-	current := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
-	sellable := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 17, Value: 17}
-	projected := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
-	_, svc := newServiceFixture(
-		now,
-		withFixtureMaxDust(1),
-		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
-		withFixturePosition(current),
-		func(f *serviceFixture) {
-			f.markets.positions.getUserSellablePositionInMarketFunc = func(context.Context, int64, string, string) (*dmarkets.UserPosition, error) {
-				return sellable, nil
-			}
-		},
-		withFixtureProjection(projected),
-		withFixtureUser(&dusers.User{Username: "testuser03"}),
-	)
-
-	_, err := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "testuser03", MarketID: 1, Amount: 17, Outcome: "NO"})
+	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 3, Outcome: "YES"})
 	if !errors.Is(err, bets.ErrInsufficientShares) {
 		t.Fatalf("expected ErrInsufficientShares, got %v", err)
 	}
-	var projectionErr bets.SaleProjectionNotExecutableError
-	if !errors.As(err, &projectionErr) {
-		t.Fatalf("expected SaleProjectionNotExecutableError, got %T %v", err, err)
-	}
-	details := projectionErr.Details
-	if details.Outcome != "NO" || details.RequestedCredits != 17 {
-		t.Fatalf("unexpected request details: %+v", details)
-	}
-	if details.PositionValue != 34 || details.PositionOutcomeShares != 34 {
-		t.Fatalf("unexpected current position details: %+v", details)
-	}
-	if details.NominalUnlockedValue != 17 || details.NominalUnlockedOutcomeShares != 17 {
-		t.Fatalf("unexpected nominal unlocked details: %+v", details)
-	}
-	if details.ProjectedPositionValue != 34 || details.ProjectedOutcomeShares != 34 {
-		t.Fatalf("unexpected projection details: %+v", details)
-	}
-	if details.ExecutableSaleValue != 0 {
-		t.Fatalf("expected executable sale value 0, got %+v", details)
+	if repo.created != nil || len(users.calls) != 0 {
+		t.Fatalf("invalid inventory sale must not mutate ledger: repo=%+v users=%+v", repo.created, users.calls)
 	}
 }
 
-func TestServiceSell_ProjectionInexecutableSaleIncludesDetailsAndDoesNotMutate(t *testing.T) {
-	now := serviceTestTime()
-	current := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
-	sellable := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 17, Value: 17}
-	projected := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
-	fixture, svc := newServiceFixture(
-		now,
-		withFixtureMaxDust(1),
-		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
-		withFixturePosition(current),
-		func(f *serviceFixture) {
-			f.markets.positions.getUserSellablePositionInMarketFunc = func(context.Context, int64, string, string) (*dmarkets.UserPosition, error) {
-				return sellable, nil
-			}
-		},
-		withFixtureProjection(projected),
-		withFixtureUser(&dusers.User{Username: "testuser03"}),
-	)
-
-	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "testuser03", MarketID: 1, Amount: 17, Outcome: "NO"})
-	if !errors.Is(err, bets.ErrInsufficientShares) {
-		t.Fatalf("expected ErrInsufficientShares, got %v", err)
-	}
-	var projectionErr bets.SaleProjectionNotExecutableError
-	if !errors.As(err, &projectionErr) {
-		t.Fatalf("expected SaleProjectionNotExecutableError, got %T %v", err, err)
-	}
-	if projectionErr.Details.PositionValue != 34 || projectionErr.Details.NominalUnlockedValue != 17 || projectionErr.Details.ExecutableSaleValue != 0 {
-		t.Fatalf("unexpected projection details: %+v", projectionErr.Details)
-	}
-	if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
-		t.Fatalf("projection-inexecutable sale must not mutate ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
-	}
-}
-
-func TestServiceSell_AttachmentSequenceRejectsOvercashoutBeforeTinyTail(t *testing.T) {
+func TestServiceSell_AttachmentSequenceCapsOvercashoutBeforeTinyTail(t *testing.T) {
 	now := serviceTestTime()
 	var history []boundary.Bet
 	nextNow := now
@@ -1126,17 +1064,155 @@ func TestServiceSell_AttachmentSequenceRejectsOvercashoutBeforeTinyTail(t *testi
 	}
 
 	beforeRows := len(history)
-	_, quoteErr := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 507, Outcome: "NO"})
-	if !errors.Is(quoteErr, bets.ErrInsufficientShares) {
-		t.Fatalf("expected quote for attachment seq 19 over-cashout to return ErrInsufficientShares, got %v", quoteErr)
+	quote, quoteErr := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 507, Outcome: "NO"})
+	if quoteErr != nil {
+		t.Fatalf("expected quote for attachment seq 19 over-cashout to cap safely, got %v", quoteErr)
+	}
+	if !quote.Allowed || quote.SharesSold != 22 || quote.SaleValue != 22 || quote.Dust != 1 || quote.NetProceeds != 21 {
+		t.Fatalf("expected quote to cap oversized request to remaining unlocked inventory, got %+v", quote)
+	}
+	if quote.SharesSold <= 4 && quote.NetProceeds >= 400 {
+		t.Fatalf("quote recreated tiny-tail over-cashout: %+v", quote)
 	}
 
-	_, sellErr := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 507, Outcome: "NO"})
-	if !errors.Is(sellErr, bets.ErrInsufficientShares) {
-		t.Fatalf("expected sell for attachment seq 19 over-cashout to return ErrInsufficientShares, got %v", sellErr)
+	sell, sellErr := svc.Sell(context.Background(), bets.SellRequest{Username: "alice", MarketID: 1, Amount: 507, Outcome: "NO"})
+	if sellErr != nil {
+		t.Fatalf("expected sell for attachment seq 19 over-cashout to cap safely, got %v", sellErr)
 	}
-	if len(history) != beforeRows {
-		t.Fatalf("rejected over-cashout must not append a sale row: before=%d after=%d", beforeRows, len(history))
+	if sell.SharesSold != quote.SharesSold || sell.SaleValue != quote.SaleValue || sell.Dust != quote.Dust || sell.NetProceeds != quote.NetProceeds {
+		t.Fatalf("sell result did not match quote: quote=%+v sell=%+v", quote, sell)
+	}
+	if sell.SharesSold <= 4 && sell.NetProceeds >= 400 {
+		t.Fatalf("sell recreated tiny-tail over-cashout: %+v", sell)
+	}
+	if len(history) != beforeRows+1 {
+		t.Fatalf("safe capped sale should append one sale row: before=%d after=%d", beforeRows, len(history))
+	}
+	if history[len(history)-1].Amount != -quote.SharesSold {
+		t.Fatalf("sale row should record capped sold shares, got %+v quote=%+v", history[len(history)-1], quote)
+	}
+}
+
+func TestServiceQuoteSell_SequenceBasedUnlockedValueRemainsExecutableAfterLaterOwnBuy(t *testing.T) {
+	now := serviceTestTime()
+	market := &dmarkets.Market{
+		ID:                 1,
+		Status:             "active",
+		ResolutionDateTime: now.Add(24 * time.Hour),
+		CreatedAt:          now.Add(-time.Hour),
+	}
+	snapshot := positionsmath.MarketSnapshot{ID: market.ID, CreatedAt: market.CreatedAt}
+	history := []boundary.Bet{
+		{Username: "testuser02", MarketID: 1, Amount: 50, Outcome: "NO", PlacedAt: now.Add(-6 * time.Minute), CreatedAt: now.Add(-6 * time.Minute)},
+		{Username: "testuser03", MarketID: 1, Amount: 25, Outcome: "NO", PlacedAt: now.Add(-5 * time.Minute), CreatedAt: now.Add(-5 * time.Minute)},
+		{Username: "testuser02", MarketID: 1, Amount: -75, Outcome: "NO", PlacedAt: now.Add(-4 * time.Minute), CreatedAt: now.Add(-4 * time.Minute)},
+		{Username: "testuser02", MarketID: 1, Amount: 75, Outcome: "NO", PlacedAt: now.Add(-3 * time.Minute), CreatedAt: now.Add(-3 * time.Minute)},
+		{Username: "testuser03", MarketID: 1, Amount: 10, Outcome: "NO", PlacedAt: now.Add(-2 * time.Minute), CreatedAt: now.Add(-2 * time.Minute)},
+		{Username: "testuser02", MarketID: 1, Amount: 20, Outcome: "NO", PlacedAt: now.Add(-time.Minute), CreatedAt: now.Add(-time.Minute)},
+	}
+
+	positionFor := func(username string, extra *boundary.Bet) (*dmarkets.UserPosition, error) {
+		projectedHistory := append([]boundary.Bet(nil), history...)
+		if extra != nil {
+			projectedHistory = append(projectedHistory, *extra)
+		}
+		position, err := positionsmath.CalculateMarketPositionForUser_WPAM_DBPM(snapshot, projectedHistory, username)
+		if err != nil {
+			return nil, err
+		}
+		return positionToDomainUserPosition(market.ID, username, position), nil
+	}
+	sellableFor := func(username string, outcome string, extra *boundary.Bet) (*dmarkets.UserPosition, error) {
+		projectedHistory := append([]boundary.Bet(nil), history...)
+		if extra != nil {
+			projectedHistory = append(projectedHistory, *extra)
+		}
+		position, err := positionsmath.CalculateUnlockedSellablePosition_WPAM_DBPM(snapshot, projectedHistory, username, outcome)
+		if err != nil {
+			return nil, err
+		}
+		return positionToDomainUserPosition(market.ID, username, position), nil
+	}
+
+	tests := []struct {
+		username          string
+		wantShares        int64
+		wantValue         int64
+		wantSellableValue int64
+	}{
+		{username: "testuser02", wantShares: 70, wantValue: 70, wantSellableValue: 17},
+		{username: "testuser03", wantShares: 35, wantValue: 35, wantSellableValue: 35},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.username, func(t *testing.T) {
+			repo := newFakeRepo(
+				withFakeRepoCreate(func(context.Context, *boundary.Bet) error { return nil }),
+				withFakeRepoHasBet(func(_ context.Context, marketID uint, username string) (bool, error) {
+					for _, bet := range history {
+						if bet.MarketID == marketID && bet.Username == username {
+							return true, nil
+						}
+					}
+					return false, nil
+				}),
+			)
+			markets := newFakeMarkets(
+				withFakeMarket(func(context.Context, int64) (*dmarkets.Market, error) { return market, nil }),
+				withFakePosition(func(_ context.Context, _ int64, username string) (*dmarkets.UserPosition, error) {
+					return positionFor(username, nil)
+				}),
+				withFakeSellablePosition(func(_ context.Context, _ int64, username string, outcome string) (*dmarkets.UserPosition, error) {
+					return sellableFor(username, outcome, nil)
+				}),
+				withFakePositionProjection(func(_ context.Context, _ int64, username string, bet boundary.Bet) (*dmarkets.UserPosition, error) {
+					return positionFor(username, &bet)
+				}),
+			)
+			users := newFakeUsers(
+				withFakeUserLookup(func(context.Context, string) (*dusers.User, error) {
+					return &dusers.User{Username: tc.username, AccountBalance: 10000}, nil
+				}),
+				withFakeApplyTransaction(func(context.Context, string, int64, string) error { return nil }),
+			)
+			svc := bets.NewService(
+				repo,
+				markets,
+				users,
+				bets.Config{MaxDustPerSale: 1, MaximumDebtAllowed: 10000},
+				newFixedClock(now),
+				bets.WithPlaceUnitOfWork(fakePlaceUnit{repo: repo, users: users}),
+				bets.WithSellUnitOfWork(fakeSellUnit{repo: repo, markets: markets, users: users}),
+			)
+
+			current, err := positionFor(tc.username, nil)
+			if err != nil {
+				t.Fatalf("calculate current position: %v", err)
+			}
+			sellable, err := sellableFor(tc.username, "NO", nil)
+			if err != nil {
+				t.Fatalf("calculate sellable position: %v", err)
+			}
+			if current.NoSharesOwned != tc.wantShares || current.Value != tc.wantValue {
+				t.Fatalf("expected current no=%d value=%d, got %+v", tc.wantShares, tc.wantValue, current)
+			}
+			if sellable.Value != tc.wantSellableValue {
+				t.Fatalf("expected sellable value %d, got %+v", tc.wantSellableValue, sellable)
+			}
+
+			quote, err := svc.QuoteSell(context.Background(), bets.SellRequest{
+				Username: tc.username,
+				MarketID: 1,
+				Amount:   1,
+				Outcome:  "NO",
+			})
+			if err != nil {
+				t.Fatalf("expected prior unlocked value to remain executable after later same-user buy, got %v", err)
+			}
+			if !quote.Allowed || quote.SharesSold <= 0 || quote.SaleValue <= 0 {
+				t.Fatalf("expected executable quote from unlocked value, got %+v", quote)
+			}
+		})
 	}
 }
 

--- a/backend/internal/domain/math/positions/positionsmath_test.go
+++ b/backend/internal/domain/math/positions/positionsmath_test.go
@@ -336,6 +336,62 @@ func TestCalculateUnlockedSellablePosition_WPAM_DBPM(t *testing.T) {
 			username: "carol",
 			outcome:  "NO",
 		},
+		{
+			name: "prior sale consumes unlocked value before later same-user buy",
+			bets: []struct {
+				Amount   int64
+				Outcome  string
+				Username string
+				Offset   time.Duration
+			}{
+				{Amount: 50, Outcome: "NO", Username: "alice", Offset: 0},
+				{Amount: 25, Outcome: "NO", Username: "bob", Offset: time.Minute},
+				{Amount: -75, Outcome: "NO", Username: "alice", Offset: 2 * time.Minute},
+				{Amount: 75, Outcome: "NO", Username: "alice", Offset: 3 * time.Minute},
+			},
+			username: "alice",
+			outcome:  "NO",
+		},
+		{
+			name: "reported mixed sequence leaves prior unlocked value executable for both users",
+			bets: []struct {
+				Amount   int64
+				Outcome  string
+				Username string
+				Offset   time.Duration
+			}{
+				{Amount: 50, Outcome: "NO", Username: "alice", Offset: 0},
+				{Amount: 25, Outcome: "NO", Username: "bob", Offset: time.Minute},
+				{Amount: -75, Outcome: "NO", Username: "alice", Offset: 2 * time.Minute},
+				{Amount: 75, Outcome: "NO", Username: "alice", Offset: 3 * time.Minute},
+				{Amount: 10, Outcome: "NO", Username: "bob", Offset: 4 * time.Minute},
+				{Amount: 20, Outcome: "NO", Username: "alice", Offset: 5 * time.Minute},
+			},
+			username: "alice",
+			outcome:  "NO",
+			wantNo:   17,
+			wantVal:  17,
+		},
+		{
+			name: "reported mixed sequence keeps counterparty unlocked value executable",
+			bets: []struct {
+				Amount   int64
+				Outcome  string
+				Username string
+				Offset   time.Duration
+			}{
+				{Amount: 50, Outcome: "NO", Username: "alice", Offset: 0},
+				{Amount: 25, Outcome: "NO", Username: "bob", Offset: time.Minute},
+				{Amount: -75, Outcome: "NO", Username: "alice", Offset: 2 * time.Minute},
+				{Amount: 75, Outcome: "NO", Username: "alice", Offset: 3 * time.Minute},
+				{Amount: 10, Outcome: "NO", Username: "bob", Offset: 4 * time.Minute},
+				{Amount: 20, Outcome: "NO", Username: "alice", Offset: 5 * time.Minute},
+			},
+			username: "bob",
+			outcome:  "NO",
+			wantNo:   35,
+			wantVal:  35,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/domain/math/positions/sellable.go
+++ b/backend/internal/domain/math/positions/sellable.go
@@ -56,12 +56,7 @@ func CalculateUnlockedSellablePosition_WPAM_DBPM(snapshot MarketSnapshot, bets [
 	}
 
 	payouts := CalculateBetPayouts_WPAM_DBPM(snapshot, bets)
-	unlockedShares := int64(0)
-	for i, payout := range payouts {
-		if isUnlockedBuy(payouts, i, username, outcome) && payout.Payout > 0 {
-			unlockedShares += payout.Payout
-		}
-	}
+	unlockedShares := deriveRemainingUnlockedShares(payouts, username, outcome)
 	if unlockedShares > currentShares {
 		unlockedShares = currentShares
 	}
@@ -96,22 +91,64 @@ func CalculateUnlockedSellablePosition_WPAM_DBPM(snapshot MarketSnapshot, bets [
 	return position, nil
 }
 
-func isUnlockedBuy(payouts []BetPayout, index int, username string, outcome string) bool {
-	if index < 0 || index >= len(payouts) {
-		return false
-	}
-	bet := payouts[index].Bet
-	if bet.Username != username || bet.Outcome != outcome || bet.Amount <= 0 {
-		return false
-	}
+type unlockedLot struct {
+	remainingShares int64
+}
 
-	for i := index + 1; i < len(payouts); i++ {
-		later := payouts[i].Bet
-		if later.Amount > 0 && later.Username != username {
-			return true
+func deriveRemainingUnlockedShares(payouts []BetPayout, username string, outcome string) int64 {
+	lots := make([]unlockedLot, 0)
+	unlockedEnd := 0
+	consumeHead := 0
+
+	for _, payout := range payouts {
+		bet := payout.Bet
+		if bet.Amount > 0 && bet.Username == username && bet.Outcome == outcome && payout.Payout > 0 {
+			lots = append(lots, unlockedLot{remainingShares: payout.Payout})
+		}
+		if bet.Amount > 0 && bet.Username != username {
+			unlockedEnd = len(lots)
+		}
+		if bet.Amount < 0 && bet.Username == username && bet.Outcome == outcome {
+			consumeHead = consumeUnlockedLots(lots, consumeHead, unlockedEnd, -bet.Amount)
 		}
 	}
-	return false
+
+	return sumRemainingUnlockedLots(lots, consumeHead, unlockedEnd)
+}
+
+func consumeUnlockedLots(lots []unlockedLot, consumeHead int, unlockedEnd int, shares int64) int {
+	if consumeHead < 0 {
+		consumeHead = 0
+	}
+	if unlockedEnd > len(lots) {
+		unlockedEnd = len(lots)
+	}
+	for shares > 0 && consumeHead < unlockedEnd {
+		consumed := lots[consumeHead].remainingShares
+		if consumed > shares {
+			consumed = shares
+		}
+		lots[consumeHead].remainingShares -= consumed
+		shares -= consumed
+		if lots[consumeHead].remainingShares == 0 {
+			consumeHead++
+		}
+	}
+	return consumeHead
+}
+
+func sumRemainingUnlockedLots(lots []unlockedLot, consumeHead int, unlockedEnd int) int64 {
+	if consumeHead < 0 {
+		consumeHead = 0
+	}
+	if unlockedEnd > len(lots) {
+		unlockedEnd = len(lots)
+	}
+	total := int64(0)
+	for i := consumeHead; i < unlockedEnd; i++ {
+		total += lots[i].remainingShares
+	}
+	return total
 }
 
 func sharesForPositionOutcome(position UserMarketPosition, outcome string) int64 {

--- a/backend/seed/seed.go
+++ b/backend/seed/seed.go
@@ -12,6 +12,7 @@ import (
 	"socialpredict/handlers/cms/homepage"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func getEnv(key string) (string, error) {
@@ -36,9 +37,10 @@ func SeedUsers(db *gorm.DB, configService configsvc.Service) error {
 		return fmt.Errorf("ADMIN_PASSWORD is set but empty")
 	}
 
-	// Check if the admin user already exists.
 	var count int64
-	db.Model(&models.User{}).Where("username = ?", "admin").Count(&count)
+	if err := db.Model(&models.User{}).Where("username = ?", "admin").Count(&count).Error; err != nil {
+		return fmt.Errorf("check admin user: %w", err)
+	}
 	if count == 0 {
 		adminUser := models.User{
 			PublicUser: models.PublicUser{
@@ -61,7 +63,10 @@ func SeedUsers(db *gorm.DB, configService configsvc.Service) error {
 			return fmt.Errorf("hash admin password: %w", err)
 		}
 
-		if err := db.Create(&adminUser).Error; err != nil {
+		if err := db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "username"}},
+			DoNothing: true,
+		}).Create(&adminUser).Error; err != nil {
 			return fmt.Errorf("create admin user: %w", err)
 		}
 	}

--- a/backend/seed/seed_users_test.go
+++ b/backend/seed/seed_users_test.go
@@ -6,6 +6,8 @@ import (
 	configsvc "socialpredict/internal/service/config"
 	"socialpredict/models"
 	"socialpredict/models/modelstesting"
+
+	"gorm.io/gorm"
 )
 
 type panicOnCurrentSeedConfigService struct {
@@ -63,6 +65,56 @@ func TestSeedUsersCreatesAdminUsingInjectedConfig(t *testing.T) {
 	}
 	if admin.AccountBalance != 321 {
 		t.Fatalf("expected injected account balance 321, got %d", admin.AccountBalance)
+	}
+}
+
+func TestSeedUsersToleratesConcurrentAdminInsert(t *testing.T) {
+	db := modelstesting.NewFakeDB(t)
+	t.Setenv("ADMIN_PASSWORD", "secret-password")
+
+	injected := false
+	err := db.Callback().Create().Before("gorm:create").Register("test:insert_admin_during_seed", func(tx *gorm.DB) {
+		if injected || tx.Statement.Schema == nil || tx.Statement.Schema.Table != "users" {
+			return
+		}
+
+		user, ok := tx.Statement.Dest.(*models.User)
+		if !ok || user.Username != "admin" {
+			return
+		}
+
+		injected = true
+		concurrentAdmin := modelstesting.GenerateUser("admin", 777)
+		concurrentAdmin.UserType = "ADMIN"
+		concurrentAdmin.DisplayName = "Concurrent Admin"
+		concurrentAdmin.Email = "concurrent-admin@example.com"
+		concurrentAdmin.APIKey = "concurrent-admin-api-key"
+		if err := concurrentAdmin.HashPassword("concurrent-password"); err != nil {
+			tx.AddError(err)
+			return
+		}
+
+		if err := tx.Session(&gorm.Session{NewDB: true}).Create(&concurrentAdmin).Error; err != nil {
+			tx.AddError(err)
+		}
+	})
+	if err != nil {
+		t.Fatalf("register create callback: %v", err)
+	}
+
+	cfg := modelstesting.GenerateEconomicConfig()
+	cfg.Economics.User.InitialAccountBalance = 321
+
+	if err := SeedUsers(db, configsvc.NewStaticService(cfg)); err != nil {
+		t.Fatalf("SeedUsers should tolerate a concurrently inserted admin user, got: %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&models.User{}).Where("username = ?", "admin").Count(&count).Error; err != nil {
+		t.Fatalf("count admin users: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one admin user, got %d", count)
 	}
 }
 

--- a/docs/superpowers/plans/2026-07-22-projection-aware-sell-quote.md
+++ b/docs/superpowers/plans/2026-07-22-projection-aware-sell-quote.md
@@ -1,0 +1,1248 @@
+# Projection-Aware Sell Quote Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `$subagent-driven-development` (recommended, if installed) or `$executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make backend quote/sell the sole authority for executable Sale Orders, return requester-only projection details for rejected unsafe sales, and update the frontend to display backend-owned explanations without computing trading math.
+
+**Architecture:** The backend keeps ownership of DBPM accounting and projection safety. Rejected projection-inexecutable sales keep the existing `422 INSUFFICIENT_SHARES` public contract while adding backend-computed `details` for explanation. The frontend routes trade calls through an API adapter, preserves backend error details, and only formats values returned by the backend.
+
+**Tech Stack:** Go backend domain/HTTP handlers, existing SocialPredict API envelopes, Node HTTP integration scripts, React/Vite frontend, focused Vitest tests for adapter behavior if frontend test dependency setup is added during execution.
+
+## Global Constraints
+
+- Backend quote and sell simulation are the only source of truth for Sale Order executability.
+- Preserve public request DTOs and success response DTOs for `/v0/sell/quote` and `/v0/sell`.
+- Keep rejected unsafe sales on the existing `422 INSUFFICIENT_SHARES` path.
+- Include requester-only diagnostic values in the existing error-envelope `details` object.
+- The frontend must not calculate unlocked value, projected position reduction, dust, sale proceeds, or domain sellability.
+- Frontend trade calls should pass through adapter seams instead of direct `fetch`, `localStorage`, or raw API-envelope handling.
+- Do not change DBPM settlement economics.
+- Do not add durable backend state or database migrations.
+- Do not introduce Redux, RTK Query, server-managed sessions, browser telemetry, CSP work, offline behavior, or broad frontend platform changes.
+- Public trading failure copy should originate from the backend when it describes domain/accounting state.
+
+---
+
+## File Structure
+
+- Modify `backend/internal/domain/bets/errors.go`
+  - Owns exported projection-inexecutable error type and requester-only detail struct.
+- Modify `backend/internal/domain/bets/bet_sell.go`
+  - Populates projection details from current, nominal sellable, and projected backend positions.
+- Modify `backend/internal/domain/bets/service_test.go`
+  - Adds red/green domain tests for quote/sell projection details and no mutation.
+- Modify `backend/handlers/bets/selling/sellpositionhandler.go`
+  - Maps the new internal error to existing `INSUFFICIENT_SHARES` failure envelope with details.
+- Modify `backend/handlers/bets/selling/sellpositionhandler_test.go`
+  - Adds HTTP envelope regression tests.
+- Modify `integrationtest/scripts/sell-shares-overcashout.mjs`
+  - Replays the two-user reported sequence and asserts backend detail fields.
+- Modify `integrationtest/cases/sell-shares-overcashout.md`
+  - Documents projection-inexecutable failure coverage.
+- Modify `integrationtest/README.md`
+  - Updates current coverage notes.
+- Modify `frontend/src/api/httpClient.js`
+  - Preserves `details` and raw backend payload on thrown API errors.
+- Create `frontend/src/api/tradeApi.js`
+  - Adapter for buy, position, quote, sell, and setup-fee calls.
+- Create `frontend/src/api/tradeApi.test.jsx`
+  - Focused adapter test for preserving projection details.
+- Modify `frontend/package.json` and `frontend/package-lock.json` only if Vitest is not locally runnable during execution.
+  - Adds a local `test` script and missing dev dependencies needed by the repo's existing frontend tests.
+- Modify `frontend/src/components/layouts/trade/TradeUtils.jsx`
+  - Removes direct transport logic and delegates to `tradeApi`.
+- Modify `frontend/src/components/layouts/trade/BuySharesLayout.jsx`
+  - Loads fee data through the adapter.
+- Modify `frontend/src/components/layouts/trade/SellSharesLayout.jsx`
+  - Treats Position Value as informational, removes aggregate-value sale clamp, and displays backend projection details.
+
+---
+
+### Task 1: Backend Domain Projection Details
+
+**Files:**
+- Modify: `backend/internal/domain/bets/errors.go`
+- Modify: `backend/internal/domain/bets/bet_sell.go`
+- Test: `backend/internal/domain/bets/service_test.go`
+
+**Interfaces:**
+- Consumes: existing `ErrInsufficientShares`, `SellRequest`, `SaleQuote`, `dmarkets.UserPosition`.
+- Produces:
+  - `const ProjectionInexecutableSaleMessage string`
+  - `type SaleProjectionDetails struct`
+  - `type SaleProjectionNotExecutableError struct`
+  - `func (e SaleProjectionNotExecutableError) Error() string`
+  - `func (e SaleProjectionNotExecutableError) Message() string`
+  - `func (e SaleProjectionNotExecutableError) Unwrap() error`
+
+- [ ] **Step 1: Write failing service tests**
+
+Append these tests near the existing unsafe projected sale tests in `backend/internal/domain/bets/service_test.go`:
+
+```go
+func TestServiceQuoteSell_ProjectionInexecutableSaleIncludesRequesterOnlyDetails(t *testing.T) {
+	now := serviceTestTime()
+	current := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	sellable := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 17, Value: 17}
+	projected := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	_, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(1),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(current),
+		func(f *serviceFixture) {
+			f.markets.positions.getUserSellablePositionInMarketFunc = func(context.Context, int64, string, string) (*dmarkets.UserPosition, error) {
+				return sellable, nil
+			}
+		},
+		withFixtureProjection(projected),
+		withFixtureUser(&dusers.User{Username: "testuser03"}),
+	)
+
+	_, err := svc.QuoteSell(context.Background(), bets.SellRequest{Username: "testuser03", MarketID: 1, Amount: 17, Outcome: "NO"})
+	if !errors.Is(err, bets.ErrInsufficientShares) {
+		t.Fatalf("expected ErrInsufficientShares, got %v", err)
+	}
+	var projectionErr bets.SaleProjectionNotExecutableError
+	if !errors.As(err, &projectionErr) {
+		t.Fatalf("expected SaleProjectionNotExecutableError, got %T %v", err, err)
+	}
+	details := projectionErr.Details
+	if details.Outcome != "NO" || details.RequestedCredits != 17 {
+		t.Fatalf("unexpected request details: %+v", details)
+	}
+	if details.PositionValue != 34 || details.PositionOutcomeShares != 34 {
+		t.Fatalf("unexpected current position details: %+v", details)
+	}
+	if details.NominalUnlockedValue != 17 || details.NominalUnlockedOutcomeShares != 17 {
+		t.Fatalf("unexpected nominal unlocked details: %+v", details)
+	}
+	if details.ProjectedPositionValue != 34 || details.ProjectedOutcomeShares != 34 {
+		t.Fatalf("unexpected projection details: %+v", details)
+	}
+	if details.ExecutableSaleValue != 0 {
+		t.Fatalf("expected executable sale value 0, got %+v", details)
+	}
+}
+
+func TestServiceSell_ProjectionInexecutableSaleIncludesDetailsAndDoesNotMutate(t *testing.T) {
+	now := serviceTestTime()
+	current := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	sellable := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 17, Value: 17}
+	projected := &dmarkets.UserPosition{Username: "testuser03", MarketID: 1, NoSharesOwned: 34, Value: 34}
+	fixture, svc := newServiceFixture(
+		now,
+		withFixtureMaxDust(1),
+		withFixtureMarket(&dmarkets.Market{ID: 1, Status: "active", ResolutionDateTime: now.Add(24 * time.Hour)}),
+		withFixturePosition(current),
+		func(f *serviceFixture) {
+			f.markets.positions.getUserSellablePositionInMarketFunc = func(context.Context, int64, string, string) (*dmarkets.UserPosition, error) {
+				return sellable, nil
+			}
+		},
+		withFixtureProjection(projected),
+		withFixtureUser(&dusers.User{Username: "testuser03"}),
+	)
+
+	_, err := svc.Sell(context.Background(), bets.SellRequest{Username: "testuser03", MarketID: 1, Amount: 17, Outcome: "NO"})
+	if !errors.Is(err, bets.ErrInsufficientShares) {
+		t.Fatalf("expected ErrInsufficientShares, got %v", err)
+	}
+	var projectionErr bets.SaleProjectionNotExecutableError
+	if !errors.As(err, &projectionErr) {
+		t.Fatalf("expected SaleProjectionNotExecutableError, got %T %v", err, err)
+	}
+	if projectionErr.Details.PositionValue != 34 || projectionErr.Details.NominalUnlockedValue != 17 || projectionErr.Details.ExecutableSaleValue != 0 {
+		t.Fatalf("unexpected projection details: %+v", projectionErr.Details)
+	}
+	if fixture.repo.created != nil || len(fixture.users.calls) != 0 {
+		t.Fatalf("projection-inexecutable sale must not mutate ledger: repo=%+v users=%+v", fixture.repo.created, fixture.users.calls)
+	}
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify red**
+
+Run:
+
+```bash
+(cd backend && go test ./internal/domain/bets -run 'TestService(QuoteSell|Sell)_ProjectionInexecutableSale' -count=1)
+```
+
+Expected: FAIL because `bets.SaleProjectionNotExecutableError` does not exist.
+
+- [ ] **Step 3: Add domain error/details types**
+
+Add this code to `backend/internal/domain/bets/errors.go` after the existing sell message constants:
+
+```go
+const ProjectionInexecutableSaleMessage = "Position value exists, but this Sale Order is not executable right now. Market accounting requires a sale to reduce your projected position before credits can be paid out. Wait for more market activity, then try again."
+
+type SaleProjectionDetails struct {
+	Outcome                       string
+	RequestedCredits              int64
+	PositionValue                 int64
+	PositionOutcomeShares         int64
+	NominalUnlockedValue          int64
+	NominalUnlockedOutcomeShares  int64
+	ProjectedPositionValue        int64
+	ProjectedOutcomeShares        int64
+	ExecutableSaleValue           int64
+}
+
+type SaleProjectionNotExecutableError struct {
+	Details SaleProjectionDetails
+}
+
+func (e SaleProjectionNotExecutableError) Error() string {
+	return ProjectionInexecutableSaleMessage
+}
+
+func (e SaleProjectionNotExecutableError) Message() string {
+	return ProjectionInexecutableSaleMessage
+}
+
+func (e SaleProjectionNotExecutableError) Unwrap() error {
+	return ErrInsufficientShares
+}
+```
+
+Run `gofmt` after adding the type. If `gofmt` aligns struct fields differently, keep the formatter output.
+
+- [ ] **Step 4: Populate the error from projection validation**
+
+In `backend/internal/domain/bets/bet_sell.go`, change both calls to `validateProjectedSale` so they pass `sellablePosition`:
+
+```go
+if err := validateProjectedSale(ctx, s.markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
+	return nil, err
+}
+```
+
+and:
+
+```go
+if err := validateProjectedSale(txCtx, markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
+	return err
+}
+```
+
+Update the function signatures and validation helper:
+
+```go
+func validateProjectedSale(
+	ctx context.Context,
+	markets PositionProjector,
+	req SellRequest,
+	outcome string,
+	current *dmarkets.UserPosition,
+	sellable *dmarkets.UserPosition,
+	sale SaleQuote,
+	saleBet boundary.Bet,
+) error {
+	if sale.SharesToSell <= 0 {
+		return ErrInsufficientShares
+	}
+	projected, err := markets.ProjectUserPositionAfterBet(ctx, int64(req.MarketID), req.Username, saleBet)
+	if err != nil {
+		return err
+	}
+	return validateSaleProjection(req, current, sellable, projected, outcome, sale)
+}
+
+func validateSaleProjection(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, projected *dmarkets.UserPosition, outcome string, sale SaleQuote) error {
+	if current == nil {
+		return ErrNoPosition
+	}
+	if projected == nil {
+		projected = &dmarkets.UserPosition{}
+	}
+
+	currentSoldShares, err := sharesForOutcome(current, outcome)
+	if err != nil {
+		return err
+	}
+	projectedSoldShares, err := sharesForOutcome(projected, outcome)
+	if err != nil {
+		return err
+	}
+	if currentSoldShares-projectedSoldShares < sale.SharesToSell {
+		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
+	}
+
+	currentOppositeShares, err := sharesForOutcome(current, oppositeOutcome(outcome))
+	if err != nil {
+		return err
+	}
+	projectedOppositeShares, err := sharesForOutcome(projected, oppositeOutcome(outcome))
+	if err != nil {
+		return err
+	}
+	if projectedOppositeShares > currentOppositeShares {
+		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
+	}
+
+	maxProjectedValue := current.Value - sale.SaleValue
+	if maxProjectedValue < 0 {
+		maxProjectedValue = 0
+	}
+	if projected.Value > maxProjectedValue {
+		return newSaleProjectionNotExecutableError(req, current, sellable, projected, outcome)
+	}
+
+	return nil
+}
+```
+
+Add helpers near `sharesForOutcome`:
+
+```go
+func newSaleProjectionNotExecutableError(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, projected *dmarkets.UserPosition, outcome string) SaleProjectionNotExecutableError {
+	return SaleProjectionNotExecutableError{
+		Details: SaleProjectionDetails{
+			Outcome:                      outcome,
+			RequestedCredits:             req.Amount,
+			PositionValue:                positionValueOrZero(current),
+			PositionOutcomeShares:        sharesForOutcomeOrZero(current, outcome),
+			NominalUnlockedValue:         positionValueOrZero(sellable),
+			NominalUnlockedOutcomeShares: sharesForOutcomeOrZero(sellable, outcome),
+			ProjectedPositionValue:       positionValueOrZero(projected),
+			ProjectedOutcomeShares:       sharesForOutcomeOrZero(projected, outcome),
+			ExecutableSaleValue:          0,
+		},
+	}
+}
+
+func positionValueOrZero(pos *dmarkets.UserPosition) int64 {
+	if pos == nil {
+		return 0
+	}
+	return pos.Value
+}
+
+func sharesForOutcomeOrZero(pos *dmarkets.UserPosition, outcome string) int64 {
+	shares, err := sharesForOutcome(pos, outcome)
+	if err != nil {
+		return 0
+	}
+	return shares
+}
+```
+
+- [ ] **Step 5: Run red test again and verify green**
+
+Run:
+
+```bash
+gofmt -w backend/internal/domain/bets/errors.go backend/internal/domain/bets/bet_sell.go backend/internal/domain/bets/service_test.go
+(cd backend && go test ./internal/domain/bets -run 'TestService(QuoteSell|Sell)_ProjectionInexecutableSale' -count=1)
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused domain sell tests**
+
+Run:
+
+```bash
+(cd backend && go test ./internal/domain/bets -run 'TestService(Sell|QuoteSell)' -count=1)
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add backend/internal/domain/bets/errors.go backend/internal/domain/bets/bet_sell.go backend/internal/domain/bets/service_test.go
+git commit -m "fix: expose projection-inexecutable sell details"
+```
+
+---
+
+### Task 2: HTTP Handler Mapping For Projection Details
+
+**Files:**
+- Modify: `backend/handlers/bets/selling/sellpositionhandler.go`
+- Test: `backend/handlers/bets/selling/sellpositionhandler_test.go`
+
+**Interfaces:**
+- Consumes: `bets.SaleProjectionNotExecutableError`, `bets.ProjectionInexecutableSaleMessage`.
+- Produces: `422 INSUFFICIENT_SHARES` failure envelopes with backend message and requester-only `details`.
+
+- [ ] **Step 1: Write failing handler tests**
+
+Append these tests near `TestSellQuoteHandler_InsufficientSharesIncludesUserGuidance` in `backend/handlers/bets/selling/sellpositionhandler_test.go`:
+
+```go
+func TestSellQuoteHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(t *testing.T) {
+	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
+	svc := &fakeSellService{quoteErr: bets.SaleProjectionNotExecutableError{Details: bets.SaleProjectionDetails{
+		Outcome:                      "NO",
+		RequestedCredits:             17,
+		PositionValue:                34,
+		PositionOutcomeShares:        34,
+		NominalUnlockedValue:         17,
+		NominalUnlockedOutcomeShares: 17,
+		ProjectedPositionValue:       34,
+		ProjectedOutcomeShares:       34,
+		ExecutableSaleValue:          0,
+	}}}
+	users := &fakeUsersService{user: &dusers.User{Username: "testuser03"}}
+
+	body, _ := json.Marshal(dto.SellBetRequest{MarketID: 1, Amount: 17, Outcome: "NO"})
+	req := httptest.NewRequest(http.MethodPost, "/v0/sell/quote", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+modelstesting.GenerateValidJWT("testuser03"))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	SellQuoteHandler(svc, users).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+	var resp handlers.FailureEnvelope
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode failure envelope: %v", err)
+	}
+	if resp.Reason != string(handlers.ReasonInsufficientShares) {
+		t.Fatalf("expected insufficient-shares reason, got %q", resp.Reason)
+	}
+	if resp.Message != bets.ProjectionInexecutableSaleMessage {
+		t.Fatalf("expected projection message, got %q", resp.Message)
+	}
+	if resp.Details["outcome"] != "NO" ||
+		resp.Details["requestedCredits"] != float64(17) ||
+		resp.Details["positionValue"] != float64(34) ||
+		resp.Details["nominalUnlockedValue"] != float64(17) ||
+		resp.Details["projectedPositionValue"] != float64(34) ||
+		resp.Details["executableSaleValue"] != float64(0) {
+		t.Fatalf("unexpected projection details: %+v", resp.Details)
+	}
+}
+
+func TestSellPositionHandler_ProjectionInexecutableIncludesRequesterOnlyDetails(t *testing.T) {
+	t.Setenv("JWT_SIGNING_KEY", "test-secret-key-for-testing")
+	svc := &fakeSellService{err: bets.SaleProjectionNotExecutableError{Details: bets.SaleProjectionDetails{
+		Outcome:                      "NO",
+		RequestedCredits:             17,
+		PositionValue:                34,
+		PositionOutcomeShares:        34,
+		NominalUnlockedValue:         17,
+		NominalUnlockedOutcomeShares: 17,
+		ProjectedPositionValue:       34,
+		ProjectedOutcomeShares:       34,
+		ExecutableSaleValue:          0,
+	}}}
+	users := &fakeUsersService{user: &dusers.User{Username: "testuser03"}}
+
+	body, _ := json.Marshal(dto.SellBetRequest{MarketID: 1, Amount: 17, Outcome: "NO"})
+	req := httptest.NewRequest(http.MethodPost, "/v0/sell", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+modelstesting.GenerateValidJWT("testuser03"))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	SellPositionHandler(svc, users).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected status %d, got %d", http.StatusUnprocessableEntity, rr.Code)
+	}
+	var resp handlers.FailureEnvelope
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode failure envelope: %v", err)
+	}
+	if resp.Reason != string(handlers.ReasonInsufficientShares) {
+		t.Fatalf("expected insufficient-shares reason, got %q", resp.Reason)
+	}
+	if resp.Message != bets.ProjectionInexecutableSaleMessage {
+		t.Fatalf("expected projection message, got %q", resp.Message)
+	}
+	if resp.Details["positionOutcomeShares"] != float64(34) ||
+		resp.Details["nominalUnlockedOutcomeShares"] != float64(17) ||
+		resp.Details["projectedOutcomeShares"] != float64(34) {
+		t.Fatalf("unexpected share details: %+v", resp.Details)
+	}
+}
+```
+
+- [ ] **Step 2: Run handler tests and verify red**
+
+Run:
+
+```bash
+(cd backend && go test ./handlers/bets/selling -run 'TestSell(Quote|Position)Handler_ProjectionInexecutable' -count=1)
+```
+
+Expected: FAIL because the handler currently falls through to the generic insufficient-shares details.
+
+- [ ] **Step 3: Implement projection handler mapping**
+
+In `backend/handlers/bets/selling/sellpositionhandler.go`, add this block in `handleSellError` after the dust-cap block and before the `switch`:
+
+```go
+	var projectionErr bets.SaleProjectionNotExecutableError
+	if errors.As(err, &projectionErr) {
+		_ = handlers.WriteFailureWithDetails(
+			w,
+			http.StatusUnprocessableEntity,
+			handlers.ReasonInsufficientShares,
+			bets.ProjectionInexecutableSaleMessage,
+			saleProjectionDetails(projectionErr.Details),
+		)
+		return
+	}
+```
+
+Add this helper below `handleSellError`:
+
+```go
+func saleProjectionDetails(details bets.SaleProjectionDetails) map[string]any {
+	return map[string]any{
+		"outcome":                       details.Outcome,
+		"requestedCredits":              details.RequestedCredits,
+		"positionValue":                 details.PositionValue,
+		"positionOutcomeShares":         details.PositionOutcomeShares,
+		"nominalUnlockedValue":          details.NominalUnlockedValue,
+		"nominalUnlockedOutcomeShares":  details.NominalUnlockedOutcomeShares,
+		"projectedPositionValue":        details.ProjectedPositionValue,
+		"projectedOutcomeShares":        details.ProjectedOutcomeShares,
+		"executableSaleValue":           details.ExecutableSaleValue,
+		"hint":                          "This Position has value, but the requested Sale Order does not currently reduce the backend-projected position enough to pay credits safely.",
+	}
+}
+```
+
+- [ ] **Step 4: Run handler tests and verify green**
+
+Run:
+
+```bash
+gofmt -w backend/handlers/bets/selling/sellpositionhandler.go backend/handlers/bets/selling/sellpositionhandler_test.go
+(cd backend && go test ./handlers/bets/selling -run 'TestSell(Quote|Position)Handler_ProjectionInexecutable|TestSellQuoteHandler_InsufficientSharesIncludesUserGuidance|TestSellPositionHandler_ErrorMapping' -count=1)
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add backend/handlers/bets/selling/sellpositionhandler.go backend/handlers/bets/selling/sellpositionhandler_test.go
+git commit -m "fix: return sell projection details in API errors"
+```
+
+---
+
+### Task 3: HTTP Integration Coverage For Reported Sequence
+
+**Files:**
+- Modify: `integrationtest/scripts/sell-shares-overcashout.mjs`
+- Modify: `integrationtest/cases/sell-shares-overcashout.md`
+- Modify: `integrationtest/README.md`
+
+**Interfaces:**
+- Consumes: existing seeded users `admin`, `testuser01`, `testuser02`, `testuser03`.
+- Produces: integration assertions that projection-inexecutable quote/sell failures include backend-computed detail fields and do not mutate state.
+
+- [ ] **Step 1: Add failing integration assertions**
+
+In `integrationtest/scripts/sell-shares-overcashout.mjs`, add a counterparty user near the existing user constants:
+
+```js
+const counterparty = args.counterparty || 'testuser03';
+```
+
+Add this sequence near the existing attachment constants:
+
+```js
+const projectionInexecutableSequence = [
+  { seq: 1, user: 'bettor', type: 'buy', outcome: 'NO', amount: 50 },
+  { seq: 2, user: 'counterparty', type: 'buy', outcome: 'NO', amount: 25 },
+  { seq: 3, user: 'bettor', type: 'sell', outcome: 'NO', amount: 75 },
+  { seq: 4, user: 'bettor', type: 'buy', outcome: 'NO', amount: 75 },
+  { seq: 5, user: 'counterparty', type: 'buy', outcome: 'NO', amount: 10 },
+];
+
+const projectionInexecutableAttempt = { user: 'counterparty', outcome: 'NO', amount: 17 };
+```
+
+Add helpers:
+
+```js
+function message(raw) {
+  return raw?.data?.message || raw?.result?.message || '';
+}
+
+function errorDetails(raw) {
+  return raw?.data?.details || raw?.result?.details || {};
+}
+
+function assertProjectionDetails(prefix, raw) {
+  const details = errorDetails(raw);
+  check(`${prefix} includes projection message`, message(raw).includes('Position value exists'), message(raw));
+  check(`${prefix} details include outcome`, details.outcome === 'NO', JSON.stringify(details));
+  check(`${prefix} details include requested credits`, Number(details.requestedCredits) === projectionInexecutableAttempt.amount, JSON.stringify(details));
+  check(`${prefix} details include position value`, Number(details.positionValue) > 0, JSON.stringify(details));
+  check(`${prefix} details include nominal unlocked value`, Number(details.nominalUnlockedValue) > 0, JSON.stringify(details));
+  sameInt(`${prefix} details executable sale value`, details.executableSaleValue, 0);
+  check(`${prefix} details include projected position value`, Number.isFinite(Number(details.projectedPositionValue)), JSON.stringify(details));
+  check(`${prefix} details include projected outcome shares`, Number.isFinite(Number(details.projectedOutcomeShares)), JSON.stringify(details));
+}
+```
+
+Add replay and assertion helpers:
+
+```js
+async function replayProjectionInexecutableSequence(tokens, marketId) {
+  for (const step of projectionInexecutableSequence) {
+    const token = tokens[step.user];
+    if (step.type === 'buy') {
+      await place(token, marketId, step.outcome, step.amount);
+      continue;
+    }
+    const quote = (await quoteRaw(token, marketId, step.outcome, step.amount)).result;
+    check(`projection setup seq ${step.seq} quote allowed`, quote.allowed === true);
+    const sell = (await sellRaw(token, marketId, step.outcome, step.amount)).result;
+    check(`projection setup seq ${step.seq} sell succeeded`, sell.sharesSold > 0 && sell.netProceeds >= 0, `shares=${sell.sharesSold}, net=${sell.netProceeds}`);
+  }
+}
+
+async function assertProjectionInexecutableRejected({ token, username, marketId }) {
+  const beforeFinancial = await financial(username);
+  const beforePosition = await position(token, marketId);
+  const beforeDetails = await details(marketId);
+
+  check('projection setup has aggregate value', positionValue(beforePosition) > 0, `value=${positionValue(beforePosition)}`);
+  check('projection setup has NO shares', shares(beforePosition, 'NO') > 0, `shares=${shares(beforePosition, 'NO')}`);
+
+  const quote = await quoteRaw(token, marketId, projectionInexecutableAttempt.outcome, projectionInexecutableAttempt.amount, [422]);
+  check('projection-inexecutable quote rejected', quote.status === 422, `status=${quote.status}`);
+  check('projection-inexecutable quote uses insufficient-shares contract', reason(quote) === 'INSUFFICIENT_SHARES', `reason=${reason(quote)}`);
+  assertProjectionDetails('projection-inexecutable quote', quote);
+
+  const sell = await sellRaw(token, marketId, projectionInexecutableAttempt.outcome, projectionInexecutableAttempt.amount, [422]);
+  check('projection-inexecutable sell rejected', sell.status === 422, `status=${sell.status}`);
+  check('projection-inexecutable sell uses insufficient-shares contract', reason(sell) === 'INSUFFICIENT_SHARES', `reason=${reason(sell)}`);
+  assertProjectionDetails('projection-inexecutable sell', sell);
+
+  const afterFinancial = await financial(username);
+  const afterPosition = await position(token, marketId);
+  const afterDetails = await details(marketId);
+  assertUnchangedAfterRejection('projection-inexecutable', beforeFinancial, afterFinancial, beforePosition, afterPosition, beforeDetails, afterDetails);
+}
+```
+
+Update `main()` to login the counterparty and run the new projection market:
+
+```js
+  const counterpartyToken = await login(counterparty);
+  check('login seeded moderator, bettor, counterparty, admin', true);
+```
+
+and after the existing sad path:
+
+```js
+  const projectionMarketId = await createMarket('projection', modToken, adminToken);
+  await replayProjectionInexecutableSequence({ bettor: bettorToken, counterparty: counterpartyToken }, projectionMarketId);
+  await assertProjectionInexecutableRejected({
+    token: counterpartyToken,
+    username: counterparty,
+    marketId: projectionMarketId,
+  });
+```
+
+- [ ] **Step 2: Run syntax validation**
+
+Run:
+
+```bash
+node --check integrationtest/scripts/sell-shares-overcashout.mjs
+```
+
+Expected: PASS for syntax. Against a backend without Task 2, the scenario would fail on missing `details`.
+
+- [ ] **Step 3: Update integration docs**
+
+In `integrationtest/cases/sell-shares-overcashout.md`, extend the sad path section with:
+
+```md
+Projection-inexecutable path:
+
+- Replays the reported two-user NO sequence:
+  - `testuser02 NO 50`
+  - `testuser03 NO 25`
+  - `testuser02 NO -75`
+  - `testuser02 NO 75`
+  - `testuser03 NO 10`
+- Attempts the `testuser03` NO sale that has aggregate Position Value and nominal unlocked value but does not reduce the backend-projected DBPM position enough to pay credits.
+- Asserts quote and sell both return `422 INSUFFICIENT_SHARES` with backend-owned message text and requester-only projection details.
+- Asserts the rejected quote/sell do not change user balance, user position, market dust, or market volume.
+```
+
+In `integrationtest/README.md`, update the sell-shares over-cashout row to:
+
+```md
+| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers valid quote/sell, dust accounting, rejected over-cashout, and projection-inexecutable sell error details |
+```
+
+- [ ] **Step 4: Run integration scenario if local stack is available**
+
+Run after `./SocialPredict dev-bootstrap-users` and a local backend is serving:
+
+```bash
+node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0
+```
+
+Expected: PASS summary. If no local stack is running, record that this verification was not run and keep `node --check` as completed validation.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add integrationtest/scripts/sell-shares-overcashout.mjs integrationtest/cases/sell-shares-overcashout.md integrationtest/README.md
+git commit -m "test: cover projection-inexecutable sell errors"
+```
+
+---
+
+### Task 4: Frontend Trade Adapter And Sell Explanation UI
+
+**Files:**
+- Modify: `frontend/src/api/httpClient.js`
+- Create: `frontend/src/api/tradeApi.js`
+- Create: `frontend/src/api/tradeApi.test.jsx`
+- Modify: `frontend/package.json`
+- Modify: `frontend/package-lock.json`
+- Modify: `frontend/src/components/layouts/trade/TradeUtils.jsx`
+- Modify: `frontend/src/components/layouts/trade/BuySharesLayout.jsx`
+- Modify: `frontend/src/components/layouts/trade/SellSharesLayout.jsx`
+
+**Interfaces:**
+- Consumes: backend `reason`, `message`, and `details` fields from API failure envelopes.
+- Produces:
+  - `placeBet({ token, marketId, outcome, amount })`
+  - `fetchUserPosition({ token, marketId })`
+  - `quoteSale({ token, marketId, outcome, amount })`
+  - `sellShares({ token, marketId, outcome, amount })`
+  - `fetchTradingFees({ token })`
+  - `TradeUtils` callback wrappers backed by the adapter.
+
+- [ ] **Step 1: Enable focused frontend tests when missing**
+
+Check whether Vitest is runnable:
+
+```bash
+test -x frontend/node_modules/.bin/vitest && echo "vitest present" || echo "vitest missing"
+```
+
+If it prints `vitest missing`, run:
+
+```bash
+npm --prefix frontend install --save-dev vitest jsdom
+```
+
+Then add this script to `frontend/package.json`:
+
+```json
+"test": "vitest run"
+```
+
+Expected: `frontend/package-lock.json` updates if dependencies were missing.
+
+- [ ] **Step 2: Write failing adapter test**
+
+Create `frontend/src/api/tradeApi.test.jsx`:
+
+```jsx
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { quoteSale } from './tradeApi';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('tradeApi', () => {
+  it('preserves backend projection details on rejected sale quotes', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      ok: false,
+      reason: 'INSUFFICIENT_SHARES',
+      message: 'Position value exists, but this Sale Order is not executable right now.',
+      details: {
+        outcome: 'NO',
+        requestedCredits: 17,
+        positionValue: 34,
+        nominalUnlockedValue: 17,
+        projectedPositionValue: 34,
+        executableSaleValue: 0,
+      },
+    }), { status: 422, headers: { 'Content-Type': 'application/json' } })));
+
+    await expect(quoteSale({
+      token: 'token-1',
+      marketId: 7,
+      outcome: 'NO',
+      amount: 17,
+    })).rejects.toMatchObject({
+      status: 422,
+      reason: 'INSUFFICIENT_SHARES',
+      message: 'Position value exists, but this Sale Order is not executable right now.',
+      details: {
+        outcome: 'NO',
+        requestedCredits: 17,
+        positionValue: 34,
+        nominalUnlockedValue: 17,
+        projectedPositionValue: 34,
+        executableSaleValue: 0,
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the adapter test and verify red**
+
+Run:
+
+```bash
+npm --prefix frontend run test -- src/api/tradeApi.test.jsx
+```
+
+Expected: FAIL because `frontend/src/api/tradeApi.js` does not exist or because `httpClient` does not attach `details`.
+
+- [ ] **Step 4: Preserve details in `httpClient`**
+
+In `frontend/src/api/httpClient.js`, extend the non-OK branch:
+
+```js
+    if (!response.ok) {
+      const error = new Error(getApiErrorMessage(response, data, fallbackMessage, reasonMessages));
+      error.status = response.status;
+      error.reason = data?.reason || '';
+      error.details = data?.details || null;
+      error.payload = data;
+      throw error;
+    }
+```
+
+- [ ] **Step 5: Create the trade API adapter**
+
+Create `frontend/src/api/tradeApi.js`:
+
+```js
+import { apiRequest, authenticatedApiRequest } from './httpClient';
+
+export const NO_SELLABLE_SHARES_MESSAGE = [
+  'No sellable shares yet.',
+  'Initial value cannot be sold until a follow-up order from another user has been placed.',
+  'Wait for another order from another user, then try selling again.',
+].join(' ');
+
+const jsonHeaders = {
+  'Content-Type': 'application/json',
+};
+
+const validateOrder = ({ marketId, amount, outcome }, actionLabel) => {
+  if (!marketId || !amount || !outcome) {
+    throw new Error(`Missing required ${actionLabel} data (marketId, amount, outcome)`);
+  }
+  if (Number(amount) < 1) {
+    throw new Error(`${actionLabel} amount must be at least 1`);
+  }
+  if (outcome !== 'YES' && outcome !== 'NO') {
+    throw new Error(`${actionLabel} outcome must be YES or NO`);
+  }
+};
+
+export const placeBet = ({ token, marketId, outcome, amount }) => {
+  if (!token) {
+    throw new Error('Please log in to place a bet.');
+  }
+  validateOrder({ marketId, amount, outcome }, 'Bet');
+
+  return authenticatedApiRequest('/v0/bet', {
+    method: 'POST',
+    headers: jsonHeaders,
+    authToken: token,
+    body: JSON.stringify({ marketId, outcome, amount }),
+    fallbackMessage: 'Bet failed. Please try again.',
+  });
+};
+
+export const fetchUserPosition = ({ token, marketId }) => {
+  if (!token) {
+    throw new Error('Please log in again to view your Position.');
+  }
+  if (!marketId) {
+    throw new Error('Market ID is required.');
+  }
+
+  return authenticatedApiRequest(`/v0/userposition/${marketId}`, {
+    authToken: token,
+    reasonMessages: {
+      INVALID_TOKEN: 'Please log in again to view your Position.',
+      AUTHORIZATION_DENIED: 'Please log in again to view your Position.',
+      PASSWORD_CHANGE_REQUIRED: 'Please update your password before viewing your Position.',
+      NO_POSITION: NO_SELLABLE_SHARES_MESSAGE,
+    },
+    fallbackMessage: NO_SELLABLE_SHARES_MESSAGE,
+  });
+};
+
+export const quoteSale = ({ token, marketId, outcome, amount }) => {
+  if (!token) {
+    throw new Error('Please log in to sell shares.');
+  }
+  validateOrder({ marketId, amount, outcome }, 'Sale');
+
+  return authenticatedApiRequest('/v0/sell/quote', {
+    method: 'POST',
+    headers: jsonHeaders,
+    authToken: token,
+    body: JSON.stringify({ marketId, outcome, amount }),
+    fallbackMessage: 'Sale quote failed. Please try again.',
+  });
+};
+
+export const sellShares = ({ token, marketId, outcome, amount }) => {
+  if (!token) {
+    throw new Error('Please log in to sell shares.');
+  }
+  validateOrder({ marketId, amount, outcome }, 'Sale');
+
+  return authenticatedApiRequest('/v0/sell', {
+    method: 'POST',
+    headers: jsonHeaders,
+    authToken: token,
+    body: JSON.stringify({ marketId, outcome, amount }),
+    fallbackMessage: 'Sale failed. Please try again.',
+  });
+};
+
+export const fetchTradingFees = async ({ token } = {}) => {
+  const setup = await apiRequest('/v0/setup', {
+    authenticated: Boolean(token),
+    authToken: token,
+    fallbackMessage: 'Failed to load trading fees.',
+  });
+  return setup?.betting?.betFees || null;
+};
+```
+
+- [ ] **Step 6: Delegate `TradeUtils` to the adapter**
+
+Replace transport logic in `frontend/src/components/layouts/trade/TradeUtils.jsx` with:
+
+```jsx
+import {
+  fetchUserPosition,
+  NO_SELLABLE_SHARES_MESSAGE,
+  placeBet,
+  quoteSale,
+  sellShares,
+} from '../../../api/tradeApi';
+
+export { NO_SELLABLE_SHARES_MESSAGE };
+
+export const submitBet = (betData, token, onSuccess, onError) => {
+  placeBet({ token, ...betData })
+    .then(onSuccess)
+    .catch(onError);
+};
+
+export const fetchUserShares = async (marketId, token) => fetchUserPosition({ token, marketId });
+
+export const fetchSaleQuote = async (saleData, token) => quoteSale({ token, ...saleData });
+
+export const submitSale = (saleData, token, onSuccess, onError) => {
+  sellShares({ token, ...saleData })
+    .then(onSuccess)
+    .catch(onError);
+};
+```
+
+- [ ] **Step 7: Load fees through the adapter**
+
+In `frontend/src/components/layouts/trade/BuySharesLayout.jsx`, remove the `API_URL` import and add:
+
+```js
+import { fetchTradingFees } from '../../../api/tradeApi';
+```
+
+Replace the `fetchFeeData` body with:
+
+```js
+            try {
+                setFeeData(await fetchTradingFees({ token }));
+            } catch {
+                setFeeData(null);
+            } finally {
+                setIsLoading(false);
+            }
+```
+
+In `frontend/src/components/layouts/trade/SellSharesLayout.jsx`, remove the `API_URL` import, add:
+
+```js
+import { fetchTradingFees } from '../../../api/tradeApi';
+```
+
+and make the same `fetchFeeData` replacement.
+
+- [ ] **Step 8: Treat Position Value as informational in sell UI**
+
+In `frontend/src/components/layouts/trade/SellSharesLayout.jsx`:
+
+Rename:
+
+```js
+const maxSaleCredits = Math.max(0, Number(shares.value) || 0);
+```
+
+to:
+
+```js
+const positionValue = Math.max(0, Number(shares.value) || 0);
+```
+
+Change the quote error state from string to object:
+
+```js
+const [quoteError, setQuoteError] = useState(null);
+```
+
+Change all quote-error resets from `setQuoteError('')` to:
+
+```js
+setQuoteError(null);
+```
+
+Replace `handleSellAmountChange` with:
+
+```js
+    const handleSellAmountChange = (event) => {
+        const newAmount = parseInt(event.target.value, 10) || 0;
+        if (newAmount < 0) {
+            return;
+        }
+        setSaleQuote(null);
+        setQuoteError(null);
+        setSellAmount(newAmount);
+    };
+```
+
+Change both quote catch blocks to preserve the backend error:
+
+```js
+                setSaleQuote(null);
+                setQuoteError(error);
+                return null;
+```
+
+and:
+
+```js
+                alert(error.message);
+                setQuoteError(error);
+                setIsSubmitting(false);
+```
+
+Change:
+
+```js
+const sellUnavailableNotice = hasOwnedShares && maxSaleCredits <= 0
+    ? NO_SELLABLE_SHARES_MESSAGE
+    : sharesNotice;
+```
+
+to:
+
+```js
+const sellUnavailableNotice = sharesNotice;
+```
+
+Change the position display to use `positionValue`:
+
+```jsx
+<span className="text-green-300">{positionValue}</span>
+```
+
+Change the sale input from:
+
+```jsx
+max={maxSaleCredits || 1}
+```
+
+to:
+
+```jsx
+max={undefined}
+```
+
+Change `defaultSaleAmount` to:
+
+```js
+const defaultSaleAmount = () => 1;
+```
+
+- [ ] **Step 9: Render backend projection details without computing math**
+
+In `frontend/src/components/layouts/trade/SellSharesLayout.jsx`, replace the quote-error branch in `SaleQuotePanel`:
+
+```jsx
+    if (quoteError) {
+        const message = typeof quoteError === 'string' ? quoteError : quoteError.message;
+        const details = typeof quoteError === 'object' ? quoteError.details : null;
+        return (
+            <div className="mb-4 rounded-lg border border-red-400 bg-red-950/40 p-3 text-sm text-red-100">
+                <p>{message}</p>
+                <ProjectionErrorDetails details={details} />
+            </div>
+        );
+    }
+```
+
+Add this component above `QuoteMetric`:
+
+```jsx
+const ProjectionErrorDetails = ({ details }) => {
+    if (!details) {
+        return null;
+    }
+
+    const rows = [
+        ['Position Value', details.positionValue],
+        ['Nominal Unlocked Value', details.nominalUnlockedValue],
+        ['Currently Executable Sale Value', details.executableSaleValue],
+    ].filter(([, value]) => value !== undefined && value !== null);
+
+    if (rows.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="mt-3 grid gap-2 sm:grid-cols-3">
+            {rows.map(([label, value]) => (
+                <QuoteMetric key={label} label={label} value={value} />
+            ))}
+        </div>
+    );
+};
+```
+
+- [ ] **Step 10: Run frontend tests and build**
+
+Run:
+
+```bash
+npm --prefix frontend run test -- src/api/tradeApi.test.jsx
+npm --prefix frontend run build:report
+```
+
+Expected: test PASS and build PASS. Existing build warnings may remain if unrelated.
+
+- [ ] **Step 11: Commit Task 4**
+
+If `package.json` and `package-lock.json` changed:
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/src/api/httpClient.js frontend/src/api/tradeApi.js frontend/src/api/tradeApi.test.jsx frontend/src/components/layouts/trade/TradeUtils.jsx frontend/src/components/layouts/trade/BuySharesLayout.jsx frontend/src/components/layouts/trade/SellSharesLayout.jsx
+git commit -m "fix: show backend sell projection guidance in trade UI"
+```
+
+If no package files changed:
+
+```bash
+git add frontend/src/api/httpClient.js frontend/src/api/tradeApi.js frontend/src/api/tradeApi.test.jsx frontend/src/components/layouts/trade/TradeUtils.jsx frontend/src/components/layouts/trade/BuySharesLayout.jsx frontend/src/components/layouts/trade/SellSharesLayout.jsx
+git commit -m "fix: show backend sell projection guidance in trade UI"
+```
+
+---
+
+### Task 5: Final Verification And Branch Preparation
+
+**Files:**
+- Read: changed files from Tasks 1-4
+- No required source edits unless verification exposes a defect.
+
+**Interfaces:**
+- Consumes: all task outputs.
+- Produces: verified branch ready for PR.
+
+- [ ] **Step 1: Run focused backend tests**
+
+```bash
+(cd backend && go test ./internal/domain/bets ./internal/domain/math/positions ./handlers/bets/selling)
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broad backend tests**
+
+```bash
+(cd backend && JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...)
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run frontend tests and build**
+
+```bash
+npm --prefix frontend run test -- src/api/tradeApi.test.jsx
+npm --prefix frontend run build:report
+```
+
+Expected: PASS. Existing unrelated build warnings can be reported.
+
+- [ ] **Step 4: Run integration syntax checks**
+
+```bash
+node --check integrationtest/scripts/sell-shares-overcashout.mjs
+node --check integrationtest/scripts/sell-shares-two-share-cap.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run local HTTP integration when stack is available**
+
+```bash
+node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0
+```
+
+Expected: PASS. If no local backend is running, record that it was not run.
+
+- [ ] **Step 6: Inspect final diff**
+
+```bash
+git status --short
+git diff origin/main... --stat
+git diff origin/main... -- backend/internal/domain/bets/errors.go backend/internal/domain/bets/bet_sell.go backend/handlers/bets/selling/sellpositionhandler.go frontend/src/api/httpClient.js frontend/src/api/tradeApi.js frontend/src/components/layouts/trade/SellSharesLayout.jsx
+```
+
+Expected: diff contains only projection-aware sell guidance, adapter seam work, tests, and integration docs.
+
+- [ ] **Step 7: Push branch and create PR when requested**
+
+```bash
+git push -u origin HEAD
+```
+
+Use PR title:
+
+```text
+Fix projection-aware sell guidance and backend details
+```
+
+Use PR body:
+
+```md
+## Summary
+- keeps backend quote/sell projection as the only authority for executable Sale Orders
+- returns requester-only projection details on existing `422 INSUFFICIENT_SHARES` failures
+- routes trade UI calls through an API adapter and displays backend-owned sell guidance
+- extends sell over-cashout integration coverage for the reported two-user sequence
+
+## Validation
+- [ ] `(cd backend && go test ./internal/domain/bets ./internal/domain/math/positions ./handlers/bets/selling)`
+- [ ] `(cd backend && JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...)`
+- [ ] `npm --prefix frontend run test -- src/api/tradeApi.test.jsx`
+- [ ] `npm --prefix frontend run build:report`
+- [ ] `node --check integrationtest/scripts/sell-shares-overcashout.mjs`
+- [ ] `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0`
+```

--- a/docs/superpowers/plans/2026-07-22-projection-aware-sell-quote.md
+++ b/docs/superpowers/plans/2026-07-22-projection-aware-sell-quote.md
@@ -176,7 +176,9 @@ Expected: FAIL because `bets.SaleProjectionNotExecutableError` does not exist.
 Add this code to `backend/internal/domain/bets/errors.go` after the existing sell message constants:
 
 ```go
-const ProjectionInexecutableSaleMessage = "Position value exists, but this Sale Order is not executable right now. Market accounting requires a sale to reduce your projected position before credits can be paid out. Wait for more market activity, then try again."
+const ProjectionInexecutableSaleMessage = "This value is not sellable yet. Wait for more market activity, then try again."
+
+const ProjectionInexecutableSaleHint = "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
 
 type SaleProjectionDetails struct {
 	Outcome                       string
@@ -506,7 +508,7 @@ func saleProjectionDetails(details bets.SaleProjectionDetails) map[string]any {
 		"projectedPositionValue":        details.ProjectedPositionValue,
 		"projectedOutcomeShares":        details.ProjectedOutcomeShares,
 		"executableSaleValue":           details.ExecutableSaleValue,
-		"hint":                          "This Position has value, but the requested Sale Order does not currently reduce the backend-projected position enough to pay credits safely.",
+		"hint":                          bets.ProjectionInexecutableSaleHint,
 	}
 }
 ```
@@ -577,7 +579,7 @@ function errorDetails(raw) {
 
 function assertProjectionDetails(prefix, raw) {
   const details = errorDetails(raw);
-  check(`${prefix} includes projection message`, message(raw).includes('Position value exists'), message(raw));
+  check(`${prefix} includes projection message`, message(raw).includes('This value is not sellable yet'), message(raw));
   check(`${prefix} details include outcome`, details.outcome === 'NO', JSON.stringify(details));
   check(`${prefix} details include requested credits`, Number(details.requestedCredits) === projectionInexecutableAttempt.amount, JSON.stringify(details));
   check(`${prefix} details include position value`, Number(details.positionValue) > 0, JSON.stringify(details));
@@ -763,7 +765,7 @@ describe('tradeApi', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       ok: false,
       reason: 'INSUFFICIENT_SHARES',
-      message: 'Position value exists, but this Sale Order is not executable right now.',
+      message: 'This value is not sellable yet. Wait for more market activity, then try again.',
       details: {
         outcome: 'NO',
         requestedCredits: 17,
@@ -782,7 +784,7 @@ describe('tradeApi', () => {
     })).rejects.toMatchObject({
       status: 422,
       reason: 'INSUFFICIENT_SHARES',
-      message: 'Position value exists, but this Sale Order is not executable right now.',
+      message: 'This value is not sellable yet. Wait for more market activity, then try again.',
       details: {
         outcome: 'NO',
         requestedCredits: 17,

--- a/docs/superpowers/plans/2026-07-22-projection-aware-sell-quote.md
+++ b/docs/superpowers/plans/2026-07-22-projection-aware-sell-quote.md
@@ -178,7 +178,7 @@ Add this code to `backend/internal/domain/bets/errors.go` after the existing sel
 ```go
 const ProjectionInexecutableSaleMessage = "This value is not sellable yet. Wait for more market activity, then try again."
 
-const ProjectionInexecutableSaleHint = "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
+const ProjectionInexecutableSaleHint = "Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
 
 type SaleProjectionDetails struct {
 	Outcome                       string

--- a/docs/superpowers/plans/2026-07-28-stateless-unlocked-lot-sellability.md
+++ b/docs/superpowers/plans/2026-07-28-stateless-unlocked-lot-sellability.md
@@ -1,0 +1,403 @@
+# Stateless Unlocked-Lot Sellability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `$subagent-driven-development` (recommended, if installed) or `$executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make backend sell quote and settlement execute against stateless sequence-derived unlocked inventory so older unlocked value remains sellable after later same-user buys.
+
+**Architecture:** Keep DBPM as the source of current position and per-row payouts. Replace the current look-ahead sellable-share summation with an `O(n)` lot replay using `unlockedEnd` and `consumeHead`, then replace the full-position post-sale projection guard with a narrower check against derived sellable inventory. Quote and settlement continue to use the same backend repository seams; settlement remains inside `SellBetTransaction`.
+
+**Tech Stack:** Go backend domain/repository tests, existing Node HTTP integration runner, no schema migration, no frontend math.
+
+## Global Constraints
+
+- Preserve backend quote/sell as the only authority for Sale Order executability.
+- Preserve the public API contract: no request DTO changes and no success response DTO changes.
+- Keep unsafe rejected sales on the existing `422 INSUFFICIENT_SHARES` path.
+- Keep all valuation and payout math routed through DBPM.
+- Use sequence-based locking only. Do not add time-based locks.
+- Avoid durable schema changes and new persisted lot tables.
+- Let later same-user buys remain locked without relocking older value that was already unlocked.
+- Rejected sales must not create a sell ledger row, credit the user balance, increase market dust, or update market volume.
+- The derived lot replay must be `O(n)` over market rows, not `O(n^2)`.
+
+---
+
+### Task 1: Add Red Regression Coverage
+
+**Files:**
+- Modify: `backend/internal/domain/math/positions/positionsmath_test.go`
+- Modify: `backend/internal/domain/bets/service_test.go`
+
+**Interfaces:**
+- Consumes: `CalculateUnlockedSellablePosition_WPAM_DBPM(snapshot MarketSnapshot, bets []boundary.Bet, username string, outcome string) (UserMarketPosition, error)`
+- Produces: failing tests proving the expected sequence behavior before production code changes.
+
+- [ ] **Step 1: Add math regression cases**
+
+Add cases to `TestCalculateUnlockedSellablePosition_WPAM_DBPM`:
+
+```go
+{
+    name: "prior sale consumes unlocked lot before later own buy",
+    bets: []struct {
+        Amount   int64
+        Outcome  string
+        Username string
+        Offset   time.Duration
+    }{
+        {Amount: 50, Outcome: "NO", Username: "alice", Offset: 0},
+        {Amount: 25, Outcome: "NO", Username: "bob", Offset: time.Minute},
+        {Amount: -75, Outcome: "NO", Username: "alice", Offset: 2 * time.Minute},
+        {Amount: 75, Outcome: "NO", Username: "alice", Offset: 3 * time.Minute},
+        {Amount: 10, Outcome: "NO", Username: "bob", Offset: 4 * time.Minute},
+        {Amount: 20, Outcome: "NO", Username: "alice", Offset: 5 * time.Minute},
+    },
+    username: "alice",
+    outcome:  "NO",
+    wantNo:   17,
+    wantVal:  17,
+},
+{
+    name: "counterparty unlocked lots remain sellable in mixed sequence",
+    bets: []struct {
+        Amount   int64
+        Outcome  string
+        Username string
+        Offset   time.Duration
+    }{
+        {Amount: 50, Outcome: "NO", Username: "alice", Offset: 0},
+        {Amount: 25, Outcome: "NO", Username: "bob", Offset: time.Minute},
+        {Amount: -75, Outcome: "NO", Username: "alice", Offset: 2 * time.Minute},
+        {Amount: 75, Outcome: "NO", Username: "alice", Offset: 3 * time.Minute},
+        {Amount: 10, Outcome: "NO", Username: "bob", Offset: 4 * time.Minute},
+        {Amount: 20, Outcome: "NO", Username: "alice", Offset: 5 * time.Minute},
+    },
+    username: "bob",
+    outcome:  "NO",
+    wantNo:   35,
+    wantVal:  35,
+},
+```
+
+Keep the existing service-level red test `TestServiceQuoteSell_SequenceBasedUnlockedValueRemainsExecutableAfterLaterOwnBuy`.
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+cd backend
+go test ./internal/domain/math/positions -run TestCalculateUnlockedSellablePosition_WPAM_DBPM -count=1
+go test ./internal/domain/bets -run TestServiceQuoteSell_SequenceBasedUnlockedValueRemainsExecutableAfterLaterOwnBuy -count=1
+```
+
+Expected: at least one test fails because current sellable math does not consume prior sale rows and the service still rejects through `validateProjectedSale`.
+
+---
+
+### Task 2: Implement `O(n)` Derived Unlocked Inventory
+
+**Files:**
+- Modify: `backend/internal/domain/math/positions/sellable.go`
+- Test: `backend/internal/domain/math/positions/positionsmath_test.go`
+
+**Interfaces:**
+- Produces: `deriveRemainingUnlockedShares(payouts []BetPayout, username string, outcome string) int64`
+- Consumes: existing `CalculateBetPayouts_WPAM_DBPM` and `CalculateMarketPositionForUser_WPAM_DBPM`
+
+- [ ] **Step 1: Replace look-ahead summation**
+
+In `CalculateUnlockedSellablePosition_WPAM_DBPM`, replace:
+
+```go
+unlockedShares := int64(0)
+for i, payout := range payouts {
+    if isUnlockedBuy(payouts, i, username, outcome) && payout.Payout > 0 {
+        unlockedShares += payout.Payout
+    }
+}
+```
+
+with:
+
+```go
+unlockedShares := deriveRemainingUnlockedShares(payouts, username, outcome)
+```
+
+- [ ] **Step 2: Add the linear replay helper**
+
+Add this helper shape in `sellable.go`:
+
+```go
+type unlockedLot struct {
+    remainingShares int64
+}
+
+func deriveRemainingUnlockedShares(payouts []BetPayout, username string, outcome string) int64 {
+    lots := make([]unlockedLot, 0)
+    unlockedEnd := 0
+    consumeHead := 0
+
+    for _, payout := range payouts {
+        bet := payout.Bet
+        if bet.Amount > 0 && bet.Username == username && bet.Outcome == outcome && payout.Payout > 0 {
+            lots = append(lots, unlockedLot{remainingShares: payout.Payout})
+        }
+        if bet.Amount > 0 && bet.Username != username {
+            unlockedEnd = len(lots)
+        }
+        if bet.Amount < 0 && bet.Username == username && bet.Outcome == outcome {
+            consumeHead = consumeUnlockedLots(lots, consumeHead, unlockedEnd, -bet.Amount)
+        }
+    }
+
+    return sumRemainingUnlockedLots(lots, consumeHead, unlockedEnd)
+}
+```
+
+Add `consumeUnlockedLots` and `sumRemainingUnlockedLots` with bounds checks:
+
+```go
+func consumeUnlockedLots(lots []unlockedLot, consumeHead int, unlockedEnd int, shares int64) int {
+    if unlockedEnd > len(lots) {
+        unlockedEnd = len(lots)
+    }
+    for shares > 0 && consumeHead < unlockedEnd {
+        consumed := lots[consumeHead].remainingShares
+        if consumed > shares {
+            consumed = shares
+        }
+        lots[consumeHead].remainingShares -= consumed
+        shares -= consumed
+        if lots[consumeHead].remainingShares == 0 {
+            consumeHead++
+        }
+    }
+    return consumeHead
+}
+
+func sumRemainingUnlockedLots(lots []unlockedLot, consumeHead int, unlockedEnd int) int64 {
+    if consumeHead < 0 {
+        consumeHead = 0
+    }
+    if unlockedEnd > len(lots) {
+        unlockedEnd = len(lots)
+    }
+    total := int64(0)
+    for i := consumeHead; i < unlockedEnd; i++ {
+        total += lots[i].remainingShares
+    }
+    return total
+}
+```
+
+- [ ] **Step 3: Run math tests**
+
+Run:
+
+```bash
+cd backend
+go test ./internal/domain/math/positions -run TestCalculateUnlockedSellablePosition_WPAM_DBPM -count=1
+```
+
+Expected: math tests pass.
+
+---
+
+### Task 3: Replace Full-Position Projection Guard
+
+**Files:**
+- Modify: `backend/internal/domain/bets/bet_sell.go`
+- Modify: `backend/internal/domain/bets/service_test.go`
+- Test: `backend/internal/domain/bets/service_test.go`
+
+**Interfaces:**
+- Consumes: derived sellable position returned by `GetUserSellablePositionInMarket`
+- Produces: `validateSaleWithinSellableInventory(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, sellableShares int64, sale SaleQuote, outcome string) error`
+
+- [ ] **Step 1: Replace guard call in quote**
+
+In `QuoteSell`, keep dust behavior but replace the projection call with:
+
+```go
+if allowed {
+    if err := validateSaleWithinSellableInventory(req, currentPosition, sellablePosition, sellableShares, sale, outcome); err != nil {
+        return nil, err
+    }
+}
+```
+
+- [ ] **Step 2: Replace guard call in settlement**
+
+In `sellInTransaction`, keep sale bet creation before ledger write but validate inventory before crediting:
+
+```go
+now := s.clock.Now()
+bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
+if err := validateSaleWithinSellableInventory(req, currentPosition, sellablePosition, sellableShares, sale, outcome); err != nil {
+    return err
+}
+if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, netSaleProceeds(sale)); err != nil {
+    return err
+}
+```
+
+- [ ] **Step 3: Add inventory validation helper**
+
+Add:
+
+```go
+func validateSaleWithinSellableInventory(req SellRequest, current *dmarkets.UserPosition, sellable *dmarkets.UserPosition, sellableShares int64, sale SaleQuote, outcome string) error {
+    if current == nil {
+        return ErrNoPosition
+    }
+    if sellable == nil || sellableShares <= 0 || sellable.Value <= 0 {
+        return ErrNoSellableShares
+    }
+    if sale.SharesToSell <= 0 {
+        return ErrInsufficientShares
+    }
+    if sale.SharesToSell > sellableShares || sale.SaleValue > sellable.Value {
+        return newSaleProjectionNotExecutableError(req, current, sellable, sellable, outcome)
+    }
+    return nil
+}
+```
+
+Remove `validateProjectedSale` and `validateSaleProjection` if unused after this change. Clean unused imports such as `socialpredict/internal/domain/boundary`.
+
+- [ ] **Step 4: Run service tests**
+
+Run:
+
+```bash
+cd backend
+go test ./internal/domain/bets -run 'TestService(QuoteSell_SequenceBasedUnlockedValueRemainsExecutableAfterLaterOwnBuy|Sell_UsesUnlockedSellableCap|Sell_AttachmentSequenceCapsOvercashoutBeforeTinyTail|Sell_RejectsCalculatorResultBeyondSellableInventoryBeforeMutatingLedger)' -count=1
+```
+
+Expected: tests pass after replacing obsolete projection-inexecutable expectations with inventory-based assertions.
+
+---
+
+### Task 4: Update Integration Scenario
+
+**Files:**
+- Modify: `integrationtest/scripts/sell-shares-overcashout.mjs`
+- Modify: `integrationtest/cases/sell-shares-overcashout.md`
+- Modify: `integrationtest/README.md`
+
+**Interfaces:**
+- Consumes: `/v0/sell/quote`, `/v0/sell`, `/v0/userposition/{marketId}`, `/v0/markets/{marketId}`
+- Produces: HTTP scenario proving the reported sequence has valid executable sell value and still blocks invalid over-execution.
+
+- [ ] **Step 1: Change projection sequence from rejection to executable regression**
+
+Rename the old projection sequence to `sequenceBasedUnlockedSequence` and include the final same-user buy:
+
+```js
+{ seq: 6, user: 'bettor', type: 'buy', outcome: 'NO', amount: 20 },
+```
+
+Replace `assertProjectionInexecutableRejected` with `assertSequenceBasedUnlockedSaleAllowed`:
+
+```js
+async function assertSequenceBasedUnlockedSaleAllowed({ token, username, marketId, amount }) {
+  const beforeFinancial = await financial(username);
+  const beforePosition = await position(token, marketId);
+  const quote = (await quoteRaw(token, marketId, 'NO', amount, [200])).result;
+  check(`${username} sequence quote allowed`, quote.allowed === true);
+  check(`${username} sequence quote executable shares`, Number(quote.sharesSold) > 0, JSON.stringify(quote));
+  const sell = (await sellRaw(token, marketId, 'NO', amount, [201])).result;
+  sameInt(`${username} sequence sell shares match quote`, sell.sharesSold, quote.sharesSold);
+  sameInt(`${username} sequence sell value match quote`, sell.saleValue, quote.saleValue);
+  const afterFinancial = await financial(username);
+  const afterPosition = await position(token, marketId);
+  sameInt(`${username} sequence balance net proceeds`, Number(afterFinancial.accountBalance || 0) - Number(beforeFinancial.accountBalance || 0), sell.netProceeds);
+  check(`${username} sequence position does not gain value`, positionValue(afterPosition) <= positionValue(beforePosition), `before=${positionValue(beforePosition)}, after=${positionValue(afterPosition)}`);
+}
+```
+
+Use fresh markets for each sequence-based sell assertion so one successful sell does not disturb the other user's expected state. Update the attachment over-request assertion to prove the request caps safely instead of producing a tiny-share large-proceeds cashout.
+
+- [ ] **Step 2: Update docs**
+
+Update the case file and README wording from projection-inexecutable rejection to sequence-based unlocked-lot executable regression and capped over-cashout requests.
+
+- [ ] **Step 3: Static script validation**
+
+Run:
+
+```bash
+node --check integrationtest/scripts/sell-shares-overcashout.mjs
+```
+
+Expected: no syntax errors.
+
+---
+
+### Task 5: Final Verification, Commit, Push, PR
+
+**Files:**
+- Verify all modified files.
+- Update PR description with design, math, tests, and validation.
+
+**Interfaces:**
+- Produces: pushed branch and GitHub PR targeting `main`.
+
+- [ ] **Step 1: Focused backend verification**
+
+Run:
+
+```bash
+cd backend
+go test ./internal/domain/bets ./internal/domain/math/positions ./internal/repository/bets ./handlers/bets/selling -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Broader backend verification**
+
+Run:
+
+```bash
+cd backend
+JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...
+```
+
+Expected: pass or report exact pre-existing failures if any.
+
+- [ ] **Step 3: Integration script syntax**
+
+Run:
+
+```bash
+node --check integrationtest/scripts/sell-shares-overcashout.mjs
+```
+
+Expected: pass. Run the HTTP script against a local stack if available.
+
+- [ ] **Step 4: Commit implementation**
+
+Commit in logical commits:
+
+```bash
+git add docs/superpowers/plans/2026-07-28-stateless-unlocked-lot-sellability.md
+git commit -m "docs: plan stateless unlocked sellability"
+git add backend/internal/domain/math/positions/sellable.go backend/internal/domain/math/positions/positionsmath_test.go
+git commit -m "fix: derive sellable shares from unlocked lots"
+git add backend/internal/domain/bets/bet_sell.go backend/internal/domain/bets/service_test.go
+git commit -m "fix: validate sells against unlocked inventory"
+git add integrationtest/scripts/sell-shares-overcashout.mjs integrationtest/cases/sell-shares-overcashout.md integrationtest/README.md
+git commit -m "test: cover sequence-based unlocked sellability"
+```
+
+- [ ] **Step 5: Push and open PR**
+
+Run:
+
+```bash
+git push -u origin pwdel/debug-sell-sequence-20260722
+gh pr create --base main --head pwdel/debug-sell-sequence-20260722 --title "Fix sequence-based sellability for unlocked lots" --body-file .context/pr-sequence-sellability.md
+```
+
+If a PR already exists for the branch, use `gh pr edit` with the same title/body instead.

--- a/docs/superpowers/specs/2026-07-22-projection-aware-sell-quote-design.md
+++ b/docs/superpowers/specs/2026-07-22-projection-aware-sell-quote-design.md
@@ -1,0 +1,208 @@
+# Projection-Aware Sell Quote Design
+
+Status: design approved for review
+Date: 2026-07-22
+Branch: `pwdel/debug-sell-sequence-20260722`
+
+## Context
+
+SocialPredict treats the backend as the source of domain truth for market lifecycle, trading, resolution, accounting, canonical outcome semantics, and authentication. The frontend is an experience boundary: it owns workflow presentation, labels, recovery copy, accessibility behavior, and display mapping, but it must not compute trading or accounting rules.
+
+The requested architecture constraints also require frontend changes to pass through adapter seams instead of adding direct `fetch`, `localStorage`, or raw API-envelope handling. Public UI language for domain failures is treated as part of the contract surface, so failure copy should originate from the backend when it describes trading/accounting state.
+
+`lib/design/design-plan.json` was referenced by the user but is not present in this checkout. This design uses the architecture notes supplied in the conversation as authoritative.
+
+## Problem
+
+A Participant can have aggregate Position Value in a market and can also have nominal unlocked value from prior buy rows. In the reported sequence, however, appending a proposed negative Sale Order row does not reduce the seller's projected DBPM position enough to safely pay out credits. The existing backend projection guard correctly rejects the sale with `422 INSUFFICIENT_SHARES`, but the UI can still imply that the aggregate Position Value is directly sellable because it reads `/v0/userposition/:marketId` and treats that value as a sale limit.
+
+That makes a correct backend rejection look like a product bug. The issue is not that the frontend needs to reimplement DBPM. The issue is that the backend quote/sell result needs to be the only authority for executable sales, and the frontend needs backend-owned language and requester-only values to explain why a visible Position Value may not currently be executable.
+
+## Goals
+
+- Keep backend quote and sell simulation as the only source of truth for Sale Order executability.
+- Preserve the public request/response DTO contract for `/v0/sell/quote` and `/v0/sell`.
+- Keep rejected unsafe sales on the existing `422 INSUFFICIENT_SHARES` path.
+- Include requester-only diagnostic values in the existing error-envelope `details` object so the frontend can display Position Value versus currently executable Sale Order value without computing domain math.
+- Move the trade UI path toward the existing HTTP/auth adapter seam instead of adding more direct transport code.
+- Add regression coverage for the reported buy/sell sequence at backend and integration levels.
+
+## Non-Goals
+
+- Do not change DBPM settlement economics in this PR.
+- Do not add durable backend state or database migrations.
+- Do not introduce Redux, RTK Query, server-managed sessions, browser telemetry, CSP work, offline behavior, or broad frontend platform changes.
+- Do not let frontend code calculate unlocked value, projected position reduction, dust, sale proceeds, or any other domain accounting rule.
+- Do not perform historical production repair.
+
+## Chosen Approach
+
+Use a projection-aware quote/sell explanation while preserving the existing API shape.
+
+`/v0/sell/quote` remains the preflight authority. `/v0/sell` remains the settlement authority. Both paths continue to run the same backend projection invariant: append the proposed Sale Order in memory, recalculate projected user position, and reject if the sale does not reduce the sold-outcome shares/value enough or causes unsafe projected state.
+
+When that projection fails after nominal unlocked value exists, the service should return a more specific internal error that still matches `ErrInsufficientShares`. The HTTP handler should keep returning `422 INSUFFICIENT_SHARES`, but with clearer backend-owned message text and requester-only details.
+
+## Backend Design
+
+Add a domain error type for a projection-inexecutable sale. It should wrap or match `ErrInsufficientShares` so existing callers and handlers remain compatible.
+
+The error should be raised from the projection validation path used by both quote and settlement. It should carry values the requester is already entitled to know about their own Position:
+
+- `outcome`: canonical Outcome Code for the attempted sale.
+- `requestedCredits`: the requested Sale Order amount.
+- `positionValue`: the Participant's current aggregate Position Value for the market.
+- `positionOutcomeShares`: the Participant's current shares for the attempted Outcome Code.
+- `nominalUnlockedValue`: backend-computed unlocked value before projection validation.
+- `nominalUnlockedOutcomeShares`: backend-computed unlocked shares before projection validation.
+- `projectedPositionValue`: projected Position Value after appending the proposed Sale Order.
+- `projectedOutcomeShares`: projected shares for the attempted Outcome Code after appending the proposed Sale Order.
+- `executableSaleValue`: `0` for this rejected quote/sell attempt.
+
+The handler should continue returning the existing error reason:
+
+```json
+{
+  "ok": false,
+  "reason": "INSUFFICIENT_SHARES",
+  "message": "Position value exists, but this Sale Order is not executable right now. Market accounting requires a sale to reduce your projected position before credits can be paid out. Wait for more market activity, then try again.",
+  "details": {
+    "outcome": "NO",
+    "requestedCredits": 17,
+    "positionValue": 34,
+    "positionOutcomeShares": 34,
+    "nominalUnlockedValue": 17,
+    "nominalUnlockedOutcomeShares": 17,
+    "projectedPositionValue": 34,
+    "projectedOutcomeShares": 34,
+    "executableSaleValue": 0,
+    "hint": "This Position has value, but the requested Sale Order does not currently reduce the backend-projected position enough to pay credits safely."
+  }
+}
+```
+
+The exact numeric values will vary by market state. The key contract is that these are backend-computed, requester-only explanation fields in the existing error envelope, not new request or success-response DTO fields.
+
+Settlement must remain transaction-scoped. A rejected projection-inexecutable sale must not create a sell ledger row, credit user balance, increase market dust, or update market volume.
+
+## Frontend Design
+
+The frontend should stop treating aggregate `/v0/userposition/:marketId` value as an executable sale limit. It may display aggregate Position Value as informational, but sellability comes from `/v0/sell/quote` and `/v0/sell` only.
+
+Create or extend a trade API adapter under `frontend/src/api/` that uses the existing HTTP/auth adapter primitives. The trade UI should call adapter functions for:
+
+- placing a Buy Order,
+- fetching the Participant's Position display data,
+- requesting a Sale Order quote,
+- submitting a Sale Order.
+
+The adapter should unwrap backend envelopes and preserve structured error fields such as `reason`, `message`, and `details`. The UI should render backend-owned domain copy when present. It may format requester-only numeric details for a Terms/Conditions panel, but it must not derive whether a Sale Order is allowed from those values.
+
+Suggested UI language:
+
+- Use `Position Value` for aggregate value.
+- Use `Sale Order` for the user's requested sale.
+- Avoid labeling aggregate value as `sellable`.
+- On projection-inexecutable failure, display the backend message and optionally show:
+  - `Position Value`
+  - `Nominal Unlocked Value`
+  - `Currently Executable Sale Value`
+
+For a rejected quote, `Currently Executable Sale Value` should be shown from backend `details.executableSaleValue`, not calculated in the browser.
+
+## Data Flow
+
+1. Participant opens Sell Shares.
+2. Frontend adapter loads position display data for the market.
+3. UI displays Position Value as informational.
+4. Participant enters a Sale Order amount.
+5. Frontend adapter calls `/v0/sell/quote`.
+6. Backend validates market state, nominal unlocked position, dust, and projection safety.
+7. If projection passes, backend returns the existing quote response and UI enables confirmation.
+8. If projection fails, backend returns `422 INSUFFICIENT_SHARES` with message/details. UI displays that explanation and does not enable a misleading confirmation path.
+9. On confirmation, frontend submits `/v0/sell`; backend repeats the transaction-scoped projection check before mutation.
+
+## Error Handling
+
+`NO_POSITION` and `NO_SELLABLE_SHARES` should continue to explain that no sellable shares exist yet.
+
+`INSUFFICIENT_SHARES` should distinguish between:
+
+- requested amount exceeds currently executable value,
+- nominal unlocked value exists but projection safety prevents this Sale Order from paying credits now.
+
+Both cases can keep the same public reason. The backend message and details provide the more precise user-facing explanation.
+
+Frontend fallback copy is allowed only for network, auth, or unknown errors. Domain trading messages should come from the backend response.
+
+## Tests
+
+Backend tests:
+
+- Add a domain regression for the reported sequence:
+  - `testuser02 NO 50`
+  - `testuser03 NO 25`
+  - `testuser02 NO -75`
+  - `testuser02 NO 75`
+  - `testuser03 NO 10`
+- Assert aggregate Position Value exists for the seller.
+- Assert nominal unlocked value may exist.
+- Assert quote and sell reject the attempted Sale Order when projection does not reduce the Position enough.
+- Assert the error matches `ErrInsufficientShares` and carries projection details.
+- Assert rejected settlement does not mutate ledger, user balance, dust, or volume.
+
+Handler tests:
+
+- Assert projection-inexecutable quote/sell returns `422 INSUFFICIENT_SHARES`.
+- Assert response message is backend-owned and avoids raw HTTP-machine language.
+- Assert `details` includes requester-only Position and projection fields.
+
+Integration test:
+
+- Add or update an executable scenario under `integrationtest/` that replays the reported sequence.
+- Cover both `/v0/sell/quote` and `/v0/sell`.
+- Assert rejected attempts do not increase user balance, market dust, market volume, or sale ledger rows.
+- Assert returned error details can support the Terms/Conditions explanation without frontend domain math.
+
+Frontend validation:
+
+- Build the frontend after moving trade calls through the adapter seam.
+- Where the test harness supports it, add focused tests around adapter error preservation and UI rendering of backend message/details.
+
+## Validation Commands
+
+Run focused backend tests:
+
+```bash
+go test ./internal/domain/bets ./internal/domain/math/positions ./handlers/bets/selling
+```
+
+Run broad backend tests when practical:
+
+```bash
+JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...
+```
+
+Run frontend validation after adapter changes:
+
+```bash
+npm --prefix frontend run build:report
+```
+
+Run the integration scenario against a local dev stack after seeded users are bootstrapped:
+
+```bash
+node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0
+```
+
+If the existing overcashout script is not the right home for the projection-inexecutable case, add a separate script and case file with a precise name.
+
+## Acceptance Criteria
+
+- The frontend does not compute domain sellability, unlocked value, projected position, dust, or proceeds.
+- Backend quote/sell are the sole authority for Sale Order executability.
+- Existing request DTOs and success response DTOs remain compatible.
+- Unsafe projection failures still use `422 INSUFFICIENT_SHARES`.
+- Error details include backend-computed requester-only values for Terms/Conditions display.
+- Reported sequence is covered by backend and integration regression tests.
+- Rejected quote/sell attempts do not mutate balance, ledger, dust, or volume.

--- a/docs/superpowers/specs/2026-07-22-projection-aware-sell-quote-design.md
+++ b/docs/superpowers/specs/2026-07-22-projection-aware-sell-quote-design.md
@@ -76,7 +76,7 @@ The handler should continue returning the existing error reason:
     "projectedPositionValue": 34,
     "projectedOutcomeShares": 34,
     "executableSaleValue": 0,
-    "hint": "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
+    "hint": "Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
   }
 }
 ```

--- a/docs/superpowers/specs/2026-07-22-projection-aware-sell-quote-design.md
+++ b/docs/superpowers/specs/2026-07-22-projection-aware-sell-quote-design.md
@@ -65,7 +65,7 @@ The handler should continue returning the existing error reason:
 {
   "ok": false,
   "reason": "INSUFFICIENT_SHARES",
-  "message": "Position value exists, but this Sale Order is not executable right now. Market accounting requires a sale to reduce your projected position before credits can be paid out. Wait for more market activity, then try again.",
+  "message": "This value is not sellable yet. Wait for more market activity, then try again.",
   "details": {
     "outcome": "NO",
     "requestedCredits": 17,
@@ -76,7 +76,7 @@ The handler should continue returning the existing error reason:
     "projectedPositionValue": 34,
     "projectedOutcomeShares": 34,
     "executableSaleValue": 0,
-    "hint": "This Position has value, but the requested Sale Order does not currently reduce the backend-projected position enough to pay credits safely."
+    "hint": "Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value."
   }
 }
 ```

--- a/docs/superpowers/specs/2026-07-27-stateless-unlocked-lot-sellability-design.md
+++ b/docs/superpowers/specs/2026-07-27-stateless-unlocked-lot-sellability-design.md
@@ -1,0 +1,585 @@
+# Stateless Unlocked-Lot Sellability Design
+
+Status: draft for user review
+Date: 2026-07-27
+Branch: `pwdel/debug-sell-sequence-20260722`
+
+## Context
+
+SocialPredict keeps trading, accounting, market lifecycle, canonical Outcome semantics, and authorization truth in the backend. The frontend is an experience boundary: it may present backend-owned values and recovery copy, but it must not calculate prediction-market math or decide whether a Sale Order is executable.
+
+The current sell flow already improved user-facing errors for projection-inexecutable sales. That was useful, but it exposed a deeper domain issue: the current projection guard can block all sales once locked and unlocked value coexist in the same Position. We need a backend-owned sellability model that can separate value created by already-unlocked prior orders from value created by the user's latest still-locked order.
+
+## Problem
+
+The reported market history is:
+
+```text
+testuser02 NO  50
+testuser03 NO  25
+testuser02 NO -75
+testuser02 NO  75
+testuser03 NO  10
+testuser02 NO  20
+```
+
+After this sequence, backend DBPM position math reports:
+
+- `testuser02`: current `NO` shares/value `70`, old nominal unlocked value `35`, derived remaining unlocked executable value `17`
+- `testuser03`: current `NO` shares/value `35`, nominal unlocked value `35`
+
+Both users should have some executable unlocked value. Instead, `/v0/sell/quote` rejects even a small `NO` sale for each user.
+
+The root cause is `validateProjectedSale`. It appends the proposed negative Sale Order row to the whole market history and requires the seller's aggregate projected DBPM Position to decrease by at least the sale value. In this sequence, appending a small sale row can make the user's full projected Position go up under DBPM normalization, even though a separate prior lot is already unlocked. The guard is therefore too broad: it protects against immediate share harvesting, but it also blocks legitimate sales from previously unlocked lots.
+
+## Goals
+
+- Preserve backend quote/sell as the only authority for Sale Order executability.
+- Preserve the public API contract: no request DTO changes and no success response DTO changes.
+- Keep unsafe rejected sales on the existing `422 INSUFFICIENT_SHARES` path.
+- Keep all valuation and payout math routed through DBPM.
+- Use sequence-based locking only. Do not add time-based locks.
+- Avoid durable schema changes and new persisted lot tables.
+- Let later same-user buys remain locked without relocking older value that was already unlocked.
+- Add regression coverage for the exact reported sequence and for preventing executed sales beyond derived unlocked inventory.
+
+## Non-Goals
+
+- Do not change DBPM settlement economics.
+- Do not let the frontend compute unlocked value, projected position, dust, sale proceeds, or executable sale limits.
+- Do not add a new public endpoint solely for this fix.
+- Do not add database migrations for a persisted lot ledger.
+- Do not perform historical production repair in this PR.
+- Do not introduce broader frontend platform work such as Redux, RTK Query, browser telemetry, CSP changes, offline/PWA behavior, or server-managed sessions.
+
+## Chosen Approach
+
+Replace the full-position post-sale projection invariant with a stateless derived unlocked-lot ledger.
+
+The ledger is not persisted. It is derived on demand from the market's existing ordered bet rows inside the same transaction-scoped repository used by settlement. It treats positive buy rows as potential lots and negative sell rows as consumption of previously unlocked lots. Quote and settlement use the same derived inventory so a quote cannot say "allowed" for a sale that settlement later rejects under the same locked market state.
+
+This keeps the public API stable and keeps DBPM as the source of valuation. The new layer only answers: "How much of this user's current DBPM-valued position is currently executable under the sequence-based unlock rule?"
+
+## Domain Terms
+
+- **Buy lot**: a positive bet row for a Participant, Market, and Outcome.
+- **Sale row**: a negative bet row. Today this records sold shares as `Amount = -sharesSold`, not the historical credited sale value.
+- **Unlocked lot**: a buy lot that has a later positive buy row from another Participant in the same Market. The later buy can be for either Outcome. A Participant's own later buy does not unlock that same Participant's previous lot.
+- **Locked lot**: a buy lot with no later positive buy from another Participant.
+- **Remaining unlocked inventory**: unlocked buy-lot shares minus prior sale-row consumption, evaluated in chronological order.
+- **Executable sale value**: the current DBPM value represented by remaining unlocked inventory, rounded with the existing sell calculator semantics and capped by the user's current DBPM Position Value.
+
+## Pre-Implementation Code References
+
+These are the concrete seams this design changes. Line numbers refer to the branch state when the design was written, before the implementation patch replaced the projection guard.
+
+- [backend/internal/domain/math/positions/sellable.go](../../../backend/internal/domain/math/positions/sellable.go): `CalculateUnlockedSellablePosition_WPAM_DBPM` currently sums every unlocked positive buy payout at lines 58-64, then only caps by current shares at lines 65-81. It does not replay negative sale rows as lot consumption.
+- [backend/internal/domain/math/positions/sellable.go](../../../backend/internal/domain/math/positions/sellable.go): `isUnlockedBuy` at lines 99-115 already encodes the market-sequence unlock trigger: a matching user/outcome buy is unlocked when there is any later positive row from another user.
+- [backend/internal/domain/bets/bet_sell.go](../../../backend/internal/domain/bets/bet_sell.go): `QuoteSell` loads current and sellable positions at lines 47-55, calculates a quote, then calls `validateProjectedSale` at lines 64-68.
+- [backend/internal/domain/bets/bet_sell.go](../../../backend/internal/domain/bets/bet_sell.go): `sellInTransaction` repeats the same path inside the sell transaction at lines 82-100 before `CreditSale` mutates ledger/user balance at line 103.
+- [backend/internal/domain/bets/bet_sell.go](../../../backend/internal/domain/bets/bet_sell.go): `validateSaleProjection` at lines 189-229 is the too-broad invariant. It requires the whole DBPM-projected Position to lose enough shares/value after appending the sale row.
+- [backend/internal/domain/bets/bet_sell.go](../../../backend/internal/domain/bets/bet_sell.go): `saleCalculator.Quote` at lines 250-288 defines the sell quote math we should keep.
+- [backend/internal/domain/bets/service.go](../../../backend/internal/domain/bets/service.go): `PositionReader` and `PositionProjector` are internal service seams at lines 49-58. We should keep quote/sell on internal backend seams and avoid public API changes.
+- [backend/internal/repository/bets/sell_transaction.go](../../../backend/internal/repository/bets/sell_transaction.go): settlement uses `SellBetTransaction` at lines 20-26 and transaction-scoped market/bet reads. `loadMarketData` orders rows by `placed_at ASC` and locks rows on Postgres at lines 129-162.
+- [backend/internal/domain/bets/models.go](../../../backend/internal/domain/bets/models.go): `SellRequest`, `SellResult`, and `SellQuoteResult` at lines 79-140 are the public domain DTO shape that should not change for this fix.
+- [backend/internal/domain/bets/errors.go](../../../backend/internal/domain/bets/errors.go): existing user-facing copy and requester-only error detail fields are at lines 55-75.
+
+## Mathematical Model
+
+Let a market history be ordered by the existing repository sort:
+
+```text
+B = [b_1, b_2, ..., b_n], ordered by placed_at ASC
+```
+
+For each row:
+
+```text
+b_i = (u_i, o_i, a_i, t_i)
+u_i = username
+o_i = outcome in {YES, NO}
+a_i = amount; a_i > 0 means buy credits, a_i < 0 means sold shares
+t_i = placed time
+```
+
+For the target Participant and Outcome:
+
+```text
+u = requested username
+x = requested outcome
+```
+
+DBPM remains the valuation source. The existing helper calculates per-row payout shares:
+
+```text
+p_i = DBPM_PAYOUT_i(B)
+```
+
+where `p_i` comes from `CalculateBetPayouts_WPAM_DBPM`. Only positive matching target rows create sellability lots:
+
+```text
+lot_i exists iff u_i = u and o_i = x and a_i > 0
+lot_i.initialShares = max(p_i, 0)
+lot_i.remainingShares starts as lot_i.initialShares
+lot_i is locked while its index is >= unlocked_end
+```
+
+The sequence unlock indicator for a target buy row is:
+
+```text
+unlocked_i(k) = exists j such that i < j <= k, a_j > 0, and u_j != u
+```
+
+This intentionally does not require `o_j = x`. The current code's `isUnlockedBuy` already unlocks from any later positive row by another user, regardless of Outcome.
+
+Historical sale rows are replayed as consumption, not as new negative lots:
+
+```text
+sale_k exists iff u_k = u and o_k = x and a_k < 0
+sale_k.sharesToConsume = abs(a_k)
+```
+
+At each row `k`, process events in order. The efficient implementation should not mark every existing lot on every outside buy. Instead, keep:
+
+```text
+lots = ordered target-user target-outcome buy lots
+unlocked_end = count of lots currently unlocked
+consume_head = first unlocked lot that may still have remaining shares
+```
+
+Then replay rows with a moving unlock boundary:
+
+```text
+if a_k > 0 and u_k = u and o_k = x:
+    append lot_k
+
+if a_k > 0 and u_k != u:
+    unlocked_end = len(lots)
+
+if a_k < 0 and u_k = u and o_k = x:
+    q = abs(a_k)
+    while q > 0 and consume_head < unlocked_end:
+        c = min(lots[consume_head].remainingShares, q)
+        lots[consume_head].remainingShares -= c
+        q -= c
+        if lots[consume_head].remainingShares == 0:
+            consume_head += 1
+```
+
+For historical replay only, if `q` remains positive after unlocked inventory is exhausted, discard the leftover consumption and continue. This avoids making a future corrective deploy reinterpret old questionable data as a reason to block newly unlocked later value. For new live sells, the service must reject before mutation whenever the sale calculator would execute more shares or value than the remaining unlocked inventory.
+
+After replay:
+
+```text
+U_shares_raw = sum(lots[i].remainingShares for consume_head <= i < unlocked_end)
+```
+
+Calculate the current DBPM Position with the existing helper:
+
+```text
+C = CalculateMarketPositionForUser_WPAM_DBPM(B, u)
+C_shares = sharesForOutcome(C, x)
+C_value = C.Value
+```
+
+Then cap derived unlocked inventory by the live current Position:
+
+```text
+U_shares = min(U_shares_raw, C_shares)
+```
+
+Convert shares to executable value using the same integer style as `saleCalculator.Quote`:
+
+```text
+value_per_share = floor(C_value / C_shares)
+U_value = min(C_value, U_shares * value_per_share)
+```
+
+If `C_shares <= 0`, `C_value <= 0`, `U_shares <= 0`, or `value_per_share <= 0`, the sellable Position is zero and the existing `NO_SELLABLE_SHARES`/`NO_POSITION` behavior applies.
+
+Given a requested sale amount:
+
+```text
+R = requested credits
+```
+
+the existing sale calculator should remain the authority for quote fields:
+
+```text
+S = min(U_shares, floor(R / value_per_share))
+sale_value = S * value_per_share
+raw_dust = max(R - sale_value, 0)
+dust = normalizeDust(raw_dust, MaxDustPerSale)
+requestedCreditsReturned = sale_value + dust
+netProceeds = sale_value - dust
+```
+
+These formulas are already implemented in [backend/internal/domain/bets/bet_sell.go](../../../backend/internal/domain/bets/bet_sell.go) lines 250-288 and should not be redefined in a second calculator.
+
+The existing quote contract allows a request above the exact executable value to round down to the available share cap when dust rules allow it. That behavior should remain. The invariant is about execution, not raw text input:
+
+```text
+S <= U_shares
+sale_value <= U_value
+```
+
+If the request cannot be normalized under those constraints and the dust cap, the existing insufficient-shares path applies.
+
+## Complexity
+
+Let:
+
+```text
+n = number of bet rows in the market
+L = number of target Participant buy lots for the requested Outcome
+S = number of target Participant sale rows for the requested Outcome
+```
+
+The naive version that loops over every existing lot on every outside buy is:
+
+```text
+O(n * L) worst case, which is O(n^2) when L grows with n
+```
+
+The boundary-and-head replay above is:
+
+```text
+O(n + L + S), which is O(n)
+```
+
+Reason:
+
+- each market row is visited once;
+- each target buy lot is appended once;
+- `unlocked_end = len(lots)` unlocks existing lots by moving an integer boundary, not by walking the lots;
+- sale consumption advances `consume_head`; across the whole replay, each fully consumed lot is advanced past once, and each sale row can touch at most one partially consumed head lot.
+
+Space is:
+
+```text
+O(L), bounded by O(n)
+```
+
+This is asymptotically optimal for an exact stateless implementation because DBPM and sequence-based sellability both depend on the ordered market history. Reducing below `O(n)` would require durable derived state or a materialized lot ledger, which is intentionally out of scope for this PR.
+
+## Worked Sequence
+
+For the reported sequence:
+
+```text
+1. A = testuser02, NO,  +50
+2. B = testuser03, NO,  +25
+3. A = testuser02, NO,  -75
+4. A = testuser02, NO,  +75
+5. B = testuser03, NO,  +10
+6. A = testuser02, NO,  +20
+```
+
+For `testuser02`:
+
+- Row 1 creates an A/NO lot.
+- Row 2 is a positive row by another Participant, so it unlocks the row 1 lot.
+- Row 3 consumes unlocked A/NO shares from that unlocked row 1 lot.
+- Row 4 creates a new A/NO lot, initially locked.
+- Row 5 is a positive row by another Participant, so it unlocks the row 4 lot.
+- Row 6 creates a new A/NO lot, initially locked. It does not relock rows 1 or 4.
+- Current DBPM Position is `NO=70`, `Value=70`.
+- Remaining unlocked executable value is `17`, so a small `NO` quote should succeed.
+
+For `testuser03`:
+
+- Row 2 creates a B/NO lot, initially locked.
+- Row 3 is a sale by A, not an unlock event.
+- Row 4 is a positive row by another Participant, so it unlocks B's row 2 lot.
+- Row 5 creates a new B/NO lot, initially locked.
+- Row 6 is a positive row by another Participant, so it unlocks B's row 5 lot.
+- Current DBPM Position is `NO=35`, `Value=35`.
+- Remaining unlocked executable value is `35`, so a small `NO` quote should succeed.
+
+The existing full-projection invariant fails this sequence because appending a new sale row can increase aggregate projected DBPM Position even when the sale is consuming a previously unlocked lot. The derived ledger avoids that false negative by checking the sellable sub-inventory instead of the whole Position.
+
+## Sellability Algorithm
+
+The backend should derive sellability from the current market history as follows:
+
+1. Load the Market snapshot and ordered bet rows using the existing repository path. Settlement must use the transaction-bound repository so concurrent sells see locked market/bet state.
+2. Calculate current user Position through existing DBPM position math.
+3. Calculate DBPM payouts for source bet rows through `CalculateBetPayouts_WPAM_DBPM` or an equivalent internal helper. These payouts attach current DBPM-valued shares to each positive buy row.
+4. Walk all market rows chronologically while tracking lots for the requested Participant and Outcome.
+5. Add positive buy rows as lots with their DBPM payout shares.
+6. When a later positive buy from another Participant appears in the same Market, mark earlier matching lots as unlocked. That outside order unlocks older value; it does not unlock the buyer's own latest order.
+7. When a negative sale row for the requested Participant and Outcome appears, consume `abs(Amount)` shares from lots before the `unlocked_end` boundary. Use FIFO order so the oldest unlocked value is consumed before newer unlocked value.
+8. Do not let a historical over-consumption consume future lots that were not unlocked when the sale occurred. Since this PR is not a historical repair, saturate the then-available inventory at zero and keep replaying later rows normally.
+9. After replay, sum remaining unlocked shares for the requested Outcome.
+10. Cap remaining unlocked shares by the user's current DBPM shares for that Outcome.
+11. Convert remaining unlocked shares to executable value from the current DBPM Position. Use existing integer credit rounding semantics and cap by current Position Value.
+12. Feed that derived sellable Position into the existing sale calculator for quote and settlement.
+
+The key behavior change is step 7. Prior sells reduce future sellability, but a later own buy does not erase older unlocked inventory. The latest own buy can stay locked while older unlocked lots remain executable.
+
+## Patch-Level Implementation Sketch
+
+This is not intended to be applied verbatim. It is the expected code shape so review can focus on exactly what changes.
+
+### 1. Rewrite sellability math in `sellable.go`
+
+Current behavior:
+
+```diff
+ func CalculateUnlockedSellablePosition_WPAM_DBPM(...) (UserMarketPosition, error) {
+     current := CalculateMarketPositionForUser_WPAM_DBPM(...)
+     payouts := CalculateBetPayouts_WPAM_DBPM(snapshot, bets)
+-    unlockedShares := int64(0)
+-    for i, payout := range payouts {
+-        if isUnlockedBuy(payouts, i, username, outcome) && payout.Payout > 0 {
+-            unlockedShares += payout.Payout
+-        }
+-    }
++    unlockedShares := deriveRemainingUnlockedShares(payouts, username, outcome)
+     unlockedShares = min(unlockedShares, currentShares)
+     sellableValue := unlockedShares * (current.Value / currentShares)
+ }
+```
+
+New helper shape:
+
+```go
+type unlockedLot struct {
+    remainingShares int64
+}
+
+func deriveRemainingUnlockedShares(payouts []BetPayout, username string, outcome string) int64 {
+    lots := make([]unlockedLot, 0)
+    unlockedEnd := 0
+    consumeHead := 0
+
+    for _, payout := range payouts {
+        bet := payout.Bet
+
+        if bet.Amount > 0 && bet.Username == username && bet.Outcome == outcome && payout.Payout > 0 {
+            lots = append(lots, unlockedLot{remainingShares: payout.Payout})
+        }
+
+        if bet.Amount > 0 && bet.Username != username {
+            unlockedEnd = len(lots)
+        }
+
+        if bet.Amount < 0 && bet.Username == username && bet.Outcome == outcome {
+            consumeHead = consumeUnlockedLots(lots, consumeHead, unlockedEnd, -bet.Amount)
+        }
+    }
+    return sumRemainingUnlocked(lots, consumeHead, unlockedEnd)
+}
+```
+
+This replaces the look-ahead-only `isUnlockedBuy` model with an event replay model. Delete `isUnlockedBuy` if no remaining test needs it directly; tests should primarily target `CalculateUnlockedSellablePosition_WPAM_DBPM`.
+
+### 2. Replace the full-position projection guard in `bet_sell.go`
+
+Current quote path:
+
+```diff
+ sale, err := s.saleCalculator.Quote(sellablePosition, sellableShares, req.Amount)
+ if err != nil {
+     return nil, err
+ }
+ ...
+-bet := req.NewSaleBet(outcome, sale.SharesToSell, s.clock.Now())
+-if err := validateProjectedSale(ctx, s.markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
++if err := validateSaleWithinSellableInventory(req, currentPosition, sellablePosition, sellableShares, sale, outcome); err != nil {
+     return nil, err
+ }
+```
+
+Current settlement path changes the same way before `CreditSale`:
+
+```diff
+ bet := req.NewSaleBet(outcome, sale.SharesToSell, now)
+-if err := validateProjectedSale(txCtx, markets, req, outcome, currentPosition, sellablePosition, sale, *bet); err != nil {
++if err := validateSaleWithinSellableInventory(req, currentPosition, sellablePosition, sellableShares, sale, outcome); err != nil {
+     return err
+ }
+ if err := (betLedger{repo: repo, users: users}).CreditSale(txCtx, bet, netSaleProceeds(sale)); err != nil {
+     return err
+ }
+```
+
+New invariant shape:
+
+```go
+func validateSaleWithinSellableInventory(
+    req SellRequest,
+    current *dmarkets.UserPosition,
+    sellable *dmarkets.UserPosition,
+    sellableShares int64,
+    sale SaleQuote,
+    outcome string,
+) error {
+    if current == nil {
+        return ErrNoPosition
+    }
+    if sellable == nil || sellableShares <= 0 || sellable.Value <= 0 {
+        return ErrNoSellableShares
+    }
+    if sale.SharesToSell <= 0 {
+        return ErrInsufficientShares
+    }
+    if sale.SharesToSell > sellableShares || sale.SaleValue > sellable.Value {
+        return newSaleProjectionNotExecutableError(req, current, sellable, sellable, outcome)
+    }
+    return nil
+}
+```
+
+The name `newSaleProjectionNotExecutableError` can be renamed later, but it should keep matching `ErrInsufficientShares` and keep the same public `422 INSUFFICIENT_SHARES` mapping.
+
+### 3. Leave the projector seam in place for this PR
+
+Once `validateProjectedSale` is no longer called by quote/sell, `PositionProjector` in [backend/internal/domain/bets/service.go](../../../backend/internal/domain/bets/service.go) lines 55-65 is no longer needed by this sell path.
+
+For this PR, prefer the smaller behavioral change:
+
+- Stop calling `ProjectUserPositionAfterBet` from `QuoteSell` and `sellInTransaction`.
+- Delete `validateProjectedSale` and `validateSaleProjection` from [backend/internal/domain/bets/bet_sell.go](../../../backend/internal/domain/bets/bet_sell.go) if that removes the only production caller.
+- Leave `ProjectUserPositionAfterBet` on the market service and transaction repository for now. It is an internal projection utility and removing it is cleanup, not required for the sellability fix.
+
+This preserves the public API and keeps the PR focused. The important behavior is that settlement still uses `SellBetTransaction` and transaction-scoped market/bet reads in [backend/internal/repository/bets/sell_transaction.go](../../../backend/internal/repository/bets/sell_transaction.go) lines 20-26 and 129-162.
+
+## Projection Guard Replacement
+
+`validateProjectedSale` currently asks whether the whole projected Position decreases enough after appending the Sale Order. That question is too broad for mixed locked/unlocked Positions.
+
+The replacement invariant should ask narrower questions:
+
+- Does the executed sale consume no more shares than the remaining unlocked inventory?
+- Does the executed sale value stay within the executable value represented by that inventory?
+- Does the sale calculator still produce a valid `sharesSold`, `saleValue`, `dust`, and `netProceeds` under the current dust rules?
+
+If any answer fails, return the existing insufficient-shares path:
+
+```text
+422 INSUFFICIENT_SHARES
+```
+
+Rejected sales must not create a sell ledger row, credit the user balance, increase market dust, or update market volume.
+
+The current projection error details can remain useful for the UI, but the field named `executableSaleValue` should be populated from the derived unlocked inventory. It should no longer default to `0` merely because the aggregate full-position projection fails.
+
+## DBPM Preservation
+
+This design does not replace DBPM or move market math to the frontend.
+
+DBPM still calculates:
+
+- current user Position,
+- source-row payouts used to size buy lots,
+- current value per Outcome share,
+- market accounting and conservation behavior.
+
+The unlocked-lot ledger only filters which DBPM-valued shares are eligible to be sold under platform rules. The sell calculator still determines `sharesSold`, `saleValue`, `dust`, and `netProceeds`. Dust remains retained by the market; users receive only `netProceeds`.
+
+## Expected Behavior For Reported Sequence
+
+For the sequence above:
+
+- `testuser02` has current `NO` Position Value `70` and remaining unlocked executable value `17`.
+- `testuser03` has current `NO` Position Value `35` and remaining unlocked executable value `35`.
+- A small valid `/v0/sell/quote` for `NO` should succeed for both users.
+- A matching `/v0/sell` should succeed inside the transaction and consume unlocked inventory.
+- A request that cannot be rounded or normalized without exceeding remaining unlocked executable value should return `422 INSUFFICIENT_SHARES`.
+- A later same-user buy can remain locked, but it must not relock prior value that had already been unlocked by another Participant's later buy.
+
+## API And UI Contract
+
+No request DTO changes are planned for `/v0/sell/quote` or `/v0/sell`.
+
+The frontend should continue to treat quote/sell responses and backend error details as the authority. It may display:
+
+- `Position Value`: aggregate current DBPM Position Value.
+- `Nominal Unlocked Value`: backend-computed value before final sale-calculator constraints.
+- `Currently Executable Sale Value`: backend-computed executable value from remaining unlocked inventory.
+
+The frontend must not derive these values itself.
+
+When remaining executable value is zero while Position Value still exists, the primary backend message should remain:
+
+```text
+This value is not sellable yet. Wait for more market activity, then try again.
+```
+
+The More Info copy should remain:
+
+```text
+Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.
+```
+
+## Test Plan
+
+Backend domain tests should cover:
+
+- A single buy has no sellable value until another Participant places a later positive buy.
+- A later buy from another Participant unlocks the earlier Participant's prior lot.
+- A later buy by the same Participant does not unlock that Participant's own previous lot.
+- A later same-user buy does not relock older inventory that was already unlocked.
+- Prior sale rows consume unlocked inventory.
+- Repeated sells cannot exceed remaining unlocked inventory.
+- The exact reported sequence leaves both `testuser02` and `testuser03` with executable unlocked `NO` value.
+
+Service tests should cover:
+
+- Valid partial sell with dust succeeds and credits only `netProceeds`.
+- Full unlocked-position sell succeeds only when it consumes available unlocked inventory.
+- A sale calculator result that exceeds derived unlocked inventory is rejected before ledger, balance, dust, or volume mutation.
+- The exact reported sequence can quote and execute a small valid sale for both users.
+- The attachment over-request sequence caps safely and does not recreate a tiny-share large-proceeds cashout.
+
+Repository/transaction tests should cover:
+
+- Quote reads and settlement reads derive sellability from the same helper.
+- Settlement derives sellability inside the existing transaction-scoped sell repository.
+- Concurrent or stale quote conditions are handled by settlement revalidation before mutation.
+
+Integration tests should update the final desired regression under `integrationtest/`:
+
+- Replay the exact reported mixed buy/sell sequence.
+- Assert both `/v0/sell/quote` and `/v0/sell` succeed for a valid unlocked sale.
+- Assert `/v0/sell/quote` and `/v0/sell` never execute more shares or value than the remaining unlocked inventory.
+- Assert `/v0/sell/quote` and `/v0/sell` cap oversized requests when the sell calculator can normalize them under remaining inventory and dust rules.
+- Assert impossible or inconsistent sale executions do not increase user balance, market dust, market volume, or sale ledger rows.
+- Assert successful dust-generating sells retain dust in market accounting and credit only net proceeds.
+
+Use separate markets or reset state within the integration scenario when a happy-path sale would otherwise alter the sad-path assertions.
+
+## Validation Commands
+
+Run focused backend tests:
+
+```bash
+go test ./internal/domain/bets ./internal/domain/math/positions ./internal/repository/bets ./handlers/bets/selling
+```
+
+Run broader backend tests when practical:
+
+```bash
+JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...
+```
+
+Run integration coverage against a local seeded dev stack:
+
+```bash
+node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0
+```
+
+If the existing integration script becomes too broad, add a separate executable script and case file for this sequence-based unlocked-lot regression.
+
+## Acceptance Criteria
+
+- Backend quote/sell remain the only authorities for Sale Order executability.
+- No frontend code computes domain sellability or DBPM math.
+- No public request DTOs or success response DTOs change.
+- Unsafe sales continue to return `422 INSUFFICIENT_SHARES`.
+- The reported sequence leaves previously unlocked value executable for both affected Participants.
+- A Participant's own latest buy can stay locked without relocking older unlocked lots.
+- Prior sales reduce remaining unlocked inventory.
+- Rejected sales do not mutate ledger, user balance, dust, or volume.
+- Market dust behavior remains covered for both successful and rejected sells.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,11 +32,13 @@
         "@vitejs/plugin-react": "^6.0.2",
         "autoprefixer": "^10.4.17",
         "esbuild": "0.28.1",
+        "jsdom": "^29.1.1",
         "path-to-regexp": ">=8.4.0",
         "postcss": "^8.5.14",
         "rollup": ">=4.59.0",
         "tailwindcss": "^3.4.1",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=21.0.0"
@@ -58,6 +60,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -88,6 +141,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@canvasjs/charts": {
       "version": "3.7.42",
       "resolved": "https://registry.npmjs.org/@canvasjs/charts/-/charts-3.7.42.tgz",
@@ -101,6 +167,146 @@
       "peerDependencies": {
         "@canvasjs/charts": "^3.7.5",
         "react": ">=16.0.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -550,6 +756,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -625,9 +849,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1292,6 +1516,13 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
@@ -1409,6 +1640,17 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -1462,6 +1704,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1615,6 +1864,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -1694,6 +2056,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.17",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
@@ -1747,6 +2119,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1850,6 +2232,16 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1960,6 +2352,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1973,6 +2372,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/css.escape": {
@@ -2375,6 +2788,27 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2523,6 +2957,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-get-iterator": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
@@ -2598,6 +3045,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -2616,6 +3073,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-equals": {
@@ -2906,6 +3373,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -3106,6 +3586,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -3401,6 +3888,47 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
@@ -3690,6 +4218,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -3699,13 +4237,20 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.11",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3878,11 +4423,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -3930,6 +4502,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4153,6 +4732,16 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4397,6 +4986,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -4542,6 +5141,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -4611,6 +5223,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4659,6 +5278,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -4817,6 +5450,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
@@ -4885,6 +5525,23 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4930,6 +5587,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4939,6 +5626,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -4953,6 +5666,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",
@@ -5133,10 +5856,168 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5198,6 +6079,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5279,6 +6177,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yaml": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
@@ -5304,6 +6219,44 @@
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true
     },
+    "@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true
+    },
+    "@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -5324,6 +6277,15 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
       "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="
     },
+    "@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "requires": {
+        "css-tree": "^3.0.0"
+      }
+    },
     "@canvasjs/charts": {
       "version": "3.7.42",
       "resolved": "https://registry.npmjs.org/@canvasjs/charts/-/charts-3.7.42.tgz",
@@ -5335,6 +6297,49 @@
       "resolved": "https://registry.npmjs.org/@canvasjs/react-charts/-/react-charts-1.0.2.tgz",
       "integrity": "sha512-PZgJlDbGdMF4AN/KvrvGY9X50EByJMZ7MHfQB/U0aky9Onn9mt0CpsvwudBsBe+DofaV3SHR4SHn/Wfo/pubDw==",
       "requires": {}
+    },
+    "@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true
+    },
+    "@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "requires": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      }
+    },
+    "@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true
     },
     "@emnapi/core": {
       "version": "1.10.0",
@@ -5549,6 +6554,13 @@
       "dev": true,
       "optional": true
     },
+    "@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "requires": {}
+    },
     "@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5609,9 +6621,9 @@
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.30",
@@ -5970,6 +6982,12 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
     "@testing-library/dom": {
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
@@ -6063,6 +7081,16 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
+    "@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -6116,6 +7144,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "@types/estree": {
       "version": "1.0.8",
@@ -6246,6 +7280,79 @@
         "@rolldown/pluginutils": "^1.0.0"
       }
     },
+    "@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "requires": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      }
+    },
+    "@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "requires": {
+        "tinyrainbow": "^3.1.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      }
+    },
+    "@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true
+    },
+    "@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      }
+    },
     "acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -6303,6 +7410,12 @@
         "is-array-buffer": "^3.0.1"
       }
     },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
+    },
     "autoprefixer": {
       "version": "10.4.17",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
@@ -6327,6 +7440,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "requires": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -6383,6 +7505,12 @@
       "version": "1.0.30001741",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
       "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
+      "dev": true
+    },
+    "chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true
     },
     "chalk": {
@@ -6458,6 +7586,12 @@
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6467,6 +7601,16 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "css.escape": {
@@ -6755,6 +7899,22 @@
         "d3-transition": "2 - 3"
       }
     },
+    "data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "requires": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      }
+    },
+    "decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
     "decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -6875,6 +8035,12 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true
+    },
     "es-get-iterator": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
@@ -6936,6 +8102,15 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -6952,6 +8127,12 @@
         "jest-message-util": "^29.7.0",
         "jest-util": "^29.7.0"
       }
+    },
+    "expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true
     },
     "fast-equals": {
       "version": "5.0.1",
@@ -7161,6 +8342,15 @@
         }
       }
     },
+    "html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "requires": {
+        "@exodus/bytes": "^1.6.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -7292,6 +8482,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
     },
     "is-regex": {
       "version": "1.1.4",
@@ -7507,6 +8703,35 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      }
+    },
     "jwt-decode": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
@@ -7634,18 +8859,30 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true
+    },
     "lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "magic-string": {
-      "version": "0.30.11",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "requires": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -7757,11 +8994,26 @@
         "object-keys": "^1.1.1"
       }
     },
+    "obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true
+    },
     "package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "requires": {
+        "entities": "^8.0.0"
+      }
     },
     "path-key": {
       "version": "3.1.1",
@@ -7797,6 +9049,12 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
       "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "dev": true
+    },
+    "pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
     },
     "picocolors": {
@@ -7928,6 +9186,12 @@
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
+    },
+    "punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -8112,6 +9376,12 @@
         "set-function-name": "^2.0.0"
       }
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -8216,6 +9486,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
     "scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -8270,6 +9549,12 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8301,6 +9586,18 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         }
       }
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true
     },
     "stop-iteration-iterator": {
       "version": "1.0.0",
@@ -8412,6 +9709,12 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "tailwindcss": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
@@ -8470,6 +9773,18 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true
+    },
     "tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -8495,12 +9810,51 @@
         }
       }
     },
+    "tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true
+    },
+    "tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "requires": {
+        "tldts-core": "^7.4.9"
+      }
+    },
+    "tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "requires": {
+        "tldts": "^7.0.5"
+      }
+    },
+    "tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.3.1"
       }
     },
     "ts-interface-checker": {
@@ -8515,6 +9869,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "optional": true
+    },
+    "undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true
     },
     "undici-types": {
       "version": "7.10.0",
@@ -8606,10 +9966,84 @@
         "magic-string": "^0.30.11"
       }
     },
+    "vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "requires": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "dependencies": {
+        "es-module-lexer": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+          "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+          "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+          "dev": true
+        }
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^5.0.0"
+      }
+    },
     "web-vitals": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+    },
+    "webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true
+    },
+    "whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "requires": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -8653,6 +10087,16 @@
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "wrap-ansi": {
@@ -8712,6 +10156,18 @@
           }
         }
       }
+    },
+    "xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "yaml": {
       "version": "2.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "start": "vite --host",
     "build": "vite build",
     "build:report": "npm run build && node scripts/report-build-size.mjs",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "vitest run"
   },
   "eslintConfig": {
     "extends": [
@@ -58,10 +59,12 @@
     "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.4.17",
     "esbuild": "0.28.1",
+    "jsdom": "^29.1.1",
     "path-to-regexp": ">=8.4.0",
     "postcss": "^8.5.14",
     "rollup": ">=4.59.0",
     "tailwindcss": "^3.4.1",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/api/httpClient.js
+++ b/frontend/src/api/httpClient.js
@@ -65,6 +65,8 @@ export const apiRequest = async (
       const error = new Error(getApiErrorMessage(response, data, fallbackMessage, reasonMessages));
       error.status = response.status;
       error.reason = data?.reason || '';
+      error.details = data?.details || null;
+      error.payload = data;
       throw error;
     }
 

--- a/frontend/src/api/tradeApi.js
+++ b/frontend/src/api/tradeApi.js
@@ -1,0 +1,97 @@
+import { apiRequest, authenticatedApiRequest } from './httpClient';
+
+export const NO_SELLABLE_SHARES_MESSAGE = [
+  'No sellable shares yet.',
+  'Initial value cannot be sold until a follow-up order from another user has been placed.',
+  'Wait for another order from another user, then try selling again.',
+].join(' ');
+
+const jsonHeaders = {
+  'Content-Type': 'application/json',
+};
+
+const validateOrder = ({ marketId, amount, outcome }, actionLabel) => {
+  if (!marketId || !amount || !outcome) {
+    throw new Error(`Missing required ${actionLabel} data (marketId, amount, outcome)`);
+  }
+  if (Number(amount) < 1) {
+    throw new Error(`${actionLabel} amount must be at least 1`);
+  }
+  if (outcome !== 'YES' && outcome !== 'NO') {
+    throw new Error(`${actionLabel} outcome must be YES or NO`);
+  }
+};
+
+export const placeBet = ({ token, marketId, outcome, amount }) => {
+  if (!token) {
+    throw new Error('Please log in to place a bet.');
+  }
+  validateOrder({ marketId, amount, outcome }, 'Bet');
+
+  return authenticatedApiRequest('/v0/bet', {
+    method: 'POST',
+    headers: jsonHeaders,
+    authToken: token,
+    body: JSON.stringify({ marketId, outcome, amount }),
+    fallbackMessage: 'Bet failed. Please try again.',
+  });
+};
+
+export const fetchUserPosition = ({ token, marketId }) => {
+  if (!token) {
+    throw new Error('Please log in again to view your Position.');
+  }
+  if (!marketId) {
+    throw new Error('Market ID is required.');
+  }
+
+  return authenticatedApiRequest(`/v0/userposition/${marketId}`, {
+    authToken: token,
+    reasonMessages: {
+      INVALID_TOKEN: 'Please log in again to view your Position.',
+      AUTHORIZATION_DENIED: 'Please log in again to view your Position.',
+      PASSWORD_CHANGE_REQUIRED: 'Please update your password before viewing your Position.',
+      NO_POSITION: NO_SELLABLE_SHARES_MESSAGE,
+    },
+    fallbackMessage: NO_SELLABLE_SHARES_MESSAGE,
+  });
+};
+
+export const quoteSale = ({ token, marketId, outcome, amount }) => {
+  if (!token) {
+    throw new Error('Please log in to sell shares.');
+  }
+  validateOrder({ marketId, amount, outcome }, 'Sale');
+
+  return authenticatedApiRequest('/v0/sell/quote', {
+    method: 'POST',
+    headers: jsonHeaders,
+    authToken: token,
+    body: JSON.stringify({ marketId, outcome, amount }),
+    fallbackMessage: 'Sale quote failed. Please try again.',
+  });
+};
+
+export const sellShares = ({ token, marketId, outcome, amount }) => {
+  if (!token) {
+    throw new Error('Please log in to sell shares.');
+  }
+  validateOrder({ marketId, amount, outcome }, 'Sale');
+
+  return authenticatedApiRequest('/v0/sell', {
+    method: 'POST',
+    headers: jsonHeaders,
+    authToken: token,
+    body: JSON.stringify({ marketId, outcome, amount }),
+    fallbackMessage: 'Sale failed. Please try again.',
+  });
+};
+
+export const fetchTradingFees = async ({ token } = {}) => {
+  const setup = await apiRequest('/v0/setup', {
+    authenticated: Boolean(token),
+    authToken: token,
+    fallbackMessage: 'Failed to load trading fees.',
+  });
+  return setup?.betting?.betFees || null;
+};

--- a/frontend/src/api/tradeApi.test.jsx
+++ b/frontend/src/api/tradeApi.test.jsx
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { quoteSale } from './tradeApi';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('tradeApi', () => {
+  it('preserves backend projection details on rejected sale quotes', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      ok: false,
+      reason: 'INSUFFICIENT_SHARES',
+      message: 'Position value exists, but this Sale Order is not executable right now.',
+      details: {
+        outcome: 'NO',
+        requestedCredits: 17,
+        positionValue: 34,
+        nominalUnlockedValue: 17,
+        projectedPositionValue: 34,
+        executableSaleValue: 0,
+      },
+    }), { status: 422, headers: { 'Content-Type': 'application/json' } })));
+
+    await expect(quoteSale({
+      token: 'token-1',
+      marketId: 7,
+      outcome: 'NO',
+      amount: 17,
+    })).rejects.toMatchObject({
+      status: 422,
+      reason: 'INSUFFICIENT_SHARES',
+      message: 'Position value exists, but this Sale Order is not executable right now.',
+      details: {
+        outcome: 'NO',
+        requestedCredits: 17,
+        positionValue: 34,
+        nominalUnlockedValue: 17,
+        projectedPositionValue: 34,
+        executableSaleValue: 0,
+      },
+    });
+  });
+});

--- a/frontend/src/api/tradeApi.test.jsx
+++ b/frontend/src/api/tradeApi.test.jsx
@@ -10,7 +10,7 @@ describe('tradeApi', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       ok: false,
       reason: 'INSUFFICIENT_SHARES',
-      message: 'Position value exists, but this Sale Order is not executable right now.',
+      message: 'This value is not sellable yet. Wait for more market activity, then try again.',
       details: {
         outcome: 'NO',
         requestedCredits: 17,
@@ -18,6 +18,7 @@ describe('tradeApi', () => {
         nominalUnlockedValue: 17,
         projectedPositionValue: 34,
         executableSaleValue: 0,
+        hint: 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
       },
     }), { status: 422, headers: { 'Content-Type': 'application/json' } })));
 
@@ -29,7 +30,7 @@ describe('tradeApi', () => {
     })).rejects.toMatchObject({
       status: 422,
       reason: 'INSUFFICIENT_SHARES',
-      message: 'Position value exists, but this Sale Order is not executable right now.',
+      message: 'This value is not sellable yet. Wait for more market activity, then try again.',
       details: {
         outcome: 'NO',
         requestedCredits: 17,
@@ -37,6 +38,7 @@ describe('tradeApi', () => {
         nominalUnlockedValue: 17,
         projectedPositionValue: 34,
         executableSaleValue: 0,
+        hint: 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
       },
     });
   });

--- a/frontend/src/api/tradeApi.test.jsx
+++ b/frontend/src/api/tradeApi.test.jsx
@@ -18,7 +18,7 @@ describe('tradeApi', () => {
         nominalUnlockedValue: 17,
         projectedPositionValue: 34,
         executableSaleValue: 0,
-        hint: 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
+        hint: 'Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
       },
     }), { status: 422, headers: { 'Content-Type': 'application/json' } })));
 
@@ -38,7 +38,7 @@ describe('tradeApi', () => {
         nominalUnlockedValue: 17,
         projectedPositionValue: 34,
         executableSaleValue: 0,
-        hint: 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
+        hint: 'Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
       },
     });
   });

--- a/frontend/src/components/layouts/trade/BuySharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/BuySharesLayout.jsx
@@ -3,7 +3,7 @@ import { BetYesButton, BetNoButton, BetInputAmount, ConfirmBetButton } from '../
 import MarketProjectionLayout from '../marketprojection/MarketProjectionLayout';
 import { submitBet } from './TradeUtils';
 import { useMarketLabels } from '../../../hooks/useMarketLabels';
-import { API_URL } from '../../../config';
+import { fetchTradingFees } from '../../../api/tradeApi';
 import { USER_CREDIT_REFRESH_EVENT } from '../../utils/userFinanceTools/FetchUserCredit';
 
 
@@ -26,16 +26,7 @@ const BuySharesLayout = ({ marketId, market, token, onTransactionSuccess }) => {
                 return;
             }
             try {
-                const response = await fetch(`${API_URL}/v0/setup`, {
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                    },
-                });
-                if (!response.ok) {
-                    throw new Error(`Failed to load setup: ${response.status}`);
-                }
-                const data = await response.json();
-                setFeeData(data.betting?.betFees || null);
+                setFeeData(await fetchTradingFees({ token }));
             } catch {
                 setFeeData(null);
             } finally {

--- a/frontend/src/components/layouts/trade/SellSharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.jsx
@@ -7,7 +7,7 @@ import {
     submitSale,
 } from './TradeUtils';
 import { useMarketLabels } from '../../../hooks/useMarketLabels';
-import { API_URL } from '../../../config';
+import { fetchTradingFees } from '../../../api/tradeApi';
 import { USER_CREDIT_REFRESH_EVENT } from '../../utils/userFinanceTools/FetchUserCredit';
 
 const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => {
@@ -19,14 +19,14 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
     const [sharesLoading, setSharesLoading] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [saleQuote, setSaleQuote] = useState(null);
-    const [quoteError, setQuoteError] = useState('');
+    const [quoteError, setQuoteError] = useState(null);
     const [sharesNotice, setSharesNotice] = useState('');
     const [isQuoteLoading, setIsQuoteLoading] = useState(false);
     
     // Get custom labels for this market
     const { yesLabel, noLabel } = useMarketLabels(market);
     const showFeeSection = !isLoading && Number(feeData?.sellSharesFee) > 0;
-    const maxSaleCredits = Math.max(0, Number(shares.value) || 0);
+    const positionValue = Math.max(0, Number(shares.value) || 0);
 
     useEffect(() => {
         const fetchFeeData = async () => {
@@ -36,16 +36,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
             }
 
             try {
-                const response = await fetch(`${API_URL}/v0/setup`, {
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                    },
-                });
-                if (!response.ok) {
-                    throw new Error(`Failed to load setup: ${response.status}`);
-                }
-                const data = await response.json();
-                setFeeData(data.betting?.betFees || null);
+                setFeeData(await fetchTradingFees({ token }));
             } catch {
                 setFeeData(null);
             } finally {
@@ -62,7 +53,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
             setSelectedOutcome(null);
             setSellAmount(1);
             setSaleQuote(null);
-            setQuoteError('');
+            setQuoteError(null);
             setSharesNotice('');
             return;
         }
@@ -77,10 +68,10 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                 // Set outcome and amount based on shares
                 if (normalized.noSharesOwned > 0 && normalized.yesSharesOwned === 0) {
                     setSelectedOutcome('NO');
-                    setSellAmount(defaultSaleAmount(normalized));
+                    setSellAmount(defaultSaleAmount());
                 } else if (normalized.yesSharesOwned > 0 && normalized.noSharesOwned === 0) {
                     setSelectedOutcome('YES');
-                    setSellAmount(defaultSaleAmount(normalized));
+                    setSellAmount(defaultSaleAmount());
                 } else {
                     setSelectedOutcome(null);
                     setSellAmount(1);
@@ -101,11 +92,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
             return;
         }
         setSaleQuote(null);
-        setQuoteError('');
-        if (maxSaleCredits > 0 && newAmount > maxSaleCredits) {
-            setSellAmount(maxSaleCredits);
-            return;
-        }
+        setQuoteError(null);
         setSellAmount(newAmount);
     };
 
@@ -124,7 +111,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
 
         setSelectedOutcome(outcomeToUse);
         setIsQuoteLoading(true);
-        setQuoteError('');
+        setQuoteError(null);
 
         return fetchSaleQuote(saleData, token)
             .then((quote) => {
@@ -133,7 +120,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
             })
             .catch((error) => {
                 setSaleQuote(null);
-                setQuoteError(error.message);
+                setQuoteError(error);
                 return null;
             })
             .finally(() => {
@@ -177,21 +164,21 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                     },
                     (error) => {
                         alert(error.message);
+                        setQuoteError(error);
                         setIsSubmitting(false);
                     }
                 );
             })
             .catch((error) => {
                 alert(error.message);
+                setQuoteError(error);
                 setIsSubmitting(false);
             });
     };
 
     const isActionDisabled = sharesLoading || isSubmitting || isQuoteLoading;
     const hasOwnedShares = shares.noSharesOwned > 0 || shares.yesSharesOwned > 0;
-    const sellUnavailableNotice = hasOwnedShares && maxSaleCredits <= 0
-        ? NO_SELLABLE_SHARES_MESSAGE
-        : sharesNotice;
+    const sellUnavailableNotice = sharesNotice;
 
     return (
         <div className="p-6 bg-blue-900 rounded-lg text-white">
@@ -211,7 +198,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                     {(shares.noSharesOwned > 0 || shares.yesSharesOwned > 0) && (
                         <div className="text-center text-lg mt-2">
                             <span className="font-bold">Position Value: </span>
-                            <span className="text-green-300">{shares.value}</span>
+                            <span className="text-green-300">{positionValue}</span>
                         </div>
                     )}
                     {sellUnavailableNotice && (
@@ -227,7 +214,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                         <SaleInputAmount
                             value={sellAmount}
                             onChange={handleSellAmountChange}
-                            max={maxSaleCredits || 1}
+                            max={undefined}
                             disabled={isActionDisabled}
                         />
                     </div>
@@ -299,8 +286,8 @@ const normalizeShares = (data) => {
     };
 };
 
-const defaultSaleAmount = (normalized) => {
-    return Math.max(1, Number(normalized?.value) || 1);
+const defaultSaleAmount = () => {
+    return 1;
 };
 
 const buildSaleSuccessMessage = (data) => {
@@ -327,9 +314,12 @@ const SaleQuotePanel = ({ quote, quoteError, isLoading, selectedOutcome, onSelec
     }
 
     if (quoteError) {
+        const message = typeof quoteError === 'string' ? quoteError : quoteError.message;
+        const details = typeof quoteError === 'object' ? quoteError.details : null;
         return (
             <div className="mb-4 rounded-lg border border-red-400 bg-red-950/40 p-3 text-sm text-red-100">
-                {quoteError}
+                <p>{message}</p>
+                <ProjectionErrorDetails details={details} />
             </div>
         );
     }
@@ -400,6 +390,30 @@ const SaleActionGroup = ({ outcome, disabled, isQuoteLoading, onTerms, onSubmit 
             >
                 {isQuoteLoading ? 'Loading Terms' : 'Terms'}
             </button>
+        </div>
+    );
+};
+
+const ProjectionErrorDetails = ({ details }) => {
+    if (!details) {
+        return null;
+    }
+
+    const rows = [
+        ['Position Value', details.positionValue],
+        ['Nominal Unlocked Value', details.nominalUnlockedValue],
+        ['Currently Executable Sale Value', details.executableSaleValue],
+    ].filter(([, value]) => value !== undefined && value !== null);
+
+    if (rows.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="mt-3 grid gap-2 sm:grid-cols-3">
+            {rows.map(([label, value]) => (
+                <QuoteMetric key={label} label={label} value={value} />
+            ))}
         </div>
     );
 };

--- a/frontend/src/components/layouts/trade/SellSharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.jsx
@@ -410,20 +410,30 @@ export const ProjectionErrorDetails = ({ details }) => {
     }
 
     return (
-        <dl className="mt-3 space-y-2" data-testid="projection-error-details">
-            {rows.map(([label, value]) => (
-                <div
-                    key={label}
-                    data-testid={`projection-error-detail-${label.toLowerCase().replace(/\s+/g, '-')}`}
-                    className="flex items-start justify-between gap-3 rounded-md bg-white/10 px-3 py-2"
-                >
-                    <dt className="min-w-0 break-words text-[0.7rem] uppercase leading-snug opacity-75">
-                        {label}
-                    </dt>
-                    <dd className="shrink-0 text-right font-semibold">{value}</dd>
-                </div>
-            ))}
-        </dl>
+        <div className="mt-3 space-y-2" data-testid="projection-error-details">
+            {details.hint && (
+                <details className="rounded-md bg-white/10 px-3 py-2">
+                    <summary className="cursor-pointer text-sm font-semibold text-red-50">
+                        More info
+                    </summary>
+                    <p className="mt-2 text-xs leading-relaxed text-red-50/90">{details.hint}</p>
+                </details>
+            )}
+            <dl className="space-y-2">
+                {rows.map(([label, value]) => (
+                    <div
+                        key={label}
+                        data-testid={`projection-error-detail-${label.toLowerCase().replace(/\s+/g, '-')}`}
+                        className="flex items-start justify-between gap-3 rounded-md bg-white/10 px-3 py-2"
+                    >
+                        <dt className="min-w-0 break-words text-[0.7rem] uppercase leading-snug opacity-75">
+                            {label}
+                        </dt>
+                        <dd className="shrink-0 text-right font-semibold">{value}</dd>
+                    </div>
+                ))}
+            </dl>
+        </div>
     );
 };
 

--- a/frontend/src/components/layouts/trade/SellSharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.jsx
@@ -394,7 +394,7 @@ const SaleActionGroup = ({ outcome, disabled, isQuoteLoading, onTerms, onSubmit 
     );
 };
 
-const ProjectionErrorDetails = ({ details }) => {
+export const ProjectionErrorDetails = ({ details }) => {
     if (!details) {
         return null;
     }
@@ -410,11 +410,20 @@ const ProjectionErrorDetails = ({ details }) => {
     }
 
     return (
-        <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        <dl className="mt-3 space-y-2" data-testid="projection-error-details">
             {rows.map(([label, value]) => (
-                <QuoteMetric key={label} label={label} value={value} />
+                <div
+                    key={label}
+                    data-testid={`projection-error-detail-${label.toLowerCase().replace(/\s+/g, '-')}`}
+                    className="flex items-start justify-between gap-3 rounded-md bg-white/10 px-3 py-2"
+                >
+                    <dt className="min-w-0 break-words text-[0.7rem] uppercase leading-snug opacity-75">
+                        {label}
+                    </dt>
+                    <dd className="shrink-0 text-right font-semibold">{value}</dd>
+                </div>
             ))}
-        </div>
+        </dl>
     );
 };
 

--- a/frontend/src/components/layouts/trade/SellSharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.jsx
@@ -300,7 +300,7 @@ const buildSaleSuccessMessage = (data) => {
     return `${base} Dust assessed: ${dust} credit${dust === 1 ? '' : 's'} retained by the market due to whole-share rounding.`;
 };
 
-const SaleQuotePanel = ({ quote, quoteError, isLoading, selectedOutcome, onSelectAmount }) => {
+export const SaleQuotePanel = ({ quote, quoteError, isLoading, selectedOutcome, onSelectAmount }) => {
     if (!selectedOutcome && !quoteError && !isLoading) {
         return null;
     }
@@ -317,7 +317,10 @@ const SaleQuotePanel = ({ quote, quoteError, isLoading, selectedOutcome, onSelec
         const message = typeof quoteError === 'string' ? quoteError : quoteError.message;
         const details = typeof quoteError === 'object' ? quoteError.details : null;
         return (
-            <div className="mb-4 rounded-lg border border-red-400 bg-red-950/40 p-3 text-sm text-red-100">
+            <div
+                className="mb-4 rounded-lg border border-red-400 bg-red-950/40 p-3 text-sm text-red-100"
+                data-testid="sale-quote-error"
+            >
                 <p>{message}</p>
                 <ProjectionErrorDetails details={details} />
             </div>

--- a/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { ProjectionErrorDetails, SaleQuotePanel } from './SellSharesLayout';
 
 const primaryMessage = 'This value is not sellable yet. Wait for more market activity, then try again.';
-const moreInfoMessage = 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.';
+const moreInfoMessage = 'Your position still has value but is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.';
 
 describe('ProjectionErrorDetails', () => {
     it('renders projection values as stacked rows so long labels do not overlap in narrow dialogs', () => {

--- a/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
@@ -11,6 +11,7 @@ describe('ProjectionErrorDetails', () => {
                     positionValue: 34,
                     nominalUnlockedValue: 17,
                     executableSaleValue: 0,
+                    hint: 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
                 }}
             />
         );
@@ -22,5 +23,7 @@ describe('ProjectionErrorDetails', () => {
         const executableRow = screen.getByTestId('projection-error-detail-currently-executable-sale-value');
         expect(within(executableRow).getByText('Currently Executable Sale Value').className).toContain('break-words');
         expect(within(executableRow).getByText('0')).not.toBeNull();
+        expect(screen.getByText('More info')).not.toBeNull();
+        expect(screen.getByText(/This protects the market from users immediately cashing out value/)).not.toBeNull();
     });
 });

--- a/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
@@ -1,0 +1,26 @@
+/** @vitest-environment jsdom */
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProjectionErrorDetails } from './SellSharesLayout';
+
+describe('ProjectionErrorDetails', () => {
+    it('renders projection values as stacked rows so long labels do not overlap in narrow dialogs', () => {
+        render(
+            <ProjectionErrorDetails
+                details={{
+                    positionValue: 34,
+                    nominalUnlockedValue: 17,
+                    executableSaleValue: 0,
+                }}
+            />
+        );
+
+        const detailsPanel = screen.getByTestId('projection-error-details');
+        expect(detailsPanel.className).toContain('space-y-2');
+        expect(detailsPanel.className).not.toContain('sm:grid-cols-3');
+
+        const executableRow = screen.getByTestId('projection-error-detail-currently-executable-sale-value');
+        expect(within(executableRow).getByText('Currently Executable Sale Value').className).toContain('break-words');
+        expect(within(executableRow).getByText('0')).not.toBeNull();
+    });
+});

--- a/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.test.jsx
@@ -1,7 +1,10 @@
 /** @vitest-environment jsdom */
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { ProjectionErrorDetails } from './SellSharesLayout';
+import { ProjectionErrorDetails, SaleQuotePanel } from './SellSharesLayout';
+
+const primaryMessage = 'This value is not sellable yet. Wait for more market activity, then try again.';
+const moreInfoMessage = 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.';
 
 describe('ProjectionErrorDetails', () => {
     it('renders projection values as stacked rows so long labels do not overlap in narrow dialogs', () => {
@@ -11,7 +14,7 @@ describe('ProjectionErrorDetails', () => {
                     positionValue: 34,
                     nominalUnlockedValue: 17,
                     executableSaleValue: 0,
-                    hint: 'Your position still has value, but some or all of that value is not sellable yet. This protects the market from users immediately cashing out value created by their own order. More market activity can unlock additional sellable value.',
+                    hint: moreInfoMessage,
                 }}
             />
         );
@@ -25,5 +28,33 @@ describe('ProjectionErrorDetails', () => {
         expect(within(executableRow).getByText('0')).not.toBeNull();
         expect(screen.getByText('More info')).not.toBeNull();
         expect(screen.getByText(/This protects the market from users immediately cashing out value/)).not.toBeNull();
+    });
+});
+
+describe('SaleQuotePanel', () => {
+    it('shows the simple sellability message above and the detailed explanation under more info', () => {
+        render(
+            <SaleQuotePanel
+                selectedOutcome="NO"
+                quote={null}
+                isLoading={false}
+                onSelectAmount={() => {}}
+                quoteError={{
+                    message: primaryMessage,
+                    details: {
+                        positionValue: 34,
+                        nominalUnlockedValue: 17,
+                        executableSaleValue: 0,
+                        hint: moreInfoMessage,
+                    },
+                }}
+            />
+        );
+
+        const alert = screen.getByTestId('sale-quote-error');
+        expect(within(alert).getByText(primaryMessage)).not.toBeNull();
+        const moreInfo = within(alert).getByText('More info').closest('details');
+        expect(moreInfo).not.toBeNull();
+        expect(within(moreInfo).getByText(moreInfoMessage)).not.toBeNull();
     });
 });

--- a/frontend/src/components/layouts/trade/TradeUtils.jsx
+++ b/frontend/src/components/layouts/trade/TradeUtils.jsx
@@ -1,205 +1,25 @@
-import { API_URL } from '../../../config';
+import {
+  fetchUserPosition,
+  NO_SELLABLE_SHARES_MESSAGE,
+  placeBet,
+  quoteSale,
+  sellShares,
+} from '../../../api/tradeApi';
 
-export const NO_SELLABLE_SHARES_MESSAGE = [
-    'No sellable shares yet.',
-    'Initial value cannot be sold until a follow-up order from another user has been placed.',
-    'Wait for another order from another user, then try selling again.',
-].join(' ');
-
-const unwrapApiResponse = (payload) => {
-    if (payload && typeof payload === 'object' && 'ok' in payload) {
-        if (payload.ok === false) {
-            throw new Error(payload.reason || 'Request failed');
-        }
-
-        if (payload.ok === true && 'result' in payload) {
-            return payload.result;
-        }
-    }
-
-    return payload;
-};
-
-const formatApiError = (errorData, fallback) => {
-    if (!errorData || typeof errorData !== 'object') {
-        return fallback;
-    }
-
-    if (errorData.reason === 'INSUFFICIENT_SHARES') {
-        return errorData.message || 'Not enough sellable shares for that sale amount. Try a smaller Sale Order amount, or wait for more market activity if your latest shares are still locked.';
-    }
-
-    if (errorData.reason === 'DUST_CAP_EXCEEDED') {
-        const dust = errorData.details?.dust;
-        const maxDust = errorData.details?.maxDust;
-        const suffix = dust !== undefined && maxDust !== undefined
-            ? ` This Sale Order would create a ${dust} credit dust fee, but the maximum allowed is ${maxDust}.`
-            : '';
-        return `${errorData.message || 'Sale would create too much rounding dust.'}${suffix} Try a different Sale Order amount.`;
-    }
-
-    return errorData.message || errorData.reason || errorData.error || fallback;
-};
-
-const parseErrorResponse = async (response, fallbackPrefix) => {
-    const text = await response.text();
-    let errorMessage;
-    let errorData;
-
-    try {
-        errorData = JSON.parse(text);
-    } catch {
-        errorMessage = text || `HTTP ${response.status}: ${response.statusText}`;
-        throw new Error(`${fallbackPrefix} (${response.status}): ${errorMessage}`);
-    }
-
-    errorMessage = formatApiError(errorData, text);
-    if (fallbackPrefix.startsWith('Sale') && ['NO_POSITION', 'INSUFFICIENT_SHARES'].includes(errorData?.reason)) {
-        throw new Error(errorMessage || NO_SELLABLE_SHARES_MESSAGE);
-    }
-    throw new Error(`${fallbackPrefix} (${response.status}): ${errorMessage}`);
-};
+export { NO_SELLABLE_SHARES_MESSAGE };
 
 export const submitBet = (betData, token, onSuccess, onError) => {
-    if (!token) {
-        alert('Please log in to place a bet.');
-        return;
-    }
-
-    if (!betData.marketId || !betData.amount || !betData.outcome) {
-        onError(new Error('Missing required bet data (marketId, amount, outcome)'));
-        return;
-    }
-
-    if (betData.amount < 1) {
-        onError(new Error('Bet amount must be at least 1'));
-        return;
-    }
-
-    if (betData.outcome !== 'YES' && betData.outcome !== 'NO') {
-        onError(new Error('Bet outcome must be YES or NO'));
-        return;
-    }
-
-    fetch(`${API_URL}/v0/bet`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(betData),
-    })
-    .then(response => {
-        if (!response.ok) {
-            return parseErrorResponse(response, 'Bet failed');
-        }
-        return response.json();
-    })
-    .then(data => onSuccess(unwrapApiResponse(data)))
-    .catch(error => {
-        onError(error);
-    });
+  placeBet({ token, ...betData })
+    .then(onSuccess)
+    .catch(onError);
 };
 
-export const fetchUserShares = async (marketId, token) => {
-    const response = await fetch(`${API_URL}/v0/userposition/${marketId}`, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    });
-    if (!response.ok) {
-        const text = await response.text();
-        let reason = '';
-        try {
-            const errorData = JSON.parse(text);
-            reason = errorData?.reason || errorData?.code || '';
-        } catch {
-            reason = '';
-        }
+export const fetchUserShares = async (marketId, token) => fetchUserPosition({ token, marketId });
 
-        if (reason === 'INVALID_TOKEN' || reason === 'AUTHORIZATION_DENIED') {
-            throw new Error('Please log in again to view sellable shares.');
-        }
-        if (reason === 'PASSWORD_CHANGE_REQUIRED') {
-            throw new Error('Please update your password before viewing sellable shares.');
-        }
-
-        throw new Error(NO_SELLABLE_SHARES_MESSAGE);
-    }
-    const data = await response.json();
-    return unwrapApiResponse(data);
-};
-
-export const fetchSaleQuote = async (saleData, token) => {
-    if (!token) {
-        throw new Error('Please log in to sell shares.');
-    }
-
-    if (!saleData.marketId || !saleData.amount || !saleData.outcome) {
-        throw new Error('Missing required sale data (marketId, amount, outcome)');
-    }
-
-    if (saleData.amount < 1) {
-        throw new Error('Sale amount must be at least 1');
-    }
-
-    if (saleData.outcome !== 'YES' && saleData.outcome !== 'NO') {
-        throw new Error('Sale outcome must be YES or NO');
-    }
-
-    const response = await fetch(`${API_URL}/v0/sell/quote`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(saleData),
-    });
-
-    if (!response.ok) {
-        return parseErrorResponse(response, 'Sale quote failed');
-    }
-
-    return unwrapApiResponse(await response.json());
-};
+export const fetchSaleQuote = async (saleData, token) => quoteSale({ token, ...saleData });
 
 export const submitSale = (saleData, token, onSuccess, onError) => {
-    if (!token) {
-        alert('Please log in to sell shares.');
-        return;
-    }
-
-    if (!saleData.marketId || !saleData.amount || !saleData.outcome) {
-        onError(new Error('Missing required sale data (marketId, amount, outcome)'));
-        return;
-    }
-
-    if (saleData.amount < 1) {
-        onError(new Error('Sale amount must be at least 1'));
-        return;
-    }
-
-    if (saleData.outcome !== 'YES' && saleData.outcome !== 'NO') {
-        onError(new Error('Sale outcome must be YES or NO'));
-        return;
-    }
-
-    fetch(`${API_URL}/v0/sell`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(saleData),
-    })
-    .then(response => {
-        if (!response.ok) {
-            return parseErrorResponse(response, 'Sale failed');
-        }
-        return response.json();
-    })
-    .then(data => onSuccess(unwrapApiResponse(data)))
-    .catch(error => {
-        onError(error);
-    });
+  sellShares({ token, ...saleData })
+    .then(onSuccess)
+    .catch(onError);
 };

--- a/integrationtest/README.md
+++ b/integrationtest/README.md
@@ -35,7 +35,7 @@ Last updated: 2026-06-17.
 | Suite | Command | Current result |
 |-------|---------|----------------|
 | Multiple-choice binary API scenario runner | `node integrationtest/scripts/multiple-choice-binary-api.mjs --base-url http://localhost:8080 --api-prefix /v0` | 17/17 checks passing |
-| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers valid quote/sell, dust accounting, and rejected over-cashout |
+| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers valid quote/sell, dust accounting, rejected over-cashout, and projection-inexecutable sell error details |
 | Sell shares two-share backend cap runner | `node integrationtest/scripts/sell-shares-two-share-cap.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers locked initial buys, different-user unlock, backend sell message, and oversized quote/sell cap |
 | Read-only Schemathesis contract smoke | `MAX_EXAMPLES=1 integrationtest/scripts/schemathesis-read.sh` | 4/4 operations passing |
 | Grouped-market Schemathesis contract runner | `node integrationtest/scripts/schemathesis-grouped-market.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers grouped read schemas with a real group ID |

--- a/integrationtest/README.md
+++ b/integrationtest/README.md
@@ -35,7 +35,7 @@ Last updated: 2026-06-17.
 | Suite | Command | Current result |
 |-------|---------|----------------|
 | Multiple-choice binary API scenario runner | `node integrationtest/scripts/multiple-choice-binary-api.mjs --base-url http://localhost:8080 --api-prefix /v0` | 17/17 checks passing |
-| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers valid quote/sell, dust accounting, rejected over-cashout, and projection-inexecutable sell error details |
+| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers valid quote/sell, dust accounting, capped over-cashout requests, and sequence-based unlocked-lot sellability |
 | Sell shares two-share backend cap runner | `node integrationtest/scripts/sell-shares-two-share-cap.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers locked initial buys, different-user unlock, backend sell message, and oversized quote/sell cap |
 | Read-only Schemathesis contract smoke | `MAX_EXAMPLES=1 integrationtest/scripts/schemathesis-read.sh` | 4/4 operations passing |
 | Grouped-market Schemathesis contract runner | `node integrationtest/scripts/schemathesis-grouped-market.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers grouped read schemas with a real group ID |

--- a/integrationtest/README.md
+++ b/integrationtest/README.md
@@ -35,7 +35,7 @@ Last updated: 2026-06-17.
 | Suite | Command | Current result |
 |-------|---------|----------------|
 | Multiple-choice binary API scenario runner | `node integrationtest/scripts/multiple-choice-binary-api.mjs --base-url http://localhost:8080 --api-prefix /v0` | 17/17 checks passing |
-| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers valid quote/sell, dust accounting, capped over-cashout requests, and sequence-based unlocked-lot sellability |
+| Sell shares over-cashout API scenario runner | `node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0 --delay 1100` | Covers valid quote/sell, dust accounting, capped over-cashout requests, and sequence-based unlocked-lot sellability |
 | Sell shares two-share backend cap runner | `node integrationtest/scripts/sell-shares-two-share-cap.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers locked initial buys, different-user unlock, backend sell message, and oversized quote/sell cap |
 | Read-only Schemathesis contract smoke | `MAX_EXAMPLES=1 integrationtest/scripts/schemathesis-read.sh` | 4/4 operations passing |
 | Grouped-market Schemathesis contract runner | `node integrationtest/scripts/schemathesis-grouped-market.mjs --base-url http://localhost:8080 --api-prefix /v0` | Covers grouped read schemas with a real group ID |
@@ -57,7 +57,8 @@ Run the sell-shares over-cashout regression:
 ```bash
 node integrationtest/scripts/sell-shares-overcashout.mjs \
   --base-url http://localhost:8080 \
-  --api-prefix /v0
+  --api-prefix /v0 \
+  --delay 1100
 ```
 
 Run the focused sell unlock and two-share backend cap regression:
@@ -68,8 +69,8 @@ node integrationtest/scripts/sell-shares-two-share-cap.mjs \
   --api-prefix /v0
 ```
 
-Defaults assume seeded users `admin`, `testuser01`, `testuser02`, `testuser03`,
-and `testuser04` all use password `password`.
+Defaults assume seeded users `admin`, `testuser01`, and `testuser02` through
+`testuser07` all use password `password`.
 
 Run read-only OpenAPI fuzz/contract checks with Schemathesis:
 

--- a/integrationtest/cases/sell-shares-overcashout.md
+++ b/integrationtest/cases/sell-shares-overcashout.md
@@ -51,4 +51,20 @@ Sad path:
   reason and that user balance, position, market dust, and market volume remain
   unchanged.
 
+Projection-inexecutable path:
+
+- Replays the reported two-user NO sequence:
+  - `testuser02 NO 50`
+  - `testuser03 NO 25`
+  - `testuser02 NO -75`
+  - `testuser02 NO 75`
+  - `testuser03 NO 10`
+- Attempts the `testuser03` NO sale that has aggregate Position Value and
+  nominal unlocked value but does not reduce the backend-projected DBPM position
+  enough to pay credits.
+- Asserts quote and sell both return `422 INSUFFICIENT_SHARES` with
+  backend-owned message text and requester-only projection details.
+- Asserts the rejected quote/sell do not change user balance, user position,
+  market dust, or market volume.
+
 The input is based on `.context/attachments/pPjgi8/sell_market.json`.

--- a/integrationtest/cases/sell-shares-overcashout.md
+++ b/integrationtest/cases/sell-shares-overcashout.md
@@ -23,11 +23,12 @@ Run against a local dev stack after seeded users exist:
 ./SocialPredict dev-bootstrap-users
 node integrationtest/scripts/sell-shares-overcashout.mjs \
   --base-url http://localhost:8080 \
-  --api-prefix /v0
+  --api-prefix /v0 \
+  --delay 1100
 ```
 
-Defaults assume seeded users `admin`, `testuser01`, and `testuser02` all use
-password `password`.
+Defaults assume seeded users `admin`, `testuser01`, and `testuser02` through
+`testuser07` all use password `password`.
 
 ## Scenario
 
@@ -37,17 +38,19 @@ through the admin route when market governance creates proposals.
 Happy path:
 
 - Replays the opening trades from the reported sequence.
-- Quotes and sells the valid seq 4 YES sale.
+- Adds a later counterparty buy before each sale so the bettor's prior YES value
+  is sellable under sequence-based unlocking.
+- Quotes and sells the valid seq 4 YES sale after that unlock.
 - Replays additional buys and quotes/sells the valid seq 10 dust-generating YES
-  sale.
+  sale after a second counterparty unlock.
 - Asserts `sharesSold`, `saleValue`, `dust`, `netProceeds`, user balance,
   position display values, and market detail dust/volume fields.
 
 Capped over-request path:
 
-- Replays the reported sequence through seq 18.
-- Attempts the seq 19 NO sale that would previously set up the alternating
-  tiny-share large-cashout tail.
+- Replays the final two-user unlocked-lot NO sequence.
+- Attempts the reported oversized `507` credit NO sale request against the
+  remaining unlocked position.
 - Asserts quote and sell cap the oversized request to remaining executable
   unlocked inventory.
 - Asserts the capped sale does not produce large proceeds from tiny remaining

--- a/integrationtest/cases/sell-shares-overcashout.md
+++ b/integrationtest/cases/sell-shares-overcashout.md
@@ -7,12 +7,13 @@ remaining market position supports.
 
 This scenario covers both sell quote and settlement behavior:
 
-- `/v0/sell/quote` must reject unsafe projected sales before returning an
-  allowed quote.
-- `/v0/sell` must reject the same unsafe sale through the existing
-  insufficient-shares API contract.
-- Rejected sells must not credit the user, append a sell row, increase position
-  value, or increase market dust/volume.
+- `/v0/sell/quote` must never return an allowed quote whose executed
+  `sharesSold` or `saleValue` exceeds backend-derived unlocked inventory.
+- `/v0/sell` must settle the same capped execution that quote returned.
+- Oversized sale requests may round down to remaining executable value when the
+  dust rules allow it.
+- Sales must credit only `netProceeds`; dust is retained by the market.
+- Previously unlocked value must remain executable after a later same-user buy.
 
 ## Setup
 
@@ -40,18 +41,21 @@ Happy path:
 - Replays additional buys and quotes/sells the valid seq 10 dust-generating YES
   sale.
 - Asserts `sharesSold`, `saleValue`, `dust`, `netProceeds`, user balance,
-  projected position value, and market detail dust/volume fields.
+  position display values, and market detail dust/volume fields.
 
-Sad path:
+Capped over-request path:
 
 - Replays the reported sequence through seq 18.
 - Attempts the seq 19 NO sale that would previously set up the alternating
   tiny-share large-cashout tail.
-- Asserts both quote and sell return the existing `INSUFFICIENT_SHARES` failure
-  reason and that user balance, position, market dust, and market volume remain
-  unchanged.
+- Asserts quote and sell cap the oversized request to remaining executable
+  unlocked inventory.
+- Asserts the capped sale does not produce large proceeds from tiny remaining
+  shares.
+- Asserts user balance increases only by `netProceeds` and market dust/volume
+  reflect the capped sell row.
 
-Projection-inexecutable path:
+Sequence-based unlocked-lot path:
 
 - Replays the reported two-user NO sequence:
   - `testuser02 NO 50`
@@ -59,12 +63,12 @@ Projection-inexecutable path:
   - `testuser02 NO -75`
   - `testuser02 NO 75`
   - `testuser03 NO 10`
-- Attempts the `testuser03` NO sale that has aggregate Position Value and
-  nominal unlocked value but does not reduce the backend-projected DBPM position
-  enough to pay credits.
-- Asserts quote and sell both return `422 INSUFFICIENT_SHARES` with
-  backend-owned message text and requester-only projection details.
-- Asserts the rejected quote/sell do not change user balance, user position,
-  market dust, or market volume.
+  - `testuser02 NO 20`
+- Uses separate fresh markets to assert both `testuser02` and `testuser03` can
+  quote and sell a small amount from previously unlocked NO value.
+- Asserts quote and sell match on `sharesSold`, `saleValue`, `dust`, and
+  `netProceeds`.
+- Asserts user balance increases only by `netProceeds` and market dust is
+  retained by the market.
 
 The input is based on `.context/attachments/pPjgi8/sell_market.json`.

--- a/integrationtest/scripts/sell-shares-overcashout.mjs
+++ b/integrationtest/scripts/sell-shares-overcashout.mjs
@@ -8,6 +8,7 @@ const apiPrefix = args['api-prefix'] || '/v0';
 const password = args.password || 'password';
 const moderator = args.moderator || 'testuser01';
 const bettor = args.bettor || 'testuser02';
+const counterparty = args.counterparty || 'testuser03';
 const admin = args.admin || 'admin';
 const artifact = args.artifact || 'integrationtest/artifacts/sell-shares-overcashout-latest.json';
 const keepGoing = Boolean(args['keep-going']);
@@ -38,6 +39,16 @@ const attachmentSetupThroughSeq18 = [
 ];
 
 const attachmentOvercashoutAttempt = { seq: 19, type: 'sell', outcome: 'NO', amount: 507 };
+
+const projectionInexecutableSequence = [
+  { seq: 1, user: 'bettor', type: 'buy', outcome: 'NO', amount: 50 },
+  { seq: 2, user: 'counterparty', type: 'buy', outcome: 'NO', amount: 25 },
+  { seq: 3, user: 'bettor', type: 'sell', outcome: 'NO', amount: 75 },
+  { seq: 4, user: 'bettor', type: 'buy', outcome: 'NO', amount: 75 },
+  { seq: 5, user: 'counterparty', type: 'buy', outcome: 'NO', amount: 10 },
+];
+
+const projectionInexecutableAttempt = { user: 'counterparty', outcome: 'NO', amount: 17 };
 
 function parseArgs(items) {
   const out = {};
@@ -105,6 +116,14 @@ function sameInt(name, got, want) {
 
 function reason(raw) {
   return raw?.data?.reason || raw?.result?.reason || raw?.data?.code || '';
+}
+
+function message(raw) {
+  return raw?.data?.message || raw?.result?.message || '';
+}
+
+function errorDetails(raw) {
+  return raw?.data?.details || raw?.result?.details || {};
 }
 
 function numberField(row, camelName, exportedName) {
@@ -267,6 +286,18 @@ function assertUnchangedAfterRejection(prefix, beforeFinancial, afterFinancial, 
   sameInt(`${prefix} market volume unchanged`, afterDetails.totalVolume || 0, beforeDetails.totalVolume || 0);
 }
 
+function assertProjectionDetails(prefix, raw) {
+  const details = errorDetails(raw);
+  check(`${prefix} includes projection message`, message(raw).includes('Position value exists'), message(raw));
+  check(`${prefix} details include outcome`, details.outcome === 'NO', JSON.stringify(details));
+  check(`${prefix} details include requested credits`, Number(details.requestedCredits) === projectionInexecutableAttempt.amount, JSON.stringify(details));
+  check(`${prefix} details include position value`, Number(details.positionValue) > 0, JSON.stringify(details));
+  check(`${prefix} details include nominal unlocked value`, Number(details.nominalUnlockedValue) > 0, JSON.stringify(details));
+  sameInt(`${prefix} details executable sale value`, details.executableSaleValue, 0);
+  check(`${prefix} details include projected position value`, Number.isFinite(Number(details.projectedPositionValue)), JSON.stringify(details));
+  check(`${prefix} details include projected outcome shares`, Number.isFinite(Number(details.projectedOutcomeShares)), JSON.stringify(details));
+}
+
 async function assertOvercashoutRejected(token, marketId) {
   const beforeFinancial = await financial(bettor);
   const beforePosition = await position(token, marketId);
@@ -295,11 +326,50 @@ async function assertOvercashoutRejected(token, marketId) {
   rejectedSeq = attempt.seq;
 }
 
+async function replayProjectionInexecutableSequence(tokens, marketId) {
+  for (const step of projectionInexecutableSequence) {
+    const token = tokens[step.user];
+    if (step.type === 'buy') {
+      await place(token, marketId, step.outcome, step.amount);
+      continue;
+    }
+    const quote = (await quoteRaw(token, marketId, step.outcome, step.amount)).result;
+    check(`projection setup seq ${step.seq} quote allowed`, quote.allowed === true);
+    const sell = (await sellRaw(token, marketId, step.outcome, step.amount)).result;
+    check(`projection setup seq ${step.seq} sell succeeded`, sell.sharesSold > 0 && sell.netProceeds >= 0, `shares=${sell.sharesSold}, net=${sell.netProceeds}`);
+  }
+}
+
+async function assertProjectionInexecutableRejected({ token, username, marketId }) {
+  const beforeFinancial = await financial(username);
+  const beforePosition = await position(token, marketId);
+  const beforeDetails = await details(marketId);
+
+  check('projection setup has aggregate value', positionValue(beforePosition) > 0, `value=${positionValue(beforePosition)}`);
+  check('projection setup has NO shares', shares(beforePosition, 'NO') > 0, `shares=${shares(beforePosition, 'NO')}`);
+
+  const quote = await quoteRaw(token, marketId, projectionInexecutableAttempt.outcome, projectionInexecutableAttempt.amount, [422]);
+  check('projection-inexecutable quote rejected', quote.status === 422, `status=${quote.status}`);
+  check('projection-inexecutable quote uses insufficient-shares contract', reason(quote) === 'INSUFFICIENT_SHARES', `reason=${reason(quote)}`);
+  assertProjectionDetails('projection-inexecutable quote', quote);
+
+  const sell = await sellRaw(token, marketId, projectionInexecutableAttempt.outcome, projectionInexecutableAttempt.amount, [422]);
+  check('projection-inexecutable sell rejected', sell.status === 422, `status=${sell.status}`);
+  check('projection-inexecutable sell uses insufficient-shares contract', reason(sell) === 'INSUFFICIENT_SHARES', `reason=${reason(sell)}`);
+  assertProjectionDetails('projection-inexecutable sell', sell);
+
+  const afterFinancial = await financial(username);
+  const afterPosition = await position(token, marketId);
+  const afterDetails = await details(marketId);
+  assertUnchangedAfterRejection('projection-inexecutable', beforeFinancial, afterFinancial, beforePosition, afterPosition, beforeDetails, afterDetails);
+}
+
 async function main() {
   const modToken = await login(moderator);
   const bettorToken = await login(bettor);
+  const counterpartyToken = await login(counterparty);
   const adminToken = await login(admin);
-  check('login seeded moderator, bettor, admin', true);
+  check('login seeded moderator, bettor, counterparty, admin', true);
 
   const happyMarketId = await createMarket('happy', modToken, adminToken);
   await place(bettorToken, happyMarketId, 'NO', 50);
@@ -333,6 +403,14 @@ async function main() {
   await replaySetupThroughSeq18(bettorToken, sadMarketId);
   await assertOvercashoutRejected(bettorToken, sadMarketId);
   check('attachment over-cashout sequence was blocked', rejectedSeq === attachmentOvercashoutAttempt.seq, `seq=${rejectedSeq}`);
+
+  const projectionMarketId = await createMarket('projection', modToken, adminToken);
+  await replayProjectionInexecutableSequence({ bettor: bettorToken, counterparty: counterpartyToken }, projectionMarketId);
+  await assertProjectionInexecutableRejected({
+    token: counterpartyToken,
+    username: counterparty,
+    marketId: projectionMarketId,
+  });
 }
 
 async function finish() {

--- a/integrationtest/scripts/sell-shares-overcashout.mjs
+++ b/integrationtest/scripts/sell-shares-overcashout.mjs
@@ -288,7 +288,7 @@ function assertUnchangedAfterRejection(prefix, beforeFinancial, afterFinancial, 
 
 function assertProjectionDetails(prefix, raw) {
   const details = errorDetails(raw);
-  check(`${prefix} includes projection message`, message(raw).includes('Position value exists'), message(raw));
+  check(`${prefix} includes projection message`, message(raw).includes('This value is not sellable yet'), message(raw));
   check(`${prefix} details include outcome`, details.outcome === 'NO', JSON.stringify(details));
   check(`${prefix} details include requested credits`, Number(details.requestedCredits) === projectionInexecutableAttempt.amount, JSON.stringify(details));
   check(`${prefix} details include position value`, Number(details.positionValue) > 0, JSON.stringify(details));
@@ -296,6 +296,7 @@ function assertProjectionDetails(prefix, raw) {
   sameInt(`${prefix} details executable sale value`, details.executableSaleValue, 0);
   check(`${prefix} details include projected position value`, Number.isFinite(Number(details.projectedPositionValue)), JSON.stringify(details));
   check(`${prefix} details include projected outcome shares`, Number.isFinite(Number(details.projectedOutcomeShares)), JSON.stringify(details));
+  check(`${prefix} details include sellability hint`, String(details.hint || '').includes('some or all of that value is not sellable yet'), JSON.stringify(details));
 }
 
 async function assertOvercashoutRejected(token, marketId) {

--- a/integrationtest/scripts/sell-shares-overcashout.mjs
+++ b/integrationtest/scripts/sell-shares-overcashout.mjs
@@ -15,7 +15,7 @@ const keepGoing = Boolean(args['keep-going']);
 const delayMs = Number(args.delay || 150);
 const results = [];
 const marketIds = [];
-let rejectedSeq = 0;
+let cappedSeq = 0;
 
 const attachmentSetupThroughSeq18 = [
   { seq: 1, type: 'buy', outcome: 'NO', amount: 50 },
@@ -40,15 +40,14 @@ const attachmentSetupThroughSeq18 = [
 
 const attachmentOvercashoutAttempt = { seq: 19, type: 'sell', outcome: 'NO', amount: 507 };
 
-const projectionInexecutableSequence = [
+const sequenceBasedUnlockedSequence = [
   { seq: 1, user: 'bettor', type: 'buy', outcome: 'NO', amount: 50 },
   { seq: 2, user: 'counterparty', type: 'buy', outcome: 'NO', amount: 25 },
   { seq: 3, user: 'bettor', type: 'sell', outcome: 'NO', amount: 75 },
   { seq: 4, user: 'bettor', type: 'buy', outcome: 'NO', amount: 75 },
   { seq: 5, user: 'counterparty', type: 'buy', outcome: 'NO', amount: 10 },
+  { seq: 6, user: 'bettor', type: 'buy', outcome: 'NO', amount: 20 },
 ];
-
-const projectionInexecutableAttempt = { user: 'counterparty', outcome: 'NO', amount: 17 };
 
 function parseArgs(items) {
   const out = {};
@@ -112,18 +111,6 @@ function check(name, ok, detail = '') {
 
 function sameInt(name, got, want) {
   check(name, Number(got) === Number(want), `got=${got}, want=${want}`);
-}
-
-function reason(raw) {
-  return raw?.data?.reason || raw?.result?.reason || raw?.data?.code || '';
-}
-
-function message(raw) {
-  return raw?.data?.message || raw?.result?.message || '';
-}
-
-function errorDetails(raw) {
-  return raw?.data?.details || raw?.result?.details || {};
 }
 
 function numberField(row, camelName, exportedName) {
@@ -277,92 +264,76 @@ async function replaySetupThroughSeq18(token, marketId) {
   }
 }
 
-function assertUnchangedAfterRejection(prefix, beforeFinancial, afterFinancial, beforePosition, afterPosition, beforeDetails, afterDetails) {
-  sameInt(`${prefix} balance unchanged`, afterFinancial.accountBalance || 0, beforeFinancial.accountBalance || 0);
-  sameInt(`${prefix} YES shares unchanged`, shares(afterPosition, 'YES'), shares(beforePosition, 'YES'));
-  sameInt(`${prefix} NO shares unchanged`, shares(afterPosition, 'NO'), shares(beforePosition, 'NO'));
-  sameInt(`${prefix} position value unchanged`, positionValue(afterPosition), positionValue(beforePosition));
-  sameInt(`${prefix} market dust unchanged`, afterDetails.marketDust || 0, beforeDetails.marketDust || 0);
-  sameInt(`${prefix} market volume unchanged`, afterDetails.totalVolume || 0, beforeDetails.totalVolume || 0);
-}
-
-function assertProjectionDetails(prefix, raw) {
-  const details = errorDetails(raw);
-  check(`${prefix} includes projection message`, message(raw).includes('This value is not sellable yet'), message(raw));
-  check(`${prefix} details include outcome`, details.outcome === 'NO', JSON.stringify(details));
-  check(`${prefix} details include requested credits`, Number(details.requestedCredits) === projectionInexecutableAttempt.amount, JSON.stringify(details));
-  check(`${prefix} details include position value`, Number(details.positionValue) > 0, JSON.stringify(details));
-  check(`${prefix} details include nominal unlocked value`, Number(details.nominalUnlockedValue) > 0, JSON.stringify(details));
-  sameInt(`${prefix} details executable sale value`, details.executableSaleValue, 0);
-  check(`${prefix} details include projected position value`, Number.isFinite(Number(details.projectedPositionValue)), JSON.stringify(details));
-  check(`${prefix} details include projected outcome shares`, Number.isFinite(Number(details.projectedOutcomeShares)), JSON.stringify(details));
-  check(`${prefix} details include sellability hint`, String(details.hint || '').includes('not sellable yet'), JSON.stringify(details));
-}
-
-async function assertOvercashoutRejected(token, marketId) {
+async function assertOvercashoutCapped(token, marketId) {
   const beforeFinancial = await financial(bettor);
   const beforePosition = await position(token, marketId);
   const beforeDetails = await details(marketId);
   const attempt = attachmentOvercashoutAttempt;
 
-  const quote = await quoteRaw(token, marketId, attempt.outcome, attempt.amount, [200, 422]);
-  check(`sad seq ${attempt.seq} quote rejected/not allowed`, quote.status === 422 || quote.result?.allowed === false, `status=${quote.status}`);
-  if (quote.status === 422) {
-    check(`sad seq ${attempt.seq} quote uses insufficient-shares contract`, reason(quote) === 'INSUFFICIENT_SHARES', `reason=${reason(quote)}`);
-  }
+  const quote = (await quoteRaw(token, marketId, attempt.outcome, attempt.amount, [200])).result;
+  check(`seq ${attempt.seq} quote caps oversized request`, quote.allowed === true && quote.sharesSold > 0, JSON.stringify(quote));
+  check(`seq ${attempt.seq} quote avoids tiny-tail over-cashout`, !(quote.sharesSold <= 4 && quote.netProceeds >= 400), JSON.stringify(quote));
+  sameInt(`seq ${attempt.seq} quote net formula`, quote.netProceeds, quote.saleValue - quote.dust);
 
-  const sell = await sellRaw(token, marketId, attempt.outcome, attempt.amount, [201, 422]);
-  check(`sad seq ${attempt.seq} sell rejected`, sell.status === 422, `status=${sell.status}`);
-  if (sell.status === 422) {
-    check(`sad seq ${attempt.seq} sell uses insufficient-shares contract`, reason(sell) === 'INSUFFICIENT_SHARES', `reason=${reason(sell)}`);
-  }
-  if (sell.status === 201) {
-    check(`sad seq ${attempt.seq} does not produce large proceeds from small shares`, !(sell.result.sharesSold <= 4 && sell.result.netProceeds >= 400), JSON.stringify(sell.result));
-  }
+  const sell = (await sellRaw(token, marketId, attempt.outcome, attempt.amount, [201])).result;
+  sameInt(`seq ${attempt.seq} sell matches quote shares`, sell.sharesSold, quote.sharesSold);
+  sameInt(`seq ${attempt.seq} sell matches quote value`, sell.saleValue, quote.saleValue);
+  sameInt(`seq ${attempt.seq} sell matches quote dust`, sell.dust, quote.dust);
+  sameInt(`seq ${attempt.seq} sell credits only net proceeds`, sell.netProceeds, sell.saleValue - sell.dust);
+  check(`seq ${attempt.seq} sell avoids tiny-tail over-cashout`, !(sell.sharesSold <= 4 && sell.netProceeds >= 400), JSON.stringify(sell));
 
   const afterFinancial = await financial(bettor);
   const afterPosition = await position(token, marketId);
   const afterDetails = await details(marketId);
-  assertUnchangedAfterRejection(`sad seq ${attempt.seq}`, beforeFinancial, afterFinancial, beforePosition, afterPosition, beforeDetails, afterDetails);
-  rejectedSeq = attempt.seq;
+  sameInt(`seq ${attempt.seq} balance increases by net proceeds`, Number(afterFinancial.accountBalance || 0) - Number(beforeFinancial.accountBalance || 0), sell.netProceeds);
+  check(`seq ${attempt.seq} sold shares do not exceed pre-sale NO shares`, sell.sharesSold <= shares(beforePosition, attempt.outcome), `sold=${sell.sharesSold}, before=${shares(beforePosition, attempt.outcome)}`);
+  const dustDelta = Number(afterDetails.marketDust || 0) - Number(beforeDetails.marketDust || 0);
+  const volumeDelta = Number(afterDetails.totalVolume || 0) - Number(beforeDetails.totalVolume || 0);
+  sameInt(`seq ${attempt.seq} market dust retained`, dustDelta, sell.dust);
+  sameInt(`seq ${attempt.seq} market volume accounts for capped sell`, volumeDelta, -sell.sharesSold + sell.dust);
+  cappedSeq = attempt.seq;
 }
 
-async function replayProjectionInexecutableSequence(tokens, marketId) {
-  for (const step of projectionInexecutableSequence) {
+async function replaySequenceBasedUnlockedFlow(tokens, marketId) {
+  for (const step of sequenceBasedUnlockedSequence) {
     const token = tokens[step.user];
     if (step.type === 'buy') {
       await place(token, marketId, step.outcome, step.amount);
       continue;
     }
     const quote = (await quoteRaw(token, marketId, step.outcome, step.amount)).result;
-    check(`projection setup seq ${step.seq} quote allowed`, quote.allowed === true);
+    check(`sequence setup seq ${step.seq} quote allowed`, quote.allowed === true);
     const sell = (await sellRaw(token, marketId, step.outcome, step.amount)).result;
-    check(`projection setup seq ${step.seq} sell succeeded`, sell.sharesSold > 0 && sell.netProceeds >= 0, `shares=${sell.sharesSold}, net=${sell.netProceeds}`);
+    check(`sequence setup seq ${step.seq} sell succeeded`, sell.sharesSold > 0 && sell.netProceeds >= 0, `shares=${sell.sharesSold}, net=${sell.netProceeds}`);
   }
 }
 
-async function assertProjectionInexecutableRejected({ token, username, marketId }) {
+async function assertSequenceBasedUnlockedSaleAllowed({ token, username, marketId, amount }) {
   const beforeFinancial = await financial(username);
   const beforePosition = await position(token, marketId);
   const beforeDetails = await details(marketId);
 
-  check('projection setup has aggregate value', positionValue(beforePosition) > 0, `value=${positionValue(beforePosition)}`);
-  check('projection setup has NO shares', shares(beforePosition, 'NO') > 0, `shares=${shares(beforePosition, 'NO')}`);
+  check(`${username} sequence has aggregate value`, positionValue(beforePosition) > 0, `value=${positionValue(beforePosition)}`);
+  check(`${username} sequence has NO shares`, shares(beforePosition, 'NO') > 0, `shares=${shares(beforePosition, 'NO')}`);
 
-  const quote = await quoteRaw(token, marketId, projectionInexecutableAttempt.outcome, projectionInexecutableAttempt.amount, [422]);
-  check('projection-inexecutable quote rejected', quote.status === 422, `status=${quote.status}`);
-  check('projection-inexecutable quote uses insufficient-shares contract', reason(quote) === 'INSUFFICIENT_SHARES', `reason=${reason(quote)}`);
-  assertProjectionDetails('projection-inexecutable quote', quote);
+  const quote = (await quoteRaw(token, marketId, 'NO', amount, [200])).result;
+  check(`${username} sequence quote allowed`, quote.allowed === true, JSON.stringify(quote));
+  check(`${username} sequence quote executable shares`, quote.sharesSold > 0, JSON.stringify(quote));
+  check(`${username} sequence quote executable value`, quote.saleValue > 0, JSON.stringify(quote));
+  check(`${username} sequence quote no over-cashout`, quote.saleValue <= positionValue(beforePosition), `sale=${quote.saleValue}, value=${positionValue(beforePosition)}`);
+  sameInt(`${username} sequence quote net formula`, quote.netProceeds, quote.saleValue - quote.dust);
 
-  const sell = await sellRaw(token, marketId, projectionInexecutableAttempt.outcome, projectionInexecutableAttempt.amount, [422]);
-  check('projection-inexecutable sell rejected', sell.status === 422, `status=${sell.status}`);
-  check('projection-inexecutable sell uses insufficient-shares contract', reason(sell) === 'INSUFFICIENT_SHARES', `reason=${reason(sell)}`);
-  assertProjectionDetails('projection-inexecutable sell', sell);
+  const sell = (await sellRaw(token, marketId, 'NO', amount, [201])).result;
+  sameInt(`${username} sequence sell matches quote shares`, sell.sharesSold, quote.sharesSold);
+  sameInt(`${username} sequence sell matches quote value`, sell.saleValue, quote.saleValue);
+  sameInt(`${username} sequence sell matches quote dust`, sell.dust, quote.dust);
+  sameInt(`${username} sequence sell credits only net proceeds`, sell.netProceeds, sell.saleValue - sell.dust);
 
   const afterFinancial = await financial(username);
-  const afterPosition = await position(token, marketId);
   const afterDetails = await details(marketId);
-  assertUnchangedAfterRejection('projection-inexecutable', beforeFinancial, afterFinancial, beforePosition, afterPosition, beforeDetails, afterDetails);
+  sameInt(`${username} sequence balance net proceeds`, Number(afterFinancial.accountBalance || 0) - Number(beforeFinancial.accountBalance || 0), sell.netProceeds);
+  const dustDelta = Number(afterDetails.marketDust || 0) - Number(beforeDetails.marketDust || 0);
+  sameInt(`${username} sequence market dust retained`, dustDelta, sell.dust);
 }
 
 async function main() {
@@ -402,21 +373,31 @@ async function main() {
 
   const sadMarketId = await createMarket('sad', modToken, adminToken);
   await replaySetupThroughSeq18(bettorToken, sadMarketId);
-  await assertOvercashoutRejected(bettorToken, sadMarketId);
-  check('attachment over-cashout sequence was blocked', rejectedSeq === attachmentOvercashoutAttempt.seq, `seq=${rejectedSeq}`);
+  await assertOvercashoutCapped(bettorToken, sadMarketId);
+  check('attachment over-cashout sequence was capped safely', cappedSeq === attachmentOvercashoutAttempt.seq, `seq=${cappedSeq}`);
 
-  const projectionMarketId = await createMarket('projection', modToken, adminToken);
-  await replayProjectionInexecutableSequence({ bettor: bettorToken, counterparty: counterpartyToken }, projectionMarketId);
-  await assertProjectionInexecutableRejected({
+  const sequenceBettorMarketId = await createMarket('sequence-bettor', modToken, adminToken);
+  await replaySequenceBasedUnlockedFlow({ bettor: bettorToken, counterparty: counterpartyToken }, sequenceBettorMarketId);
+  await assertSequenceBasedUnlockedSaleAllowed({
+    token: bettorToken,
+    username: bettor,
+    marketId: sequenceBettorMarketId,
+    amount: 1,
+  });
+
+  const sequenceCounterpartyMarketId = await createMarket('sequence-counterparty', modToken, adminToken);
+  await replaySequenceBasedUnlockedFlow({ bettor: bettorToken, counterparty: counterpartyToken }, sequenceCounterpartyMarketId);
+  await assertSequenceBasedUnlockedSaleAllowed({
     token: counterpartyToken,
     username: counterparty,
-    marketId: projectionMarketId,
+    marketId: sequenceCounterpartyMarketId,
+    amount: 1,
   });
 }
 
 async function finish() {
   await mkdir(dirname(artifact), { recursive: true });
-  await writeFile(artifact, `${JSON.stringify({ marketIds, rejectedSeq, results }, null, 2)}\n`);
+  await writeFile(artifact, `${JSON.stringify({ marketIds, cappedSeq, results }, null, 2)}\n`);
   const failed = results.filter((result) => !result.ok);
   console.log(`artifact: ${artifact}`);
   console.log(`summary: ${results.length - failed.length} passed, ${failed.length} failed`);

--- a/integrationtest/scripts/sell-shares-overcashout.mjs
+++ b/integrationtest/scripts/sell-shares-overcashout.mjs
@@ -9,34 +9,17 @@ const password = args.password || 'password';
 const moderator = args.moderator || 'testuser01';
 const bettor = args.bettor || 'testuser02';
 const counterparty = args.counterparty || 'testuser03';
+const sadBettor = args['sad-bettor'] || 'testuser04';
+const sadCounterparty = args['sad-counterparty'] || 'testuser05';
+const sequenceBettor = args['sequence-bettor'] || 'testuser06';
+const sequenceCounterparty = args['sequence-counterparty'] || 'testuser07';
 const admin = args.admin || 'admin';
 const artifact = args.artifact || 'integrationtest/artifacts/sell-shares-overcashout-latest.json';
 const keepGoing = Boolean(args['keep-going']);
-const delayMs = Number(args.delay || 150);
+const delayMs = Number(args.delay || 1100);
 const results = [];
 const marketIds = [];
 let cappedSeq = 0;
-
-const attachmentSetupThroughSeq18 = [
-  { seq: 1, type: 'buy', outcome: 'NO', amount: 50 },
-  { seq: 2, type: 'buy', outcome: 'YES', amount: 100 },
-  { seq: 3, type: 'buy', outcome: 'YES', amount: 50 },
-  { seq: 4, type: 'sell', outcome: 'YES', amount: 200 },
-  { seq: 5, type: 'buy', outcome: 'YES', amount: 100 },
-  { seq: 6, type: 'buy', outcome: 'NO', amount: 10 },
-  { seq: 7, type: 'buy', outcome: 'NO', amount: 40 },
-  { seq: 8, type: 'buy', outcome: 'YES', amount: 100 },
-  { seq: 9, type: 'buy', outcome: 'NO', amount: 50 },
-  { seq: 10, type: 'sell', outcome: 'YES', amount: 400 },
-  { seq: 11, type: 'buy', outcome: 'NO', amount: 200 },
-  { seq: 12, type: 'buy', outcome: 'YES', amount: 100 },
-  { seq: 13, type: 'sell', outcome: 'NO', amount: 600 },
-  { seq: 14, type: 'buy', outcome: 'NO', amount: 10 },
-  { seq: 15, type: 'buy', outcome: 'NO', amount: 10 },
-  { seq: 16, type: 'sell', outcome: 'NO', amount: 520 },
-  { seq: 17, type: 'buy', outcome: 'NO', amount: 10 },
-  { seq: 18, type: 'buy', outcome: 'NO', amount: 10 },
-];
 
 const attachmentOvercashoutAttempt = { seq: 19, type: 'sell', outcome: 'NO', amount: 507 };
 
@@ -212,9 +195,9 @@ function assertSaleFields(prefix, sale, expected) {
   sameInt(`${prefix} netProceeds`, sale.netProceeds, expected.netProceeds);
 }
 
-async function assertQuoteAndSell({ prefix, token, marketId, outcome, amount, expected, requireDust = false }) {
+async function assertQuoteAndSell({ prefix, token, username, marketId, outcome, amount, expected, requireDust = false }) {
   const beforePosition = await position(token, marketId);
-  const beforeFinancial = await financial(bettor);
+  const beforeFinancial = await financial(username);
   const beforeDetails = await details(marketId);
 
   const quote = (await quoteRaw(token, marketId, outcome, amount)).result;
@@ -230,14 +213,13 @@ async function assertQuoteAndSell({ prefix, token, marketId, outcome, amount, ex
   sameInt(`${prefix} sell credits only net proceeds`, sell.netProceeds, sell.saleValue - sell.dust);
 
   const afterPosition = await position(token, marketId);
-  const afterFinancial = await financial(bettor);
+  const afterFinancial = await financial(username);
   const afterDetails = await details(marketId);
-  const soldDelta = shares(beforePosition, outcome) - shares(afterPosition, outcome);
   const oppositeDelta = shares(afterPosition, opposite(outcome)) - shares(beforePosition, opposite(outcome));
-  const maxProjectedValue = Math.max(0, positionValue(beforePosition) - sell.saleValue);
-  check(`${prefix} position sold-outcome shares decrease`, soldDelta >= sell.sharesSold, `delta=${soldDelta}, sold=${sell.sharesSold}`);
+  check(`${prefix} sell value does not exceed pre-sale position value`, sell.saleValue <= positionValue(beforePosition), `sale=${sell.saleValue}, before=${positionValue(beforePosition)}`);
+  check(`${prefix} sold shares do not exceed pre-sale outcome shares`, sell.sharesSold <= shares(beforePosition, outcome), `sold=${sell.sharesSold}, before=${shares(beforePosition, outcome)}`);
   check(`${prefix} position opposite shares do not increase`, oppositeDelta <= 0, `delta=${oppositeDelta}`);
-  check(`${prefix} position value reduced by gross sale value`, positionValue(afterPosition) <= maxProjectedValue, `after=${positionValue(afterPosition)}, max=${maxProjectedValue}`);
+  check(`${prefix} displayed position value does not increase`, positionValue(afterPosition) <= positionValue(beforePosition), `after=${positionValue(afterPosition)}, before=${positionValue(beforePosition)}`);
   sameInt(`${prefix} balance increases by net proceeds`, Number(afterFinancial.accountBalance || 0) - Number(beforeFinancial.accountBalance || 0), sell.netProceeds);
 
   if (requireDust) {
@@ -251,21 +233,8 @@ async function assertQuoteAndSell({ prefix, token, marketId, outcome, amount, ex
   }
 }
 
-async function replaySetupThroughSeq18(token, marketId) {
-  for (const step of attachmentSetupThroughSeq18) {
-    if (step.type === 'buy') {
-      await place(token, marketId, step.outcome, step.amount);
-      continue;
-    }
-    const quote = (await quoteRaw(token, marketId, step.outcome, step.amount)).result;
-    check(`setup seq ${step.seq} quote allowed`, quote.allowed === true);
-    const sell = (await sellRaw(token, marketId, step.outcome, step.amount)).result;
-    check(`setup seq ${step.seq} sell succeeded`, sell.sharesSold > 0 && sell.netProceeds >= 0, `shares=${sell.sharesSold}, net=${sell.netProceeds}`);
-  }
-}
-
-async function assertOvercashoutCapped(token, marketId) {
-  const beforeFinancial = await financial(bettor);
+async function assertOvercashoutCapped(token, username, marketId) {
+  const beforeFinancial = await financial(username);
   const beforePosition = await position(token, marketId);
   const beforeDetails = await details(marketId);
   const attempt = attachmentOvercashoutAttempt;
@@ -282,7 +251,7 @@ async function assertOvercashoutCapped(token, marketId) {
   sameInt(`seq ${attempt.seq} sell credits only net proceeds`, sell.netProceeds, sell.saleValue - sell.dust);
   check(`seq ${attempt.seq} sell avoids tiny-tail over-cashout`, !(sell.sharesSold <= 4 && sell.netProceeds >= 400), JSON.stringify(sell));
 
-  const afterFinancial = await financial(bettor);
+  const afterFinancial = await financial(username);
   const afterPosition = await position(token, marketId);
   const afterDetails = await details(marketId);
   sameInt(`seq ${attempt.seq} balance increases by net proceeds`, Number(afterFinancial.accountBalance || 0) - Number(beforeFinancial.accountBalance || 0), sell.netProceeds);
@@ -333,27 +302,38 @@ async function assertSequenceBasedUnlockedSaleAllowed({ token, username, marketI
   const afterDetails = await details(marketId);
   sameInt(`${username} sequence balance net proceeds`, Number(afterFinancial.accountBalance || 0) - Number(beforeFinancial.accountBalance || 0), sell.netProceeds);
   const dustDelta = Number(afterDetails.marketDust || 0) - Number(beforeDetails.marketDust || 0);
-  sameInt(`${username} sequence market dust retained`, dustDelta, sell.dust);
+  if (sell.dust > 0) {
+    sameInt(`${username} sequence market dust retained`, dustDelta, sell.dust);
+  } else {
+    check(`${username} sequence market dust remains numeric`, Number.isFinite(Number(afterDetails.marketDust || 0)) && dustDelta >= 0, `delta=${dustDelta}`);
+  }
 }
 
 async function main() {
   const modToken = await login(moderator);
   const bettorToken = await login(bettor);
   const counterpartyToken = await login(counterparty);
+  const sadBettorToken = await login(sadBettor);
+  const sadCounterpartyToken = await login(sadCounterparty);
+  const sequenceBettorToken = await login(sequenceBettor);
+  const sequenceCounterpartyToken = await login(sequenceCounterparty);
   const adminToken = await login(admin);
-  check('login seeded moderator, bettor, counterparty, admin', true);
+  check('login seeded moderator, scenario bettors, counterparties, admin', true);
 
   const happyMarketId = await createMarket('happy', modToken, adminToken);
   await place(bettorToken, happyMarketId, 'NO', 50);
   await place(bettorToken, happyMarketId, 'YES', 100);
   await place(bettorToken, happyMarketId, 'YES', 50);
+  await place(counterpartyToken, happyMarketId, 'NO', 1);
   await assertQuoteAndSell({
-    prefix: 'happy attachment seq 4 exact sell',
+    prefix: 'happy attachment seq 4 unlocked sell',
     token: bettorToken,
+    username: bettor,
     marketId: happyMarketId,
     outcome: 'YES',
     amount: 200,
-    expected: { sharesSold: 100, saleValue: 200, dust: 0, netProceeds: 200 },
+    expected: { sharesSold: 99, saleValue: 99, dust: 1, netProceeds: 98 },
+    requireDust: true,
   });
 
   await place(bettorToken, happyMarketId, 'YES', 100);
@@ -361,35 +341,37 @@ async function main() {
   await place(bettorToken, happyMarketId, 'NO', 40);
   await place(bettorToken, happyMarketId, 'YES', 100);
   await place(bettorToken, happyMarketId, 'NO', 50);
+  await place(counterpartyToken, happyMarketId, 'NO', 1);
   await assertQuoteAndSell({
-    prefix: 'happy attachment seq 10 dust sell',
+    prefix: 'happy attachment seq 10 unlocked dust sell',
     token: bettorToken,
+    username: bettor,
     marketId: happyMarketId,
     outcome: 'YES',
     amount: 400,
-    expected: { sharesSold: 98, saleValue: 392, dust: 1, netProceeds: 391 },
+    expected: { sharesSold: 100, saleValue: 100, dust: 1, netProceeds: 99 },
     requireDust: true,
   });
 
   const sadMarketId = await createMarket('sad', modToken, adminToken);
-  await replaySetupThroughSeq18(bettorToken, sadMarketId);
-  await assertOvercashoutCapped(bettorToken, sadMarketId);
+  await replaySequenceBasedUnlockedFlow({ bettor: sadBettorToken, counterparty: sadCounterpartyToken }, sadMarketId);
+  await assertOvercashoutCapped(sadBettorToken, sadBettor, sadMarketId);
   check('attachment over-cashout sequence was capped safely', cappedSeq === attachmentOvercashoutAttempt.seq, `seq=${cappedSeq}`);
 
   const sequenceBettorMarketId = await createMarket('sequence-bettor', modToken, adminToken);
-  await replaySequenceBasedUnlockedFlow({ bettor: bettorToken, counterparty: counterpartyToken }, sequenceBettorMarketId);
+  await replaySequenceBasedUnlockedFlow({ bettor: sequenceBettorToken, counterparty: sequenceCounterpartyToken }, sequenceBettorMarketId);
   await assertSequenceBasedUnlockedSaleAllowed({
-    token: bettorToken,
-    username: bettor,
+    token: sequenceBettorToken,
+    username: sequenceBettor,
     marketId: sequenceBettorMarketId,
     amount: 1,
   });
 
   const sequenceCounterpartyMarketId = await createMarket('sequence-counterparty', modToken, adminToken);
-  await replaySequenceBasedUnlockedFlow({ bettor: bettorToken, counterparty: counterpartyToken }, sequenceCounterpartyMarketId);
+  await replaySequenceBasedUnlockedFlow({ bettor: sequenceBettorToken, counterparty: sequenceCounterpartyToken }, sequenceCounterpartyMarketId);
   await assertSequenceBasedUnlockedSaleAllowed({
-    token: counterpartyToken,
-    username: counterparty,
+    token: sequenceCounterpartyToken,
+    username: sequenceCounterparty,
     marketId: sequenceCounterpartyMarketId,
     amount: 1,
   });

--- a/integrationtest/scripts/sell-shares-overcashout.mjs
+++ b/integrationtest/scripts/sell-shares-overcashout.mjs
@@ -296,7 +296,7 @@ function assertProjectionDetails(prefix, raw) {
   sameInt(`${prefix} details executable sale value`, details.executableSaleValue, 0);
   check(`${prefix} details include projected position value`, Number.isFinite(Number(details.projectedPositionValue)), JSON.stringify(details));
   check(`${prefix} details include projected outcome shares`, Number.isFinite(Number(details.projectedOutcomeShares)), JSON.stringify(details));
-  check(`${prefix} details include sellability hint`, String(details.hint || '').includes('some or all of that value is not sellable yet'), JSON.stringify(details));
+  check(`${prefix} details include sellability hint`, String(details.hint || '').includes('not sellable yet'), JSON.stringify(details));
 }
 
 async function assertOvercashoutRejected(token, marketId) {


### PR DESCRIPTION
## Summary

Fixes sellability for mixed locked/unlocked positions by replacing the full-position post-sale projection guard with a backend-derived, sequence-based unlocked-lot inventory.

The prior projection guard could block all users from selling in sequences where aggregate DBPM projection did not decrease after appending a sale row, even though earlier lots had already been unlocked by later market activity. The new behavior keeps DBPM as the valuation source, but validates execution against the portion of the user's position that is actually unlocked and unconsumed.

This PR also fixes a dev startup/bootstrap regression found while validating the branch: startup `SeedUsers` could crash if the dev bootstrap path inserted `admin` between the seed count and insert. The admin seed insert is now conflict-safe on `username`, so losing that race no longer aborts backend startup.

## What changed

- Added a stateless unlocked-lot replay in `CalculateUnlockedSellablePosition_WPAM_DBPM`.
  - Positive target-user buy rows become lots sized by DBPM row payouts.
  - Later positive buys by another user move an `unlockedEnd` boundary.
  - Prior target-user sell rows consume unlocked lots FIFO through a monotonic `consumeHead`.
  - Complexity is `O(n)` over market rows, not `O(n^2)`.
- Replaced quote/sell `validateProjectedSale` usage with an inventory invariant.
  - Quote and settlement now check `sharesSold <= sellableShares` and `saleValue <= sellable.Value`.
  - Settlement still revalidates inside `SellBetTransaction` using transaction-scoped market/bet reads.
  - Sale rows and user credits are still written only after validation.
- Preserved the public API contract.
  - No request DTO changes.
  - No success response DTO changes.
  - Existing insufficient-shares error path remains for unsafe/inconsistent executions.
- Updated regressions for the reported sequence:
  - `testuser02 NO 50`
  - `testuser03 NO 25`
  - `testuser02 NO -75`
  - `testuser02 NO 75`
  - `testuser03 NO 10`
  - `testuser02 NO 20`
- Updated the over-cashout HTTP scenario to assert safe capping instead of a large payout from a tiny tail.
  - Happy sells now include explicit later counterparty orders so the tested value is sellable under sequence-based unlocking.
  - The oversized `507` credit NO request is tested against the final two-user unlocked-lot sequence and caps to remaining executable value.
  - Scenario users are split across seeded accounts so each market starts with clean dev credit capacity.
  - The runner defaults to a `1100ms` delay to stay under the local one-request-per-second rate limit.
- Made startup admin seeding idempotent under concurrent dev bootstrap/startup execution.
  - `SeedUsers` still creates `admin` when absent.
  - If another process inserts `admin` first, startup now performs `ON CONFLICT (username) DO NOTHING` instead of crashing.
  - Added a regression test that injects a concurrent admin insert during seed creation.

## Behavioral notes

- `testuser02` has current `NO` position value `70`; after replaying the earlier `-75` sale, derived remaining executable value is `17`.
- `testuser03` has current `NO` position value `35`; derived remaining executable value is `35`.
- Oversized requests may still round down when the existing sell calculator can normalize them under remaining inventory and dust rules. The important invariant is that executed shares/value never exceed derived unlocked inventory.
- The startup seed change does not alter public APIs, migrations, user DTOs, or dev bootstrap command syntax.

## Validation

Passed:

```sh
(cd backend && go test ./internal/domain/bets ./internal/domain/math/positions ./internal/repository/bets ./handlers/bets/selling -count=1)
(cd backend && go test ./seed -run TestSeedUsers -count=1)
(cd backend && JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...)
node --check integrationtest/scripts/sell-shares-overcashout.mjs
git diff --check
./SocialPredict dev-bootstrap-users
node integrationtest/scripts/sell-shares-overcashout.mjs --base-url http://localhost:8080 --api-prefix /v0 --delay 1100
```

Live HTTP integration result: `96 passed, 0 failed`.
