### PR TITLE
Fix stale market stats on discovery list

### DIFF
--- a/backend/handlers/markets/discovery_read_model.go
+++ b/backend/handlers/markets/discovery_read_model.go
@@ -297,6 +297,9 @@ func (h *MarketDiscoveryReadModelHandler) snapshotUsable(snapshot *readmodelrepo
 	if snapshot == nil || snapshot.PayloadJSON == "" {
 		return false
 	}
+	if snapshot.IsStale {
+		return false
+	}
 	return h.now().Sub(snapshot.GeneratedAt) <= marketDiscoverySnapshotTargetFreshness
 }
 

--- a/backend/handlers/markets/summary_read_model_test.go
+++ b/backend/handlers/markets/summary_read_model_test.go
@@ -122,7 +122,7 @@ func TestMarketSummaryToDetailsResponseDoesNotIncludeAmendments(t *testing.T) {
 	}
 }
 
-func TestMarketDiscoverySnapshotUsableAllowsYoungStaleSnapshot(t *testing.T) {
+func TestMarketDiscoverySnapshotUsableRejectsStaleSnapshot(t *testing.T) {
 	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
 	handler := &MarketDiscoveryReadModelHandler{clock: func() time.Time { return now }}
 	snapshot := &readmodelrepo.Snapshot{
@@ -132,10 +132,11 @@ func TestMarketDiscoverySnapshotUsableAllowsYoungStaleSnapshot(t *testing.T) {
 		StaleReason: "bet_accepted",
 	}
 
-	if !handler.snapshotUsable(snapshot) {
-		t.Fatalf("expected young stale discovery snapshot to be usable")
+	if handler.snapshotUsable(snapshot) {
+		t.Fatalf("expected stale discovery snapshot to be unusable")
 	}
 
+	snapshot.IsStale = false
 	snapshot.GeneratedAt = now.Add(-marketDiscoverySnapshotTargetFreshness - time.Second)
 	if handler.snapshotUsable(snapshot) {
 		t.Fatalf("expected expired discovery snapshot to be unusable")

--- a/backend/internal/domain/markets/market_accounting_snapshot_refresh.go
+++ b/backend/internal/domain/markets/market_accounting_snapshot_refresh.go
@@ -61,7 +61,7 @@ func (s *Service) GetMarketSummaryReadModel(ctx context.Context, marketID int64)
 	if err != nil {
 		return nil, err
 	}
-	if snapshot == nil {
+	if snapshot == nil || snapshot.IsStale {
 		snapshot, err = s.RefreshMarketAccountingSnapshot(ctx, marketID)
 		if err != nil {
 			return nil, err

--- a/backend/internal/domain/markets/market_accounting_snapshot_refresh_test.go
+++ b/backend/internal/domain/markets/market_accounting_snapshot_refresh_test.go
@@ -69,7 +69,7 @@ func TestServiceRefreshMarketAccountingSnapshotPersistsRawRecomputedSnapshot(t *
 	}
 }
 
-func TestServiceGetMarketSummaryReadModelReturnsStaleSnapshotWithoutRecomputing(t *testing.T) {
+func TestServiceGetMarketSummaryReadModelRefreshesStaleSnapshot(t *testing.T) {
 	service, db, _ := setupServiceWithDB(t)
 	ctx := context.Background()
 
@@ -106,12 +106,12 @@ func TestServiceGetMarketSummaryReadModelReturnsStaleSnapshotWithoutRecomputing(
 	if err != nil {
 		t.Fatalf("GetMarketSummaryReadModel returned error: %v", err)
 	}
-	if summary.Accounting.BetCount != 1 || summary.Accounting.UserCount != 1 || summary.Accounting.VolumeWithDust != 100 {
-		t.Fatalf("summary recomputed instead of returning stale snapshot: %+v", summary.Accounting)
+	if summary.Accounting.BetCount != 2 || summary.Accounting.UserCount != 2 || summary.Accounting.VolumeWithDust != 150 {
+		t.Fatalf("summary did not refresh stale snapshot: %+v", summary.Accounting)
 	}
 	freshness := summary.Accounting.Freshness()
-	if !freshness.IsStale || freshness.StaleReason != "bet_accepted" {
-		t.Fatalf("expected stale freshness from stored snapshot, got %+v", freshness)
+	if freshness.IsStale || freshness.StaleReason != "" {
+		t.Fatalf("expected refreshed non-stale freshness, got %+v", freshness)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes stale `Users`, `Size`, probability, and dust values on the `/markets` discovery list after bets or sells are placed.

The market detail page was reading current canonical market data, but the `/markets` page reads `/v0/read/market-discovery/{slug}`. That endpoint can serve a persisted discovery snapshot. Trade mutations marked the discovery snapshot and per-market accounting snapshot stale, but the read path still treated young stale snapshots as usable and returned stale per-market accounting values.

## Root Cause

This was backend PostgreSQL-backed read-model caching, not browser caching.

- `/markets` uses the market discovery read model.
- The discovery snapshot could be marked `is_stale=true` after `bet_accepted` or `sale_accepted`.
- `MarketDiscoveryReadModelHandler.snapshotUsable` ignored `IsStale` and only checked age against the 10-minute freshness window.
- Rebuilding the discovery page could still use stale per-market accounting because `GetMarketSummaryReadModel` returned stale accounting snapshots without recomputing.

## Changes

- Reject stale market-discovery snapshots immediately instead of serving them during the freshness window.
- Refresh stale per-market accounting snapshots on the next summary read.
- Updated regression tests for both layers:
  - stale discovery snapshots are unusable
  - stale market accounting summaries recompute from canonical market/bet data

## Behavior After This Change

After a buy/sell mutates market stats, the next `/markets` list read should rebuild from fresh accounting instead of continuing to show `0` users / `0` volume / stale dust until the cache ages out.

This does not make read models transaction-safe and does not change transaction paths. Market/bet truth still comes from canonical tables.

## Validation

Passed:

```sh
cd backend
go test ./handlers/markets ./internal/domain/markets -run 'TestMarketDiscoverySnapshotUsableRejectsStaleSnapshot|TestServiceGetMarketSummaryReadModelRefreshesStaleSnapshot' -count=1
go test ./handlers/markets ./internal/domain/markets ./internal/repository/markets ./internal/repository/readmodels -count=1
JWT_SIGNING_KEY=test-secret-key-for-testing go test ./...
```

Also passed:

```sh
git diff --check
```
