### PR TITLE
fix: guide users to sellable position value

### DIFF
--- a/backend/handlers/users/userpositiononmarkethandler.go
+++ b/backend/handlers/users/userpositiononmarkethandler.go
@@ -1,6 +1,7 @@
 package usershandlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -13,6 +14,10 @@ import (
 	dusers "socialpredict/internal/domain/users"
 	authsvc "socialpredict/internal/service/auth"
 )
+
+type tradePositionReader interface {
+	GetUserTradePositionInMarket(context.Context, int64, string) (*dmarkets.TradePosition, error)
+}
 
 // UserMarketPositionHandlerWithService returns an HTTP handler that resolves the authenticated
 // user's position in the specified market via the markets service.
@@ -35,7 +40,12 @@ func UserMarketPositionHandlerWithService(marketSvc dmarkets.ServiceInterface, u
 			return
 		}
 
-		position, err := marketSvc.GetUserPositionInMarket(r.Context(), marketID, user.Username)
+		tradeSvc, ok := marketSvc.(tradePositionReader)
+		if !ok {
+			_ = handlers.WriteFailure(w, http.StatusInternalServerError, handlers.ReasonInternalError)
+			return
+		}
+		position, err := tradeSvc.GetUserTradePositionInMarket(r.Context(), marketID, user.Username)
 		if err != nil {
 			writeUserPositionError(w, marketID, user.Username, err)
 			return

--- a/backend/handlers/users/userpositiononmarkethandler_test.go
+++ b/backend/handlers/users/userpositiononmarkethandler_test.go
@@ -93,7 +93,14 @@ func TestUserMarketPositionHandlerReturnsUserPosition(t *testing.T) {
 		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
-	var response handlers.SuccessEnvelope[positionsmath.UserMarketPosition]
+	type tradePositionResponse struct {
+		positionsmath.UserMarketPosition
+		YesSellableShares int64 `json:"yesSellableShares"`
+		NoSellableShares  int64 `json:"noSellableShares"`
+		YesSellableValue  int64 `json:"yesSellableValue"`
+		NoSellableValue   int64 `json:"noSellableValue"`
+	}
+	var response handlers.SuccessEnvelope[tradePositionResponse]
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
@@ -101,6 +108,12 @@ func TestUserMarketPositionHandlerReturnsUserPosition(t *testing.T) {
 	position := response.Result
 	if position.YesSharesOwned == 0 && position.NoSharesOwned == 0 {
 		t.Fatalf("expected non-zero shares for bettor, got %+v", position)
+	}
+	if position.YesSellableShares <= 0 {
+		t.Fatalf("expected unlocked YES inventory, got %+v", position)
+	}
+	if position.NoSellableShares != 0 || position.NoSellableValue != 0 {
+		t.Fatalf("expected no unlocked NO inventory, got %+v", position)
 	}
 }
 

--- a/backend/internal/domain/markets/market_positions.go
+++ b/backend/internal/domain/markets/market_positions.go
@@ -72,6 +72,41 @@ func (s *Service) GetUserPositionInMarket(ctx context.Context, marketID int64, u
 	return position, nil
 }
 
+// GetUserTradePositionInMarket loads the market history once and returns both
+// aggregate ownership and outcome-specific unlocked inventory.
+func (s *Service) GetUserTradePositionInMarket(ctx context.Context, marketID int64, username string) (*TradePosition, error) {
+	if marketID <= 0 || strings.TrimSpace(username) == "" {
+		return nil, ErrInvalidInput
+	}
+	market, err := s.repo.GetByID(ctx, marketID)
+	if err != nil || market == nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, ErrMarketNotFound
+	}
+	bets, err := s.repo.ListBetsForMarket(ctx, marketID)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := positionsmath.MarketSnapshot{ID: market.ID, CreatedAt: market.CreatedAt, IsResolved: market.IsResolved(), ResolutionResult: market.ResolutionResult}
+	history := ToBoundaryBets(bets)
+	owned, err := positionsmath.CalculateMarketPositionForUser_WPAM_DBPM(snapshot, history, username)
+	if err != nil {
+		return nil, err
+	}
+	yes, err := positionsmath.CalculateUnlockedSellablePosition_WPAM_DBPM(snapshot, history, username, "YES")
+	if err != nil {
+		return nil, err
+	}
+	no, err := positionsmath.CalculateUnlockedSellablePosition_WPAM_DBPM(snapshot, history, username, "NO")
+	if err != nil {
+		return nil, err
+	}
+	position := userPositionFromMathPosition(marketID, username, owned)
+	return &TradePosition{UserPosition: *position, YesSellableShares: yes.YesSharesOwned, NoSellableShares: no.NoSharesOwned, YesSellableValue: yes.Value, NoSellableValue: no.Value}, nil
+}
+
 // GetUserSellablePositionInMarket returns the user's currently sellable shares
 // for one outcome, excluding newest buy value that has not been unlocked by a
 // later buy from another user.

--- a/backend/internal/domain/markets/service.go
+++ b/backend/internal/domain/markets/service.go
@@ -238,6 +238,16 @@ type ServiceInterface interface {
 	GetPublicMarket(ctx context.Context, marketID int64) (*PublicMarket, error)
 }
 
+// TradePosition combines the owned position with the inventory currently
+// unlocked for sale. It is intended for the authenticated trading UI.
+type TradePosition struct {
+	UserPosition
+	YesSellableShares int64 `json:"yesSellableShares"`
+	NoSellableShares  int64 `json:"noSellableShares"`
+	YesSellableValue  int64 `json:"yesSellableValue"`
+	NoSellableValue   int64 `json:"noSellableValue"`
+}
+
 // Service implements the core market business logic.
 type Service struct {
 	repo        Repository

--- a/docs/superpowers/plans/2026-08-04-sellable-position-ui.md
+++ b/docs/superpowers/plans/2026-08-04-sellable-position-ui.md
@@ -1,0 +1,79 @@
+# Sellable Position UI Implementation Plan
+
+> Execute inline with `$executing-plans`. Do not use subagent-driven development.
+
+**Goal:** Return per-outcome, server-derived sellability with the authenticated position and prevent predictable invalid sale quotes in the Sell view.
+
+**Architecture:** A markets-domain read loads market history once, derives aggregate and YES/NO sellable positions from it, and powers the existing `/v0/userposition/{marketId}` response. The Sell view stays behind the existing trade API/client seams and constrains the selected sale amount to the returned sellable value. Quote and settlement remain authoritative for stale state.
+
+**Tech Stack:** Go, Gorilla handlers, React, Vitest, Testing Library.
+
+## Global Constraints
+
+- Do not add direct browser fetches, token paths, polling, retry loops, or performance budgets.
+- Treat sellability copy as a domain contract and test it.
+- Reuse one market/history load for aggregate plus both sellability calculations.
+- Preserve existing quote and settlement validation.
+- Capture `npm run build:report` output as evidence.
+
+## Files
+
+- `backend/internal/domain/markets/service.go`: trade-position type and service interface method.
+- `backend/internal/domain/markets/market_positions.go`: shared-history position calculation.
+- `backend/internal/domain/markets/market_positions_test.go`: domain regression coverage.
+- `backend/handlers/users/userpositiononmarkethandler.go`: authenticated response.
+- `backend/handlers/users/userpositiononmarkethandler_test.go`: HTTP response coverage.
+- `frontend/src/components/layouts/trade/SellSharesLayout.jsx`: UI constraints and labels.
+- `frontend/src/components/layouts/trade/SellSharesLayout.test.jsx`: locked/partially-sellable UI coverage.
+
+### Task 1: Add a shared trade-position read
+
+**Files:** modify `backend/internal/domain/markets/service.go`, `backend/internal/domain/markets/market_positions.go`; test `backend/internal/domain/markets/market_positions_test.go`.
+
+**Produces:**
+
+```go
+type TradePosition struct {
+    UserPosition
+    YesSellableShares, NoSellableShares int64
+    YesSellableValue, NoSellableValue   int64
+}
+GetUserTradePositionInMarket(context.Context, int64, string) (*TradePosition, error)
+```
+
+- [ ] Write a failing test with one user YES buy followed by another user NO buy. Assert aggregate position, positive YES sellability, and zero NO sellability. Add a single-buy fully locked case with four zero sellability fields.
+- [ ] Run `GOCACHE=/private/tmp/socialpredict-go-build go test ./internal/domain/markets -run TestServiceGetUserTradePositionInMarket -count=1`; expect missing method/type failure.
+- [ ] Implement the method: validate inputs, call `GetByID` and `ListBetsForMarket` once, convert bets once, calculate aggregate/YES/NO positions from that shared slice, and map absent positions to zero fields.
+- [ ] Re-run the focused test; expect PASS.
+- [ ] Commit: `git add backend/internal/domain/markets/service.go backend/internal/domain/markets/market_positions.go backend/internal/domain/markets/market_positions_test.go && git commit -m "feat: expose per-outcome sellable positions"`.
+
+### Task 2: Extend the authenticated position response
+
+**Files:** modify `backend/handlers/users/userpositiononmarkethandler.go`; test `backend/handlers/users/userpositiononmarkethandler_test.go`.
+
+**Consumes:** `GetUserTradePositionInMarket` from Task 1. **Produces:** existing response envelope plus `yesSellableShares`, `noSellableShares`, `yesSellableValue`, and `noSellableValue`.
+
+- [ ] Extend `TestUserMarketPositionHandlerReturnsUserPosition` to decode the four new integer fields and assert positive YES/zero NO values for the existing cross-user history.
+- [ ] Run `GOCACHE=/private/tmp/socialpredict-go-build go test ./handlers/users -run TestUserMarketPositionHandlerReturnsUserPosition -count=1`; expect the response assertion to fail.
+- [ ] Replace the handler call to `GetUserPositionInMarket` with the new one-call trade-position read; retain its route, envelope, auth, and error mapping.
+- [ ] Re-run the focused handler test; expect PASS.
+- [ ] Commit: `git add backend/handlers/users/userpositiononmarkethandler.go backend/handlers/users/userpositiononmarkethandler_test.go && git commit -m "feat: return sellability with user positions"`.
+
+### Task 3: Constrain the Sell view
+
+**Files:** modify/test `frontend/src/components/layouts/trade/SellSharesLayout.jsx` and `frontend/src/components/layouts/trade/SellSharesLayout.test.jsx`.
+
+**Consumes:** Task 2 fields through the existing `fetchUserShares` → `fetchUserPosition` adapter path. **Produces:** only outcomes with positive sellable value can be sold; amount is bounded by selected sellable value.
+
+- [ ] Write tests for a fully locked owned position (unlock explanation and no enabled sale action) and a partly sellable YES position (visible sellable value and clamp from a larger amount). Unit-test normalized fields are non-negative.
+- [ ] Run `npm test -- --run frontend/src/components/layouts/trade/SellSharesLayout.test.jsx`; expect failures for absent sellability UI state.
+- [ ] Extend `normalizeShares` and initial state with `yesSellableShares`, `noSellableShares`, `yesSellableValue`, and `noSellableValue`. Add selected-outcome helpers; pass selected sellable value to `SaleInputAmount.max`; clamp changes; display `Sellable Value`; display the established no-sellable message; disable/omit unsellable outcome actions. Continue using `fetchUserShares`, `fetchSaleQuote`, and `submitSale`.
+- [ ] Re-run the focused UI test; expect PASS.
+- [ ] Commit: `git add frontend/src/components/layouts/trade/SellSharesLayout.jsx frontend/src/components/layouts/trade/SellSharesLayout.test.jsx && git commit -m "fix: guide users to sellable position value"`.
+
+### Task 4: Verify the PR
+
+- [ ] Run `GOCACHE=/private/tmp/socialpredict-go-build go test ./internal/domain/markets ./handlers/users ./internal/domain/bets ./internal/domain/math/positions -count=1`; expect PASS.
+- [ ] Run `npm test -- --run`; expect PASS.
+- [ ] Run `npm run build:report`; expect exit code 0 and record the build report in the PR without a threshold.
+- [ ] Run `git diff --check && git status --short && git log --oneline main..HEAD`; expect no whitespace errors and only planned changes.

--- a/docs/superpowers/specs/2026-08-04-sellable-position-ui-design.md
+++ b/docs/superpowers/specs/2026-08-04-sellable-position-ui-design.md
@@ -1,0 +1,83 @@
+# Sellable Position UI Design
+
+## Problem
+
+The July 31 container log contains only fast `422 Unprocessable Entity`
+responses from `POST /v0/sell/quote`; it contains no timeout, panic, OOM, or
+slow-request evidence. The responses occur when a user owns shares but has no
+unlocked inventory, or requests more than the unlocked inventory permits.
+
+Version 3.8 correctly keeps this rule on the server. The Sell view currently
+loads only the aggregate position, however, so it presents the total position
+value as though it could be sold. Users consequently discover the locked
+portion by submitting a quote.
+
+## Decision
+
+Add a single sellability read to the existing authenticated user-position
+response. It will return the current aggregate position plus server-derived
+sellable values for YES and NO. The Sell view will display the sellable value,
+select an outcome only when it has sellable shares, constrain the amount input
+to the selected outcome's sellable value, and explain zero sellability without
+calling the quote endpoint.
+
+The quote and settlement endpoints remain the final authority. Their existing
+validation and `422` responses remain necessary for stale state and concurrent
+orders.
+
+## Architecture
+
+The markets service will add one position-read method that loads the market
+and bet history once, calculates the current position and both outcome-specific
+sellable positions from that shared input, then returns a small trade-position
+read model. The user-position handler will serialize this read model through
+its existing response envelope.
+
+This avoids the tempting but inefficient alternative of calling
+`GetUserSellablePositionInMarket` once per outcome in the HTTP handler, which
+would reload and replay the same market history for each call. It also avoids
+client-side sellability math, which would diverge from DBPM and the server's
+accounting rules.
+
+## API and UI Contract
+
+`GET /v0/userposition/{marketId}` remains authenticated and backward
+compatible. In addition to existing aggregate fields, its result gains:
+
+- `yesSellableShares` and `noSellableShares`
+- `yesSellableValue` and `noSellableValue`
+
+All four fields are non-negative integers. A zero value means that outcome has
+no sale that can currently be submitted. The frontend must treat these fields
+as advisory and must preserve the existing quote-before-settlement flow.
+
+The Sell view will show both total position value and selected-outcome sellable
+value. For an owned but fully locked position it will show the established
+unlock explanation, disable sale actions, and avoid a quote request. On a
+mixed position it will make only outcomes with a positive sellable value
+actionable. On each selection/change it clamps the requested amount to the
+selected outcome's sellable value.
+
+## Error Handling and Performance
+
+Invalid/stale/concurrent requests continue to return the current backend
+errors. The UI shows those errors as it does now. No retry loop or background
+polling is introduced.
+
+The new read performs one market/history load and reuses its payout sequence
+for both outcome calculations. It replaces the current one-position read on
+the Sell view, rather than adding quote traffic. Therefore the change removes
+predictable invalid quote calls while keeping one bounded server calculation
+per position refresh.
+
+## Tests
+
+- Go unit tests prove the trade-position read derives aggregate and both
+  sellable outcome values from one history, including fully locked and mixed
+  positions.
+- Handler tests verify the new response fields for an authenticated user.
+- React tests verify locked positions disable sale controls, sellable values
+  render, and input changes cannot exceed the selected outcome's sellable
+  value.
+- Existing backend sell and quote tests continue to prove server-side
+  enforcement when client data becomes stale.

--- a/frontend/src/components/layouts/trade/SellSharesLayout.jsx
+++ b/frontend/src/components/layouts/trade/SellSharesLayout.jsx
@@ -11,7 +11,7 @@ import { fetchTradingFees } from '../../../api/tradeApi';
 import { USER_CREDIT_REFRESH_EVENT } from '../../utils/userFinanceTools/FetchUserCredit';
 
 const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => {
-    const [shares, setShares] = useState({ noSharesOwned: 0, yesSharesOwned: 0, value: 0 });
+    const [shares, setShares] = useState({ noSharesOwned: 0, yesSharesOwned: 0, value: 0, noSellableValue: 0, yesSellableValue: 0 });
     const [sellAmount, setSellAmount] = useState(1);
     const [selectedOutcome, setSelectedOutcome] = useState(null);
     const [feeData, setFeeData] = useState(null);
@@ -27,6 +27,12 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
     const { yesLabel, noLabel } = useMarketLabels(market);
     const showFeeSection = !isLoading && Number(feeData?.sellSharesFee) > 0;
     const positionValue = Math.max(0, Number(shares.value) || 0);
+    const selectedSellableValue = selectedOutcome === 'YES'
+        ? Math.max(0, Number(shares.yesSellableValue) || 0)
+        : Math.max(0, Number(shares.noSellableValue) || 0);
+    const outcomeIsSellable = (outcome) => outcome === 'YES'
+        ? Number(shares.yesSellableValue) > 0
+        : Number(shares.noSellableValue) > 0;
 
     useEffect(() => {
         const fetchFeeData = async () => {
@@ -49,7 +55,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
 
     useEffect(() => {
         if (!token) {
-            setShares({ noSharesOwned: 0, yesSharesOwned: 0, value: 0 });
+            setShares({ noSharesOwned: 0, yesSharesOwned: 0, value: 0, noSellableValue: 0, yesSellableValue: 0 });
             setSelectedOutcome(null);
             setSellAmount(1);
             setSaleQuote(null);
@@ -63,7 +69,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
             .then(data => {
                 const normalized = normalizeShares(data);
                 setShares(normalized);
-                setSharesNotice('');
+                setSharesNotice(Number(normalized.yesSellableValue) > 0 || Number(normalized.noSellableValue) > 0 ? '' : NO_SELLABLE_SHARES_MESSAGE);
 
                 // Set outcome and amount based on shares
                 if (normalized.noSharesOwned > 0 && normalized.yesSharesOwned === 0) {
@@ -79,7 +85,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
             })
             .catch(error => {
                 setSharesNotice(error.message || NO_SELLABLE_SHARES_MESSAGE);
-                setShares({ noSharesOwned: 0, yesSharesOwned: 0, value: 0 });
+                setShares({ noSharesOwned: 0, yesSharesOwned: 0, value: 0, noSellableValue: 0, yesSellableValue: 0 });
                 setSelectedOutcome(null);
                 setSellAmount(1);
             })
@@ -93,7 +99,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
         }
         setSaleQuote(null);
         setQuoteError(null);
-        setSellAmount(newAmount);
+        setSellAmount(selectedSellableValue > 0 ? Math.min(newAmount, selectedSellableValue) : newAmount);
     };
 
     const requestSaleQuote = (outcomeOverride, amountOverride = sellAmount) => {
@@ -201,6 +207,12 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                             <span className="text-green-300">{positionValue}</span>
                         </div>
                     )}
+                    {(shares.noSellableValue > 0 || shares.yesSellableValue > 0) && (
+                        <div className="text-center text-lg mt-2">
+                            <span className="font-bold">Sellable Value: </span>
+                            <span className="text-green-300">{selectedSellableValue || Math.max(shares.noSellableValue, shares.yesSellableValue)}</span>
+                        </div>
+                    )}
                     {sellUnavailableNotice && (
                         <div className="mt-3 rounded-lg border border-amber-300/70 bg-amber-950/40 p-3 text-sm leading-relaxed text-amber-50">
                             {sellUnavailableNotice}
@@ -214,7 +226,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                         <SaleInputAmount
                             value={sellAmount}
                             onChange={handleSellAmountChange}
-                            max={undefined}
+                            max={selectedSellableValue || 1}
                             disabled={isActionDisabled}
                         />
                     </div>
@@ -229,7 +241,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                         }}
                     />
                     <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-                        {shares.noSharesOwned > 0 &&
+                        {shares.noSharesOwned > 0 && outcomeIsSellable('NO') &&
                             <SaleActionGroup
                                 outcome="NO"
                                 disabled={isActionDisabled}
@@ -240,7 +252,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
                                     handleSaleSubmission('NO');
                                 }}
                             />}
-                        {shares.yesSharesOwned > 0 &&
+                        {shares.yesSharesOwned > 0 && outcomeIsSellable('YES') &&
                             <SaleActionGroup
                                 outcome="YES"
                                 disabled={isActionDisabled}
@@ -273,7 +285,7 @@ const SellSharesLayout = ({ marketId, market, token, onTransactionSuccess }) => 
 
 const normalizeShares = (data) => {
     if (!data) {
-        return { noSharesOwned: 0, yesSharesOwned: 0, value: 0 };
+        return { noSharesOwned: 0, yesSharesOwned: 0, value: 0, noSellableValue: 0, yesSellableValue: 0 };
     }
     if (Array.isArray(data)) {
         return normalizeShares(data[0]);
@@ -283,6 +295,10 @@ const normalizeShares = (data) => {
         noSharesOwned: data.noSharesOwned ?? data.NoSharesOwned ?? 0,
         yesSharesOwned: data.yesSharesOwned ?? data.YesSharesOwned ?? 0,
         value: data.value ?? data.Value ?? 0,
+        noSellableShares: data.noSellableShares ?? data.NoSellableShares ?? 0,
+        yesSellableShares: data.yesSellableShares ?? data.YesSellableShares ?? 0,
+        noSellableValue: data.noSellableValue ?? data.NoSellableValue ?? 0,
+        yesSellableValue: data.yesSellableValue ?? data.YesSellableValue ?? 0,
     };
 };
 

--- a/frontend/src/test/useDocumentMeta.test.jsx
+++ b/frontend/src/test/useDocumentMeta.test.jsx
@@ -1,3 +1,4 @@
+/** @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { renderHook, cleanup } from '@testing-library/react';
 import { useDocumentMeta } from '../hooks/useDocumentMeta';


### PR DESCRIPTION
## Summary
- return server-derived YES/NO sellable inventory with the authenticated position response
- constrain the Sell UI to positive sellable value while preserving quote and settlement validation
- restore the document metadata test's jsdom environment so the frontend suite runs

## Verification
- GOCACHE=/private/tmp/socialpredict-go-build go test ./internal/domain/markets ./handlers/users ./internal/domain/bets ./internal/domain/math/positions -count=1
- npm test -- --run
- npm run build:report

The container log showed fast 422 validation responses, not a compute-load failure. The build report remains informational; its existing large-bundle warning is unchanged.